### PR TITLE
fix: Fix TestSignalEnvironment to prevent flaky signal tests

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/SignalsTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/SignalsTest.java
@@ -18,13 +18,13 @@ package com.vaadin.browserless;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.example.base.signals.SignalsView;
-import com.vaadin.flow.signals.SignalEnvironment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+
+import com.vaadin.flow.signals.SignalEnvironment;
 
 @ViewPackages(packages = "com.example.base.signals")
 @Timeout(10)

--- a/junit6/src/test/java/com/vaadin/browserless/SignalsTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/SignalsTest.java
@@ -16,9 +16,12 @@
 package com.vaadin.browserless;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.example.base.signals.SignalsView;
+import com.vaadin.flow.signals.SignalEnvironment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -72,6 +75,30 @@ public class SignalsTest extends BrowserlessTest {
         test(view.quickBackgroundTaskButton).click();
         runPendingSignalsTasks(300, TimeUnit.MILLISECONDS);
         Assertions.assertEquals("Counter: 10", counterTester.getText());
+    }
+
+    @Test
+    void effectDispatcher_routesToTestQueue_notServiceThreadPool()
+            throws InterruptedException {
+        // On the test thread, both VaadinServiceEnvironment (from
+        // MockVaadin) and TestSignalEnvironment are active. The default
+        // effect dispatcher must resolve to TestSignalEnvironment's queue
+        // (via registerFirst) so that runPendingSignalsTasks() can drive
+        // effect execution deterministically. Without registerFirst,
+        // VaadinServiceEnvironment's thread pool would be used instead,
+        // making effects run asynchronously outside the test's control.
+        navigate(SignalsView.class);
+
+        var latch = new CountDownLatch(1);
+        SignalEnvironment.getDefaultEffectDispatcher()
+                .execute(latch::countDown);
+
+        Assertions.assertFalse(latch.await(50, TimeUnit.MILLISECONDS),
+                "Task should be queued, not executed immediately on a "
+                        + "thread pool");
+        runPendingSignalsTasks();
+        Assertions.assertTrue(latch.await(0, TimeUnit.MILLISECONDS),
+                "Task should have executed after draining the test queue");
     }
 
     @Test

