### PR TITLE
chore: update Quarkus version to 3.27.0

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <!-- Using the same version as in vaadin-quarkus extension -->
-        <quarkus.version>3.24.0</quarkus.version>
+        <quarkus.version>3.27.0</quarkus.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
Same version as vaadin-quarkus add-on for Vaadin 25