### PR TITLE
feat: support shared Vaadin environment across tests and composition-based setup

### DIFF
--- a/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.vaadin.browserless.internal.MockInternalSeverError;
+import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.ShortcutsKt;
+import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.RouteParameters;
+
+/**
+ * Abstract base for browserless JUnit 5 extensions. Holds all shared state and
+ * logic; concrete subclasses implement only the lifecycle callbacks they need.
+ */
+abstract class AbstractBrowserlessExtension implements TesterWrappers {
+
+    // Programmatic config (builder-style)
+    private final Set<String> viewPackages = new HashSet<>();
+    private final Set<Class<?>> services = new HashSet<>();
+    private final Set<String> componentTesterPackages = new HashSet<>();
+
+    // Runtime state
+    private TestSignalEnvironment signalsTestEnvironment;
+    private Runnable cleanupAction;
+
+    // --- Protected builder helpers ---
+
+    protected void addViewPackages(Class<?>... classes) {
+        Stream.of(classes).map(Class::getPackageName)
+                .forEach(viewPackages::add);
+    }
+
+    protected void addViewPackages(String... packages) {
+        viewPackages.addAll(Arrays.asList(packages));
+    }
+
+    protected void addServices(Class<?>... serviceClasses) {
+        services.addAll(Arrays.asList(serviceClasses));
+    }
+
+    protected void addComponentTesterPackages(String... packages) {
+        componentTesterPackages.addAll(Arrays.asList(packages));
+    }
+
+    // --- Lifecycle callbacks ---
+
+    protected void doInit(Object testInstance, ExtensionContext ctx) {
+        if (testInstance instanceof BaseBrowserlessTest base) {
+            base.initVaadinEnvironment();
+            cleanupAction = base::cleanVaadinEnvironment;
+        } else {
+            standaloneInit(ctx.getRequiredTestClass());
+            cleanupAction = this::standaloneCleanup;
+        }
+    }
+
+    protected void doCleanup() {
+        if (cleanupAction != null) {
+            cleanupAction.run();
+            cleanupAction = null;
+        }
+    }
+
+    private void standaloneCleanup() {
+        if (signalsTestEnvironment != null) {
+            signalsTestEnvironment.unregister();
+            signalsTestEnvironment = null;
+        }
+        MockVaadin.tearDown();
+    }
+
+    private void standaloneInit(Class<?> testClass) {
+        // Scan for additional component testers
+        Set<String> testerPkgs = new HashSet<>(componentTesterPackages);
+        ComponentTesterPackages testerAnnotation = testClass
+                .getAnnotation(ComponentTesterPackages.class);
+        if (testerAnnotation != null) {
+            testerPkgs.addAll(Arrays.asList(testerAnnotation.value()));
+        }
+        for (String pkg : testerPkgs) {
+            if (BaseBrowserlessTest.scanned.add(pkg)) {
+                BaseBrowserlessTest.testers
+                        .putAll(BaseBrowserlessTest.scanForTesters(pkg));
+            }
+        }
+
+        // Resolve view packages from annotation and programmatic config
+        Set<String> packages = new HashSet<>(viewPackages);
+        ViewPackages vpAnnotation = testClass.getAnnotation(ViewPackages.class);
+        if (vpAnnotation != null) {
+            Stream.of(vpAnnotation.classes()).map(Class::getPackageName)
+                    .forEach(packages::add);
+            packages.addAll(Arrays.asList(vpAnnotation.packages()));
+            // If annotation is present but empty, default to test class package
+            if (packages.isEmpty()) {
+                packages.add(testClass.getPackageName());
+            }
+        }
+        packages.removeIf(Objects::isNull);
+
+        Routes routes = BaseBrowserlessTest.discoverRoutes(packages);
+        MockVaadin.setup(routes, MockedUI::new, services);
+        signalsTestEnvironment = TestSignalEnvironment.register();
+    }
+
+    // --- Testing DSL ---
+
+    /**
+     * Navigates to the given view class.
+     *
+     * @param target
+     *            view class to navigate to
+     * @param <T>
+     *            view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(Class<T> target) {
+        getUI().navigate(target);
+        return validateNavigationTarget(target);
+    }
+
+    /**
+     * Navigates to the given view class with a URL parameter.
+     *
+     * @param target
+     *            view class to navigate to
+     * @param parameter
+     *            URL parameter
+     * @param <T>
+     *            view type
+     * @param <C>
+     *            parameter type
+     * @return the instantiated view
+     */
+    public <C, T extends Component & HasUrlParameter<C>> T navigate(
+            Class<T> target, C parameter) {
+        getUI().navigate(target, parameter);
+        return validateNavigationTarget(target);
+    }
+
+    /**
+     * Navigates to the given view class with route parameters.
+     *
+     * @param target
+     *            view class to navigate to
+     * @param parameters
+     *            route parameters
+     * @param <T>
+     *            view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(Class<T> target,
+            Map<String, String> parameters) {
+        getUI().navigate(target, new RouteParameters(parameters));
+        return validateNavigationTarget(target);
+    }
+
+    /**
+     * Navigates to the given location string and verifies the expected target.
+     *
+     * @param location
+     *            navigation location string
+     * @param expectedTarget
+     *            expected view class
+     * @param <T>
+     *            view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(String location,
+            Class<T> expectedTarget) {
+        getUI().navigate(location);
+        return validateNavigationTarget(expectedTarget);
+    }
+
+    /**
+     * Gets a query object for finding components of the given type in the UI.
+     *
+     * @param type
+     *            component type to search for
+     * @param <T>
+     *            component type
+     * @return a component query
+     */
+    public <T extends Component> ComponentQuery<T> $(Class<T> type) {
+        getUI();
+        return BaseBrowserlessTest.internalQuery(type);
+    }
+
+    /**
+     * Gets a query object for finding components nested inside a given
+     * component.
+     *
+     * @param type
+     *            component type to search for
+     * @param fromThis
+     *            starting component for search
+     * @param <T>
+     *            component type
+     * @return a component query scoped to the given component
+     */
+    public <T extends Component> ComponentQuery<T> $(Class<T> type,
+            Component fromThis) {
+        getUI();
+        return new ComponentQuery<>(type).from(fromThis);
+    }
+
+    /**
+     * Gets a query object for finding components inside the current view.
+     *
+     * @param type
+     *            component type to search for
+     * @param <T>
+     *            component type
+     * @return a component query scoped to the current view
+     */
+    public <T extends Component> ComponentQuery<T> $view(Class<T> type) {
+        Component viewComponent = getCurrentView().getElement().getComponent()
+                .orElseThrow(() -> new AssertionError(
+                        "Cannot get Component instance for current view"));
+        return new ComponentQuery<>(type).from(viewComponent);
+    }
+
+    /**
+     * Gets the current view instance shown in the UI.
+     *
+     * @return the current view
+     */
+    public HasElement getCurrentView() {
+        return getUI().getInternals().getActiveRouterTargetsChain().get(0);
+    }
+
+    /**
+     * Simulates a server round-trip, flushing pending component changes.
+     */
+    public void roundTrip() {
+        BaseBrowserlessTest.roundTrip();
+    }
+
+    /**
+     * Processes all pending Signals tasks with a default max wait of 100
+     * milliseconds.
+     *
+     * @return {@code true} if any pending Signals tasks were processed
+     */
+    public boolean runPendingSignalsTasks() {
+        return runPendingSignalsTasks(100, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Processes all pending Signals tasks, waiting up to the specified timeout
+     * for tasks to arrive.
+     *
+     * @param maxWaitTime
+     *            maximum time to wait for the first task
+     * @param unit
+     *            time unit for the timeout
+     * @return {@code true} if any pending Signals tasks were processed
+     */
+    public boolean runPendingSignalsTasks(long maxWaitTime, TimeUnit unit) {
+        if (signalsTestEnvironment != null) {
+            return signalsTestEnvironment.runPendingTasks(maxWaitTime, unit);
+        }
+        return false;
+    }
+
+    /**
+     * Simulates a keyboard shortcut performed on the browser.
+     *
+     * @param key
+     *            primary key of the shortcut
+     * @param modifiers
+     *            key modifiers
+     */
+    public void fireShortcut(Key key, KeyModifier... modifiers) {
+        UI ui = getUI();
+        if (ui.hasModalComponent()) {
+            ShortcutsKt._fireShortcut(
+                    ui.getInternals().getActiveModalComponent(), key,
+                    modifiers);
+        } else {
+            ShortcutsKt.fireShortcut(key, modifiers);
+        }
+    }
+
+    private UI getUI() {
+        UI ui = UI.getCurrent();
+        if (ui == null) {
+            throw new BrowserlessTestSetupException(
+                    "Test Vaadin environment is not initialized. "
+                            + "Make sure BrowserlessExtension is registered and active "
+                            + "before calling test DSL methods.");
+        }
+        return ui;
+    }
+
+    private <T extends Component> T validateNavigationTarget(Class<T> target) {
+        HasElement currentView = getCurrentView();
+        if (!target.isAssignableFrom(currentView.getClass())) {
+            if (currentView instanceof MockInternalSeverError) {
+                System.err.println(
+                        currentView.getElement().getProperty("stackTrace"));
+            }
+            throw new IllegalArgumentException(
+                    "Navigation resulted in unexpected class "
+                            + currentView.getClass().getName() + " instead of "
+                            + target.getName());
+        }
+        return target.cast(currentView);
+    }
+}

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessClassExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessClassExtension.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension for browserless Vaadin testing with per-class lifecycle.
+ *
+ * <p>
+ * The Vaadin environment is initialized once before all tests in the class and
+ * torn down after all tests. Use as a static field with
+ * {@code @RegisterExtension}:
+ *
+ * <pre>
+ * {@code
+ * class MyStatefulTest {
+ *     &#64;RegisterExtension
+ *     static BrowserlessClassExtension ext = new BrowserlessClassExtension()
+ *             .withViewPackages(MyView.class);
+ *
+ *     &#64;BeforeAll
+ *     static void setup() {
+ *         ext.navigate(MyView.class);
+ *     }
+ *
+ *     &#64;Test
+ *     void testA() {
+ *         /* same session *&#47; }
+ * 
+ *     &#64;Test
+ *     void testB() {
+ *         /* same session *&#47; }
+ * }
+ * }
+ * </pre>
+ *
+ * <p>
+ * For a fresh environment per test method, use {@link BrowserlessExtension}
+ * instead.
+ *
+ * @see BrowserlessExtension
+ * @see BrowserlessTest
+ * @see ViewPackages
+ */
+public class BrowserlessClassExtension extends AbstractBrowserlessExtension
+        implements BeforeAllCallback, AfterAllCallback {
+
+    /**
+     * Creates a new extension with per-class lifecycle.
+     */
+    public BrowserlessClassExtension() {
+    }
+
+    /**
+     * Adds packages to scan for {@code @Route}-annotated views, derived from
+     * the given classes' packages.
+     *
+     * @param classes
+     *            classes whose packages should be scanned
+     * @return this extension instance
+     */
+    public BrowserlessClassExtension withViewPackages(Class<?>... classes) {
+        addViewPackages(classes);
+        return this;
+    }
+
+    /**
+     * Adds packages to scan for {@code @Route}-annotated views.
+     *
+     * @param packages
+     *            package names to scan
+     * @return this extension instance
+     */
+    public BrowserlessClassExtension withViewPackages(String... packages) {
+        addViewPackages(packages);
+        return this;
+    }
+
+    /**
+     * Adds Vaadin {@link com.vaadin.flow.di.Lookup} service implementation
+     * classes.
+     *
+     * @param serviceClasses
+     *            service implementation classes to register
+     * @return this extension instance
+     */
+    public BrowserlessClassExtension withServices(Class<?>... serviceClasses) {
+        addServices(serviceClasses);
+        return this;
+    }
+
+    /**
+     * Adds extra packages to scan for {@link ComponentTester} implementations.
+     *
+     * @param packages
+     *            package names to scan for testers
+     * @return this extension instance
+     */
+    public BrowserlessClassExtension withComponentTesterPackages(
+            String... packages) {
+        addComponentTesterPackages(packages);
+        return this;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext ctx) {
+        doInit(ctx.getTestInstance().orElse(null), ctx);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext ctx) {
+        doCleanup();
+    }
+}

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessExtension.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension for browserless Vaadin testing with per-method lifecycle.
+ *
+ * <p>
+ * A fresh Vaadin environment is initialized before each test method and torn
+ * down after. Use as an instance field with {@code @RegisterExtension}:
+ *
+ * <pre>
+ * {@code
+ * &#64;ViewPackages(classes = MyView.class)
+ * class MyTest {
+ *     &#64;RegisterExtension
+ *     BrowserlessExtension ext = new BrowserlessExtension()
+ *             .withServices(MyService.class);
+ *
+ *     &#64;Test
+ *     void test() {
+ *         MyView view = ext.navigate(MyView.class);
+ *         ext.test(view.getButton()).click();
+ *     }
+ * }
+ * }
+ * </pre>
+ *
+ * <p>
+ * For a shared Vaadin environment across all tests in a class, use
+ * {@link BrowserlessClassExtension} instead.
+ *
+ * @see BrowserlessClassExtension
+ * @see BrowserlessTest
+ * @see ViewPackages
+ */
+public class BrowserlessExtension extends AbstractBrowserlessExtension
+        implements BeforeEachCallback, AfterEachCallback {
+
+    /**
+     * Creates a new extension with per-method lifecycle.
+     */
+    public BrowserlessExtension() {
+    }
+
+    /**
+     * Adds packages to scan for {@code @Route}-annotated views, derived from
+     * the given classes' packages.
+     *
+     * @param classes
+     *            classes whose packages should be scanned
+     * @return this extension instance
+     */
+    public BrowserlessExtension withViewPackages(Class<?>... classes) {
+        addViewPackages(classes);
+        return this;
+    }
+
+    /**
+     * Adds packages to scan for {@code @Route}-annotated views.
+     *
+     * @param packages
+     *            package names to scan
+     * @return this extension instance
+     */
+    public BrowserlessExtension withViewPackages(String... packages) {
+        addViewPackages(packages);
+        return this;
+    }
+
+    /**
+     * Adds Vaadin {@link com.vaadin.flow.di.Lookup} service implementation
+     * classes.
+     *
+     * @param serviceClasses
+     *            service implementation classes to register
+     * @return this extension instance
+     */
+    public BrowserlessExtension withServices(Class<?>... serviceClasses) {
+        addServices(serviceClasses);
+        return this;
+    }
+
+    /**
+     * Adds extra packages to scan for {@link ComponentTester} implementations.
+     *
+     * @param packages
+     *            package names to scan for testers
+     * @return this extension instance
+     */
+    public BrowserlessExtension withComponentTesterPackages(
+            String... packages) {
+        addComponentTesterPackages(packages);
+        return this;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext ctx) {
+        doInit(ctx.getTestInstance().orElse(null), ctx);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext ctx) {
+        doCleanup();
+    }
+}

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessTest.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessTest.java
@@ -15,16 +15,15 @@
  */
 package com.vaadin.browserless;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Base JUnit 6 class for browserless tests.
  *
- * The class automatically scans classpath for routes and error views.
- * Subclasses should typically restrict classpath scanning to a specific
- * packages for faster bootstrap, by using {@link ViewPackages} annotation. If
- * the annotation is not present a full classpath scan is performed
+ * The class automatically scans the classpath for routes and error views.
+ * Subclasses should typically restrict classpath scanning to specific packages
+ * for faster bootstrap by using the {@link ViewPackages} annotation. If the
+ * annotation is not present, a full classpath scan is performed.
  *
  * <pre>
  * {@code
@@ -44,52 +43,43 @@ import org.junit.jupiter.api.BeforeEach;
  * }
  * </pre>
  *
- * Set up of Vaadin environment is performed before each test by {@link
- * #initVaadinEnvironment()} method, and will be executed before
- * {@code @BeforeEach} methods defined in subclasses. At the same way, cleanup
- * tasks operated by {@link #cleanVaadinEnvironment()} are executed after each
- * test, and after all {@code @AfterEach} annotated methods in subclasses.
+ * The Vaadin environment lifecycle is managed by {@link
+ * BrowserlessTestExtension}, which calls {@link #initVaadinEnvironment()}
+ * before each test and {@link #cleanVaadinEnvironment()} after each test via
+ * virtual dispatch. When the test class is annotated with
+ * {@code @TestInstance(TestInstance.Lifecycle.PER_CLASS)}, the environment is
+ * shared across all tests in the class (initialized once in {@code @BeforeAll},
+ * torn down in {@code @AfterAll}).
  *
- * Usually, it is not necessary to override {@link #initVaadinEnvironment()} or
- * {@link #cleanVaadinEnvironment()} methods, but if this is done it is
- * mandatory to add the {@code @BeforeEach} and {@code @AfterEach} annotations
- * in the subclass, in order to have hooks handled by testing framework.
- *
- * A use case for overriding {@link #initVaadinEnvironment()} is to provide
- * custom Flow service implementations supported by {@link
- * com.vaadin.flow.di.Lookup} SPI. Implementations can be provided overriding
- * {@link #initVaadinEnvironment()} and passing to super implementation the
- * service classes that should be initialized during setup.
+ * <p>
+ * To provide custom Flow service implementations via the {@link
+ * com.vaadin.flow.di.Lookup} SPI, override {@link #lookupServices()}:
  *
  * <pre>
  * {@code
- * &#64;BeforeEach
  * &#64;Override
- * void initVaadinEnvironment() {
- *     super.initVaadinEnvironment(CustomInstantiatorFactory.class);
+ * protected Set<Class<?>> lookupServices() {
+ *     return Set.of(CustomInstantiatorFactory.class);
  * }
  * }
  * </pre>
- * <p/>
- * To get a graphical ascii representation of the UI tree on failure add the
- * annotation {@code @ExtendWith(TreeOnFailureExtension.class)} to the test
- * class.
+ *
+ * <p>
+ * <strong>Note:</strong> Subclasses that override {@code initVaadinEnvironment}
+ * must NOT add {@code @BeforeEach} — the extension handles invocation via
+ * virtual dispatch.
+ *
+ * <p>
+ * To get a graphical ASCII representation of the UI tree on failure, add
+ * {@code @ExtendWith(TreeOnFailureExtension.class)} to the test class.
  *
  * @see ViewPackages
+ * 
+ * @see BrowserlessExtension
  */
+@ExtendWith(BrowserlessTestExtension.class)
 public abstract class BrowserlessTest extends BaseBrowserlessTest
         implements TesterWrappers {
-
-    @BeforeEach
-    protected void initVaadinEnvironment() {
-        super.initVaadinEnvironment();
-    }
-
-    @AfterEach
-    @Override
-    protected void cleanVaadinEnvironment() {
-        super.cleanVaadinEnvironment();
-    }
 
     @Override
     protected final String testingEngine() {

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessTestExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessTestExtension.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Package-private extension used exclusively by {@code @ExtendWith} on
+ * {@link BrowserlessTest}. Auto-detects lifecycle from
+ * {@code @TestInstance(PER_CLASS)} on the test class.
+ */
+class BrowserlessTestExtension extends AbstractBrowserlessExtension
+        implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback,
+        AfterEachCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext ctx) {
+        if (isPerClass(ctx)) {
+            doInit(ctx.getTestInstance().orElse(null), ctx);
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext ctx) {
+        if (isPerClass(ctx)) {
+            doCleanup();
+        }
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext ctx) {
+        if (!isPerClass(ctx)) {
+            doInit(ctx.getTestInstance().orElse(null), ctx);
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext ctx) {
+        if (!isPerClass(ctx)) {
+            doCleanup();
+        }
+    }
+
+    private boolean isPerClass(ExtensionContext ctx) {
+        return ctx.getTestInstanceLifecycle()
+                .filter(l -> l == TestInstance.Lifecycle.PER_CLASS).isPresent();
+    }
+}

--- a/junit6/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
+++ b/junit6/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
@@ -17,6 +17,7 @@ package com.vaadin.browserless;
 
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,11 +51,12 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  * class ViewTest extends SpringBrowserlessTest {
  *
  * }
+ * 
  * &#64;Configuration
  * class ViewTestConfig {
  *     &#64;Bean
  *     MyService myService() {
- *         return new my MockMyService();
+ *         return new MockMyService();
  *     }
  * }
  * }
@@ -62,10 +64,16 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  */
 @ExtendWith({ SpringExtension.class })
 @TestExecutionListeners(listeners = BrowserlessTestSpringLookupInitializer.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-public abstract class SpringBrowserlessTest extends BrowserlessTest {
+public abstract class SpringBrowserlessTest extends BaseBrowserlessTest
+        implements TesterWrappers {
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Override
+    protected final String testingEngine() {
+        return "JUnit 6";
+    }
 
     @Override
     protected Set<Class<?>> lookupServices() {
@@ -73,11 +81,25 @@ public abstract class SpringBrowserlessTest extends BrowserlessTest {
                 SpringSecurityRequestCustomizer.class);
     }
 
+    /**
+     * Sets up the mock Vaadin Spring environment before each test. Runs as a
+     * {@code @BeforeEach} method so that it fires <em>after</em> all JUnit 5
+     * extension {@code beforeEach} callbacks — in particular after
+     * {@code SpringExtension.beforeEach()}, which populates the Spring Security
+     * context for annotations such as {@code @WithMockUser}.
+     */
     @BeforeEach
+    @Override
     protected void initVaadinEnvironment() {
         scanTesters();
         MockSpringServlet servlet = new MockSpringServlet(discoverRoutes(),
                 applicationContext, MockedUI::new);
         MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+    }
+
+    @AfterEach
+    @Override
+    protected void cleanVaadinEnvironment() {
+        super.cleanVaadinEnvironment();
     }
 }

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessExtensionPerClassTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessExtensionPerClassTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Verifies that {@link BrowserlessClassExtension} creates a single Vaadin
+ * environment shared across all test methods (same {@link UI} instance).
+ */
+@ViewPackages(classes = WelcomeView.class)
+class BrowserlessExtensionPerClassTest {
+
+    @RegisterExtension
+    static BrowserlessClassExtension ext = new BrowserlessClassExtension();
+
+    private static UI sharedUI;
+
+    @BeforeAll
+    static void captureUI() {
+        sharedUI = UI.getCurrent();
+        Assertions.assertNotNull(sharedUI,
+                "Expecting current UI to be available after per-class init");
+        ext.navigate(WelcomeView.class);
+    }
+
+    @Test
+    void firstTest_sameUIInstance() {
+        Assertions.assertSame(sharedUI, UI.getCurrent(),
+                "Per-class lifecycle must reuse the same UI across tests");
+        Assertions.assertInstanceOf(WelcomeView.class, ext.getCurrentView());
+    }
+
+    @Test
+    void secondTest_sameUIInstance() {
+        Assertions.assertSame(sharedUI, UI.getCurrent(),
+                "Per-class lifecycle must reuse the same UI across tests");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessExtensionPerMethodTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessExtensionPerMethodTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Verifies that {@link BrowserlessExtension} creates a fresh Vaadin environment
+ * for each test method (different {@link UI} instances).
+ */
+@ViewPackages(classes = WelcomeView.class)
+class BrowserlessExtensionPerMethodTest {
+
+    @RegisterExtension
+    BrowserlessExtension ext = new BrowserlessExtension();
+
+    private static final Set<UI> seenUIs = Collections
+            .synchronizedSet(new HashSet<>());
+
+    @Test
+    void firstTest_recordsUI() {
+        UI ui = UI.getCurrent();
+        Assertions.assertNotNull(ui, "Expecting current UI to be available");
+        ext.navigate(WelcomeView.class);
+        Assertions.assertInstanceOf(WelcomeView.class, ext.getCurrentView());
+        seenUIs.add(ui);
+    }
+
+    @Test
+    void secondTest_recordsUI() {
+        UI ui = UI.getCurrent();
+        Assertions.assertNotNull(ui, "Expecting current UI to be available");
+        seenUIs.add(ui);
+    }
+
+    @AfterAll
+    static void assertDistinctUIInstances() {
+        Assertions.assertEquals(2, seenUIs.size(),
+                "Per-method lifecycle must create a distinct UI for each test");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestPerClassLifecycleTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestPerClassLifecycleTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Verifies that {@link BrowserlessTest} combined with
+ * {@code @TestInstance(PER_CLASS)} reuses the same Vaadin environment across
+ * all test methods in the class.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ViewPackages(classes = WelcomeView.class)
+class BrowserlessTestPerClassLifecycleTest extends BrowserlessTest {
+
+    private UI sharedUI;
+
+    @BeforeAll
+    void captureUI() {
+        sharedUI = UI.getCurrent();
+        Assertions.assertNotNull(sharedUI,
+                "Expecting current UI to be available after PER_CLASS init");
+        navigate(WelcomeView.class);
+    }
+
+    @Test
+    void firstTest_sameUIInstance() {
+        Assertions.assertSame(sharedUI, UI.getCurrent(),
+                "PER_CLASS lifecycle must reuse the same UI across tests");
+        Assertions.assertInstanceOf(WelcomeView.class, getCurrentView());
+    }
+
+    @Test
+    void secondTest_sameUIInstance() {
+        Assertions.assertSame(sharedUI, UI.getCurrent(),
+                "PER_CLASS lifecycle must reuse the same UI across tests");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/SpringBrowserlessPerClassLifecycleTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/SpringBrowserlessPerClassLifecycleTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ContextConfiguration(classes = SpringBrowserlessPerClassLifecycleTest.TestConfig.class)
+class SpringBrowserlessPerClassLifecycleTest extends SpringBrowserlessTest {
+
+    @Test
+    void perClassLifecycle_firstTest_vaadinEnvironmentIsSetup() {
+        Assertions.assertNotNull(VaadinService.getCurrent(),
+                "VaadinService should be available with PER_CLASS lifecycle");
+        Assertions.assertNotNull(VaadinSession.getCurrent(),
+                "VaadinSession should be available with PER_CLASS lifecycle");
+    }
+
+    @Test
+    void perClassLifecycle_secondTest_vaadinEnvironmentIsSetup() {
+        Assertions.assertNotNull(VaadinService.getCurrent(),
+                "VaadinService should be available with PER_CLASS lifecycle");
+        Assertions.assertNotNull(VaadinSession.getCurrent(),
+                "VaadinSession should be available with PER_CLASS lifecycle");
+    }
+
+    @Configuration
+    static class TestConfig {
+    }
+}

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
@@ -19,9 +19,11 @@ import jakarta.enterprise.inject.spi.CDI;
 
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import com.vaadin.browserless.BrowserlessTest;
+import com.vaadin.browserless.BaseBrowserlessTest;
+import com.vaadin.browserless.TesterWrappers;
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.mocks.MockedUI;
 import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
@@ -36,14 +38,13 @@ import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
  * work.
  *
  * With Quarkus testing framework, setting up the CDI environment can be
- * achieved by annotating the {@link BrowserlessTest} class with
- * {@code @QuarkusTest}. The annotation registers a JUnit extension that deploys
- * and starts the whole application, including the initialization of the CDI
- * container. The drawback of this approach is that the application also starts
- * the HTTP server, effectively initializing the entire Vaadin application.
- * Tests are still performed in a mocked environment, but it is not possible
- * out-of-the-box to run them in isolation, with only the components needed by
- * the test.
+ * achieved by annotating the test class with {@code @QuarkusTest}. The
+ * annotation registers a JUnit extension that deploys and starts the whole
+ * application, including the initialization of the CDI container. The drawback
+ * of this approach is that the application also starts the HTTP server,
+ * effectively initializing the entire Vaadin application. Tests are still
+ * performed in a mocked environment, but it is not possible out-of-the-box to
+ * run them in isolation, with only the components needed by the test.
  *
  * <pre>
  * {
@@ -68,16 +69,38 @@ import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
  * may still be removed by the CDI container because considered unused or not
  * found because of missing bean defining annotations. For the above reasons,
  * currently, using {@code @QuarkusComponentTest} is not recommended.
+ *
+ * <p>
+ * This class extends {@link BaseBrowserlessTest} directly (not
+ * {@code BrowserlessTest}) to avoid inheriting
+ * {@code @ExtendWith(BrowserlessTestExtension.class)}. The Vaadin environment
+ * lifecycle is instead managed by {@code @BeforeEach}/{@code @AfterEach}
+ * methods, which JUnit 5 fires <em>after</em> all extension {@code beforeEach}
+ * callbacks — in particular after {@code QuarkusTestExtension.beforeEach()},
+ * which activates the CDI request scope and applies {@code @TestSecurity}
+ * identities.
  */
+public abstract class QuarkusBrowserlessTest extends BaseBrowserlessTest
+        implements TesterWrappers {
 
-public abstract class QuarkusBrowserlessTest extends BrowserlessTest {
+    @Override
+    protected final String testingEngine() {
+        return "JUnit 6";
+    }
 
     @BeforeEach
+    @Override
     protected void initVaadinEnvironment() {
         scanTesters();
         MockQuarkusServlet servlet = new MockQuarkusServlet(discoverRoutes(),
                 CDI.current().getBeanManager(), MockedUI::new);
         MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+    }
+
+    @AfterEach
+    @Override
+    protected void cleanVaadinEnvironment() {
+        super.cleanVaadinEnvironment();
     }
 
     @Override

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
@@ -30,16 +30,16 @@ public class QuarkusSecurityCustomizer implements MockRequestCustomizer {
 
     @Override
     public void apply(MockRequest request) {
-        SecurityIdentity current = CurrentIdentityAssociation.current();
-        if (current.isAnonymous()) {
-            request.setUserPrincipalInt(null);
-            request.setUserInRole((principal, role) -> false);
-        } else {
-            request.setUserPrincipalInt(current.getPrincipal());
-            request.setUserInRole((principal,
-                    role) -> current.getPrincipal().equals(principal)
-                            && hasRole(current, role));
-        }
+        request.setUserPrincipalProvider(() -> {
+            SecurityIdentity current = CurrentIdentityAssociation.current();
+            return current.isAnonymous() ? null : current.getPrincipal();
+        });
+        request.setUserInRole((principal, role) -> {
+            SecurityIdentity current = CurrentIdentityAssociation.current();
+            return !current.isAnonymous()
+                    && current.getPrincipal().equals(principal)
+                    && hasRole(current, role);
+        });
     }
 
     // This method should be removed after implementing a proper solution

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -48,10 +48,29 @@ public class BrowserlessTestSpringLookupInitializer
     private static final ThreadLocal<ApplicationContext> applicationContext = new ThreadLocal<>();
 
     @Override
-    public void beforeTestMethod(TestContext testContext) throws Exception {
+    public void prepareTestInstance(TestContext testContext) throws Exception {
         // SpringLookup requires a WebApplicationContext. Store current test
         // ApplicationContext so that it can be adapted later on by this
-        // initializer
+        // initializer. This must be done in prepareTestInstance so the
+        // ThreadLocal is populated before any JUnit 5 extension
+        // beforeAll/beforeEach callbacks fire.
+        setApplicationContext(testContext);
+    }
+
+    @Override
+    public void beforeTestMethod(TestContext testContext) throws Exception {
+        // Re-set ThreadLocal per test method: afterTestMethod clears it, so
+        // for @TestInstance(PER_CLASS) (where prepareTestInstance runs only
+        // once) this ensures subsequent methods still see the context.
+        setApplicationContext(testContext);
+    }
+
+    @Override
+    public void afterTestMethod(TestContext testContext) throws Exception {
+        BrowserlessTestSpringLookupInitializer.applicationContext.remove();
+    }
+
+    private void setApplicationContext(TestContext testContext) {
         BrowserlessTestSpringLookupInitializer.applicationContext
                 .set(testContext.getApplicationContext());
         ApplicationContext appCtx = testContext.getApplicationContext();
@@ -65,11 +84,6 @@ public class BrowserlessTestSpringLookupInitializer
                             SpringSecurityRequestCustomizer.class.getName(),
                             new SpringSecurityRequestCustomizer());
         }
-    }
-
-    @Override
-    public void afterTestMethod(TestContext testContext) throws Exception {
-        BrowserlessTestSpringLookupInitializer.applicationContext.remove();
     }
 
     @Override

--- a/shared/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
+++ b/shared/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
@@ -129,24 +129,21 @@ public class MockSpringServlet extends SpringServlet {
             HttpServletRequest wrappedRequest = SpringSecuritySupport.springSecurityRequestWrapper
                     .apply(request);
             if (wrappedRequest instanceof MockRequest) {
-                // Spring Security Web not on classpath
-                applySimplifiedSpringSecurity(request);
+                // Spring Security Web not on classpath: read
+                // SecurityContextHolder lazily
+                request.setUserPrincipalProvider(
+                        SpringSecuritySupport::currentPrincipal);
+                request.setUserInRole(SpringSecuritySupport::isGranted);
             } else {
-                request.setUserPrincipalInt(wrappedRequest.getUserPrincipal());
+                // Spring Security Web on classpath: delegate to
+                // SecurityContextHolderAwareRequestWrapper lazily so that
+                // security context populated after setup (e.g. @WithMockUser)
+                // is picked up at test execution time
+                request.setUserPrincipalProvider(
+                        wrappedRequest::getUserPrincipal);
                 request.setUserInRole(
                         (principal, role) -> wrappedRequest.isUserInRole(role));
             }
-        }
-    }
-
-    private static void applySimplifiedSpringSecurity(MockRequest request) {
-        Authentication authentication = SpringSecuritySupport.authentication();
-        if (authentication == null || authentication.getPrincipal() == null) {
-            request.setUserPrincipalInt(null);
-            request.setUserInRole((principal, role) -> false);
-        } else {
-            request.setUserPrincipalInt(authentication);
-            request.setUserInRole(SpringSecuritySupport::isGranted);
         }
     }
 
@@ -156,8 +153,10 @@ public class MockSpringServlet extends SpringServlet {
         private static final boolean SPRING_SECURITY_PRESENT = hasSpringSecurity();
         private static final UnaryOperator<HttpServletRequest> springSecurityRequestWrapper = springSecurityRequestWrapper();
 
-        private static Authentication authentication() {
-            return SecurityContextHolder.getContext().getAuthentication();
+        private static Principal currentPrincipal() {
+            Authentication auth = SecurityContextHolder.getContext()
+                    .getAuthentication();
+            return (auth != null && auth.getPrincipal() != null) ? auth : null;
         }
 
         private static boolean hasSpringSecurity() {

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
@@ -217,9 +217,17 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
     var userPrincipalInt: Principal? = null
 
     /**
-     * Set via [userPrincipalInt].
+     * Optional provider for [getUserPrincipal]. When set, takes precedence over
+     * [userPrincipalInt], allowing the principal to be resolved lazily at
+     * call time (e.g. from a security context that is populated after setup).
      */
-    override fun getUserPrincipal(): Principal? = userPrincipalInt
+    var userPrincipalProvider: (() -> Principal?)? = null
+
+    /**
+     * Returns the principal from [userPrincipalProvider] if set, otherwise
+     * falls back to [userPrincipalInt].
+     */
+    override fun getUserPrincipal(): Principal? = userPrincipalProvider?.invoke() ?: userPrincipalInt
 
     override fun getReader(): BufferedReader {
         throw UnsupportedOperationException("not implemented")


### PR DESCRIPTION
When testing many views that share a MainLayout, the environment was recreated before every single test method, causing unnecessary overhead. Users with large test suites (hundreds of tests) experienced slow runs because there was no way to initialize the Vaadin environment once and reuse it across tests in the same class.

Additionally, the only way to use browserless testing was by extending `BrowserlessTest`, which conflicts with projects that already have their own test base class.

This change introduces `BrowserlessExtension` and
`BrowserlessClassExtension` as JUnit 5 `@RegisterExtension` alternatives that support both per-method and per-class lifecycles. `BrowserlessTest` now also honors `@TestInstance(PER_CLASS)` to keep the same session across all test methods.

Fix security principal resolution to be lazy so that identities set up by framework extensions (e.g. Quarkus `@TestSecurity`, Spring Security) are picked up at call time rather than at environment init time, when the security context is not yet populated.

Ref: https://vaadin.com/forum/t/browserless-testing-in-vaadin-25-1/179350

Closes #22