--- a/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
+++ b/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.VaadinSession;
@@ -33,8 +34,8 @@ import com.vaadin.flow.signals.SignalEnvironment;
  * How it works:
  * <ul>
  * <li>{@link #getEffectDispatcher()} returns an executor that enqueues tasks
- * into an internal queue. {@link #getResultNotifier()} returns {@code null} so
- * that result notifications fall through to the next environment or run
+ * into an internal queue. {@link #getResultNotifier()} returns {@code null}
+ * so that result notifications fall through to the next environment or run
  * immediately.</li>
  * <li>Tests call {@link #runPendingTasks(long, TimeUnit)} to dequeue and run
  * all pending tasks on the calling thread.</li>
@@ -147,7 +148,8 @@ public class TestSignalEnvironment extends SignalEnvironment {
      * @return {@code true} if any pending Signals tasks were processed.
      */
     public boolean runPendingTasks(long maxWaitTime, TimeUnit unit) {
-        long deadlineNanos = System.nanoTime() + unit.toNanos(maxWaitTime);
+        long deadlineMillis = System.currentTimeMillis()
+                + unit.toMillis(maxWaitTime);
         VaadinSession session = VaadinSession.getCurrent();
         boolean hadLock = false;
         if (session != null && session.hasLock()) {
@@ -157,11 +159,13 @@ public class TestSignalEnvironment extends SignalEnvironment {
         try {
             boolean processedAny = false;
             while (true) {
-                long remainingNanos = deadlineNanos - System.nanoTime();
+                long remainingMillis = deadlineMillis
+                        - System.currentTimeMillis();
                 Runnable task;
                 try {
-                    task = remainingNanos > 0
-                            ? tasks.poll(remainingNanos, TimeUnit.NANOSECONDS)
+                    task = remainingMillis > 0
+                            ? tasks.poll(remainingMillis,
+                                    TimeUnit.MILLISECONDS)
                             : tasks.poll();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();

--- a/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
+++ b/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.VaadinSession;
@@ -32,8 +33,10 @@ import com.vaadin.flow.signals.SignalEnvironment;
  * <p>
  * How it works:
  * <ul>
- * <li>{@link #getResultNotifier()} and {@link #getEffectDispatcher()} return
- * executors that enqueue tasks into an internal queue.</li>
+ * <li>{@link #getEffectDispatcher()} returns an executor that enqueues tasks
+ * into an internal queue. {@link #getResultNotifier()} returns {@code null}
+ * so that result notifications fall through to the next environment or run
+ * immediately.</li>
  * <li>Tests call {@link #runPendingTasks(long, TimeUnit)} to dequeue and run
  * all pending tasks on the calling thread.</li>
  * <li>If the current thread holds a {@link VaadinSession} lock, the lock is
@@ -79,7 +82,7 @@ public class TestSignalEnvironment extends SignalEnvironment {
      */
     public static TestSignalEnvironment register() {
         TestSignalEnvironment environment = new TestSignalEnvironment();
-        environment.cleanup = SignalEnvironment.register(environment);
+        environment.cleanup = SignalEnvironment.registerFirst(environment);
         return environment;
     }
 
@@ -109,35 +112,35 @@ public class TestSignalEnvironment extends SignalEnvironment {
 
     @Override
     protected Executor getResultNotifier() {
-        return createTaskEnqueueExecutor();
+        // Return null so result notifications fall through to the next
+        // environment (e.g. VaadinServiceEnvironment) or to the immediate
+        // executor. This keeps result processing synchronous on the calling
+        // thread, which is important for deterministic test behavior when
+        // signal operations are triggered on the test thread.
+        return null;
     }
 
     @Override
     protected Executor getEffectDispatcher() {
-        return createTaskEnqueueExecutor();
-    }
-
-    private Executor createTaskEnqueueExecutor() {
         return tasks::offer;
     }
 
     /**
-     * Executes all pending tasks from the queue, waiting for the first task to
-     * arrive if necessary. Once the first task is processed, all remaining
-     * tasks are processed immediately without additional waiting.
+     * Executes pending tasks from the queue, continuously polling for new tasks
+     * until the timeout expires with no new task arriving.
      *
      * <p>
      * If a {@link VaadinSession} lock is held by the current thread, it is
-     * temporarily released during the wait for the first task, allowing
-     * background threads to acquire the lock and enqueue tasks. The lock is
-     * automatically reacquired before this method returns.
+     * temporarily released while polling for tasks, allowing background threads
+     * to acquire the lock and enqueue tasks. The lock is reacquired before
+     * running each task and released again before the next poll.
      *
      * <p>
      * If the current thread is interrupted while waiting for tasks, the method
      * restores the interrupt status and fails with an {@link AssertionError}.
      *
      * @param maxWaitTime
-     *            the maximum time to wait for the first task to arrive in the
+     *            the maximum time to wait for the next task to arrive in the
      *            given time unit. If &lt;= 0, returns immediately if no tasks
      *            are available.
      * @param unit
@@ -145,7 +148,7 @@ public class TestSignalEnvironment extends SignalEnvironment {
      * @return {@code true} if any pending Signals tasks were processed.
      */
     public boolean runPendingTasks(long maxWaitTime, TimeUnit unit) {
-        long waitMillis = unit.toMillis(maxWaitTime);
+        long deadlineNanos = System.nanoTime() + unit.toNanos(maxWaitTime);
         VaadinSession session = VaadinSession.getCurrent();
         boolean hadLock = false;
         if (session != null && session.hasLock()) {
@@ -153,35 +156,49 @@ public class TestSignalEnvironment extends SignalEnvironment {
             session.unlock();
         }
         try {
-            // Wait for the first task with the specified timeout
-            Runnable task;
-            try {
-                task = waitMillis > 0
-                        ? tasks.poll(waitMillis, TimeUnit.MILLISECONDS)
-                        : tasks.poll();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new AssertionError(
-                        "Thread interrupted while waiting for pending Signals tasks");
+            boolean processedAny = false;
+            while (true) {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                Runnable task;
+                try {
+                    task = remainingNanos > 0
+                            ? tasks.poll(remainingNanos, TimeUnit.NANOSECONDS)
+                            : tasks.poll();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(
+                            "Thread interrupted while waiting for pending Signals tasks");
+                }
+                if (task == null) {
+                    if (!processedAny) {
+                        LoggerFactory.getLogger(TestSignalEnvironment.class)
+                                .debug("No pending Signals tasks found after waiting for {} {}",
+                                        maxWaitTime, unit);
+                    }
+                    break;
+                }
+                // Re-acquire the session lock before running the task so
+                // that DOM operations (which assert the lock is held) work
+                // correctly when the effect runs directly on the test
+                // thread instead of going through ui.access().
+                if (hadLock) {
+                    session.lock();
+                }
+                try {
+                    task.run();
+                } finally {
+                    if (hadLock) {
+                        session.unlock();
+                    }
+                }
+                processedAny = true;
             }
-            if (task == null) {
-                LoggerFactory.getLogger(TestSignalEnvironment.class).debug(
-                        "No pending Signals tasks found after waiting for {} {}",
-                        maxWaitTime, unit);
-                return false;
-            }
-            while (task != null) {
-                task.run();
-                // Process remaining tasks immediately, do not wait for
-                // additional tasks to be enqueued
-                task = tasks.poll();
-            }
+            return processedAny;
         } finally {
             if (hadLock) {
                 session.lock();
             }
         }
-        return true;
     }
 
 }

--- a/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
+++ b/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.VaadinSession;
@@ -34,8 +33,8 @@ import com.vaadin.flow.signals.SignalEnvironment;
  * How it works:
  * <ul>
  * <li>{@link #getEffectDispatcher()} returns an executor that enqueues tasks
- * into an internal queue. {@link #getResultNotifier()} returns {@code null}
- * so that result notifications fall through to the next environment or run
+ * into an internal queue. {@link #getResultNotifier()} returns {@code null} so
+ * that result notifications fall through to the next environment or run
  * immediately.</li>
  * <li>Tests call {@link #runPendingTasks(long, TimeUnit)} to dequeue and run
  * all pending tasks on the calling thread.</li>

--- a/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
+++ b/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.VaadinSession;
@@ -34,8 +33,8 @@ import com.vaadin.flow.signals.SignalEnvironment;
  * How it works:
  * <ul>
  * <li>{@link #getEffectDispatcher()} returns an executor that enqueues tasks
- * into an internal queue. {@link #getResultNotifier()} returns {@code null}
- * so that result notifications fall through to the next environment or run
+ * into an internal queue. {@link #getResultNotifier()} returns {@code null} so
+ * that result notifications fall through to the next environment or run
  * immediately.</li>
  * <li>Tests call {@link #runPendingTasks(long, TimeUnit)} to dequeue and run
  * all pending tasks on the calling thread.</li>
@@ -164,8 +163,7 @@ public class TestSignalEnvironment extends SignalEnvironment {
                 Runnable task;
                 try {
                     task = remainingMillis > 0
-                            ? tasks.poll(remainingMillis,
-                                    TimeUnit.MILLISECONDS)
+                            ? tasks.poll(remainingMillis, TimeUnit.MILLISECONDS)
                             : tasks.poll();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();


### PR DESCRIPTION
Use registerFirst() so TestSignalEnvironment takes priority over VaadinServiceEnvironment for effect dispatching. Return null from getResultNotifier() so result notifications run synchronously on the calling thread. Use deadline-based polling in runPendingTasks() to handle tasks that arrive after initial queue drain. Re-acquire the session lock before running each task so DOM operations work when effects run directly on the test thread.
