### PR TITLE
fix: ensure overridden `notUsableReasons` is called by `ensureComponentIsUsable`

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/ComponentTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentTesterTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import com.example.base.WelcomeView;
 import org.junit.jupiter.api.BeforeEach;
@@ -271,6 +272,46 @@ public class ComponentTesterTest extends BrowserlessTest {
         @Override
         public void fireDomEvent(String eventType, ObjectNode eventData) {
             super.fireDomEvent(eventType, eventData);
+        }
+    }
+
+    @Test
+    void ensureComponentIsUsable_subclassOverride_includesCustomReason() {
+        Span span = new Span();
+        home.add(span);
+
+        CustomTester<Span> tester = new CustomTester<>(span);
+        tester.markNotUsable();
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                tester::ensureComponentIsUsable);
+        assertTrue(ex.getMessage().contains("custom reason"),
+                "Error message should contain subclass reason: "
+                        + ex.getMessage());
+    }
+
+    static class CustomTester<T extends Component> extends ComponentTester<T> {
+        private boolean usable = true;
+
+        public CustomTester(T component) {
+            super(component);
+        }
+
+        void markNotUsable() {
+            usable = false;
+        }
+
+        @Override
+        public boolean isUsable() {
+            return usable && super.isUsable();
+        }
+
+        @Override
+        protected void notUsableReasons(Consumer<String> collector) {
+            super.notUsableReasons(collector);
+            if (!usable) {
+                collector.accept("custom reason");
+            }
         }
     }
 

--- a/shared/src/main/java/com/vaadin/browserless/ComponentTester.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentTester.java
@@ -148,7 +148,8 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      * component.
      */
     public final void ensureComponentIsUsable() {
-        ensureComponentIsUsable(component, unused -> isUsable());
+        throwIfNotUsable(component, unused -> isUsable(),
+                this::notUsableReasons);
     }
 
     /**
@@ -162,12 +163,19 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      */
     protected static void ensureComponentIsUsable(Component component,
             Predicate<Component> usableTest) {
+        throwIfNotUsable(component, usableTest,
+                collector -> notUsableReasons(component, collector));
+    }
+
+    private static void throwIfNotUsable(Component component,
+            Predicate<Component> usableTest,
+            Consumer<Consumer<String>> reasonsProvider) {
         if (!usableTest.test(component)) {
             StringBuilder message = new StringBuilder(
                     PrettyPrintTreeKt.toPrettyString(component)
                             + " is not usable");
             Stream.Builder<String> reasons = Stream.builder();
-            notUsableReasons(component, reasons::add);
+            reasonsProvider.accept(reasons::add);
             message.append(reasons.build()
                     .collect(Collectors.joining(", ", " because it is ", ".")));
             throw new IllegalStateException(message.toString());


### PR DESCRIPTION
When a `ComponentTester` subclass overrides `notUsableReasons`, the override was never invoked when building error messages, causing subclass-specific reasons (e.g. "read only", "not opened") to be missing from the exception.

Fixed by routing the instance method through virtual dispatch so that subclass overrides are properly picked up.
