### PR TITLE
feat: make ComponentTesterPackages inherithed

### DIFF
--- a/shared/src/main/java/com/vaadin/browserless/ComponentTesterPackages.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentTesterPackages.java
@@ -16,6 +16,7 @@
 package com.vaadin.browserless;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,6 +30,7 @@ import java.lang.annotation.Target;
  */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface ComponentTesterPackages {
 
     /**


### PR DESCRIPTION
Allows scenarios where a custom test base class is used to setup tester scanning for other tests.
