### PR TITLE
feat!: IntegerSliderTester / IntegerRangeSliderTester

### DIFF
--- a/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerRangeSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerRangeSliderTesterTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.slider;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.BrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.router.RouteConfiguration;
+
+@ViewPackages
+class IntegerRangeSliderTesterTest extends BrowserlessTest {
+
+    IntegerRangeSliderView view;
+
+    @BeforeAll
+    static void enableSliderFeatureFlag() {
+        System.setProperty("vaadin.experimental.sliderComponent", "true");
+    }
+
+    @AfterAll
+    static void clearSliderFeatureFlag() {
+        System.clearProperty("vaadin.experimental.sliderComponent");
+    }
+
+    @BeforeEach
+    void init() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(IntegerRangeSliderView.class);
+        view = navigate(IntegerRangeSliderView.class);
+    }
+
+    @Test
+    void setValue_usable_valueChanges() {
+        IntegerRangeSliderValue range = new IntegerRangeSliderValue(20, 80);
+        test(view.rangeSlider).setValue(range);
+        Assertions.assertEquals(range, view.rangeSlider.getValue(),
+                "Range value should be set");
+    }
+
+    @Test
+    void setValue_usable_eventFired() {
+        AtomicReference<IntegerRangeSliderValue> received = new AtomicReference<>();
+        view.rangeSlider.addValueChangeListener(event -> {
+            if (event.isFromClient()) {
+                received.set(event.getValue());
+            }
+        });
+
+        IntegerRangeSliderValue range = new IntegerRangeSliderValue(30, 70);
+        test(view.rangeSlider).setValue(range);
+        Assertions.assertEquals(range, received.get(),
+                "Value change event should have fired");
+    }
+
+    @Test
+    void setValue_disabled_throws() {
+        view.rangeSlider.setEnabled(false);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> test(view.rangeSlider)
+                        .setValue(new IntegerRangeSliderValue(20, 80)));
+    }
+
+    @Test
+    void setValue_readOnly_throws() {
+        view.rangeSlider.setReadOnly(true);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> test(view.rangeSlider)
+                        .setValue(new IntegerRangeSliderValue(20, 80)));
+    }
+
+    @Test
+    void setValue_startBelowMin_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> test(view.rangeSlider)
+                        .setValue(new IntegerRangeSliderValue(-10, 80)));
+    }
+
+    @Test
+    void setValue_endAboveMax_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> test(view.rangeSlider)
+                        .setValue(new IntegerRangeSliderValue(20, 110)));
+    }
+
+    @Test
+    void setValue_startExceedsEnd_throws() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> test(view.rangeSlider)
+                        .setValue(new IntegerRangeSliderValue(80, 20)));
+    }
+
+    @Test
+    void setStart_usable_updatesStart() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 80));
+        test(view.rangeSlider).setStart(40);
+        Assertions.assertEquals(new IntegerRangeSliderValue(40, 80),
+                view.rangeSlider.getValue(), "Start should be updated");
+    }
+
+    @Test
+    void setEnd_usable_updatesEnd() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 80));
+        test(view.rangeSlider).setEnd(60);
+        Assertions.assertEquals(new IntegerRangeSliderValue(20, 60),
+                view.rangeSlider.getValue(), "End should be updated");
+    }
+
+    @Test
+    void setStart_exceedsEnd_throws() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 50));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> test(view.rangeSlider).setStart(60));
+    }
+
+    @Test
+    void setEnd_belowStart_throws() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(50, 80));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> test(view.rangeSlider).setEnd(40));
+    }
+
+    @Test
+    void incrementStart_usable_increasesByStep() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 80));
+        test(view.rangeSlider).incrementStart();
+        Assertions.assertEquals(30, view.rangeSlider.getValue().start(),
+                "Start should increase by step");
+    }
+
+    @Test
+    void decrementStart_usable_decreasesByStep() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 80));
+        test(view.rangeSlider).decrementStart();
+        Assertions.assertEquals(10, view.rangeSlider.getValue().start(),
+                "Start should decrease by step");
+    }
+
+    @Test
+    void incrementStart_atEnd_clampsToEnd() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(50, 50));
+        test(view.rangeSlider).incrementStart();
+        Assertions.assertEquals(50, view.rangeSlider.getValue().start(),
+                "Start should be clamped to end");
+    }
+
+    @Test
+    void decrementStart_atMin_staysAtMin() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(0, 80));
+        test(view.rangeSlider).decrementStart();
+        Assertions.assertEquals(0, view.rangeSlider.getValue().start(),
+                "Start should stay at min");
+    }
+
+    @Test
+    void incrementEnd_usable_increasesByStep() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 80));
+        test(view.rangeSlider).incrementEnd();
+        Assertions.assertEquals(90, view.rangeSlider.getValue().end(),
+                "End should increase by step");
+    }
+
+    @Test
+    void decrementEnd_usable_decreasesByStep() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 80));
+        test(view.rangeSlider).decrementEnd();
+        Assertions.assertEquals(70, view.rangeSlider.getValue().end(),
+                "End should decrease by step");
+    }
+
+    @Test
+    void incrementEnd_atMax_staysAtMax() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 100));
+        test(view.rangeSlider).incrementEnd();
+        Assertions.assertEquals(100, view.rangeSlider.getValue().end(),
+                "End should stay at max");
+    }
+
+    @Test
+    void decrementEnd_atStart_clampsToStart() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(50, 50));
+        test(view.rangeSlider).decrementEnd();
+        Assertions.assertEquals(50, view.rangeSlider.getValue().end(),
+                "End should be clamped to start");
+    }
+
+    @Test
+    void incrementStartBy_usable_increasesByMultipleSteps() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(0, 80));
+        test(view.rangeSlider).incrementStartBy(3);
+        Assertions.assertEquals(30, view.rangeSlider.getValue().start(),
+                "Start should increase by 3 steps");
+    }
+
+    @Test
+    void decrementEndBy_usable_decreasesByMultipleSteps() {
+        test(view.rangeSlider).setValue(new IntegerRangeSliderValue(20, 80));
+        test(view.rangeSlider).decrementEndBy(2);
+        Assertions.assertEquals(60, view.rangeSlider.getValue().end(),
+                "End should decrease by 2 steps");
+    }
+
+    @Test
+    void increment_readOnly_throws() {
+        view.rangeSlider.setReadOnly(true);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> test(view.rangeSlider).incrementStart());
+    }
+
+    @Test
+    void isUsable_readOnly_false() {
+        view.rangeSlider.setReadOnly(true);
+        Assertions.assertFalse(test(view.rangeSlider).isUsable(),
+                "Read-only range slider should not be usable");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerRangeSliderView.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerRangeSliderView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.slider;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "integer-range-slider", registerAtStartup = false)
+public class IntegerRangeSliderView extends Component implements HasComponents {
+
+    IntegerRangeSlider rangeSlider;
+
+    public IntegerRangeSliderView() {
+        rangeSlider = new IntegerRangeSlider(0, 100);
+        rangeSlider.setStep(10);
+        add(rangeSlider);
+    }
+}

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerSliderTesterTest.java
@@ -56,8 +56,7 @@ class IntegerSliderTesterTest extends BrowserlessTest {
     @Test
     void setValue_usable_valueChanges() {
         test(view.slider).setValue(50);
-        assertEquals(50, view.slider.getValue(),
-                "Slider value should be 50");
+        assertEquals(50, view.slider.getValue(), "Slider value should be 50");
     }
 
     @Test
@@ -145,8 +144,7 @@ class IntegerSliderTesterTest extends BrowserlessTest {
     void increment_atMax_staysAtMax() {
         test(view.slider).setValue(100);
         test(view.slider).increment();
-        assertEquals(100, view.slider.getValue(),
-                "Value should stay at max");
+        assertEquals(100, view.slider.getValue(), "Value should stay at max");
     }
 
     @Test

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerSliderTesterTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.slider;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.BrowserlessTest;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.router.RouteConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ViewPackages
+class IntegerSliderTesterTest extends BrowserlessTest {
+
+    IntegerSliderView view;
+
+    @BeforeAll
+    static void enableSliderFeatureFlag() {
+        System.setProperty("vaadin.experimental.sliderComponent", "true");
+    }
+
+    @AfterAll
+    static void clearSliderFeatureFlag() {
+        System.clearProperty("vaadin.experimental.sliderComponent");
+    }
+
+    @BeforeEach
+    void init() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(IntegerSliderView.class);
+        view = navigate(IntegerSliderView.class);
+    }
+
+    @Test
+    void setValue_usable_valueChanges() {
+        test(view.slider).setValue(50);
+        assertEquals(50, view.slider.getValue(),
+                "Slider value should be 50");
+    }
+
+    @Test
+    void setValue_usable_eventFired() {
+        AtomicReference<Integer> received = new AtomicReference<>();
+        view.slider.addValueChangeListener(event -> {
+            if (event.isFromClient()) {
+                received.set(event.getValue());
+            }
+        });
+
+        test(view.slider).setValue(70);
+        assertEquals(70, received.get(),
+                "Value change event should have fired");
+    }
+
+    @Test
+    void setValue_disabled_throws() {
+        view.slider.setEnabled(false);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> test(view.slider).setValue(50));
+        assertTrue(exception.getMessage().contains("not enabled"));
+    }
+
+    @Test
+    void setValue_readOnly_throws() {
+        view.slider.setReadOnly(true);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> test(view.slider).setValue(50));
+        assertTrue(exception.getMessage().contains("read only"));
+    }
+
+    @Test
+    void setValue_invisible_throws() {
+        view.slider.setVisible(false);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> test(view.slider).setValue(50));
+        assertTrue(exception.getMessage().contains("not visible"));
+    }
+
+    @Test
+    void setValue_belowMin_throws() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> test(view.slider).setValue(-10));
+        assertTrue(exception.getMessage().contains("below minimum"));
+    }
+
+    @Test
+    void setValue_aboveMax_throws() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> test(view.slider).setValue(110));
+        assertTrue(exception.getMessage().contains("above maximum"));
+    }
+
+    @Test
+    void setValue_notAlignedWithStep_throws() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> test(view.slider).setValue(55));
+        assertTrue(exception.getMessage().contains("not aligned with step"));
+    }
+
+    @Test
+    void increment_usable_valueIncreasesByStep() {
+        test(view.slider).setValue(50);
+        test(view.slider).increment();
+        assertEquals(60, view.slider.getValue(),
+                "Value should increase by step");
+    }
+
+    @Test
+    void decrement_usable_valueDecreasesByStep() {
+        test(view.slider).setValue(50);
+        test(view.slider).decrement();
+        assertEquals(40, view.slider.getValue(),
+                "Value should decrease by step");
+    }
+
+    @Test
+    void increment_atMax_staysAtMax() {
+        test(view.slider).setValue(100);
+        test(view.slider).increment();
+        assertEquals(100, view.slider.getValue(),
+                "Value should stay at max");
+    }
+
+    @Test
+    void decrement_atMin_staysAtMin() {
+        test(view.slider).setValue(0);
+        test(view.slider).decrement();
+        assertEquals(0, view.slider.getValue(), "Value should stay at min");
+    }
+
+    @Test
+    void incrementBy_usable_valueIncreasesByMultipleSteps() {
+        test(view.slider).setValue(0);
+        test(view.slider).incrementBy(3);
+        assertEquals(30, view.slider.getValue(),
+                "Value should increase by 3 steps");
+    }
+
+    @Test
+    void decrementBy_usable_valueDecreasesByMultipleSteps() {
+        test(view.slider).setValue(50);
+        test(view.slider).decrementBy(2);
+        assertEquals(30, view.slider.getValue(),
+                "Value should decrease by 2 steps");
+    }
+
+    @Test
+    void increment_readOnly_throws() {
+        view.slider.setReadOnly(true);
+        assertThrows(IllegalStateException.class,
+                () -> test(view.slider).increment());
+    }
+
+    @Test
+    void isUsable_readOnly_false() {
+        view.slider.setReadOnly(true);
+        assertFalse(test(view.slider).isUsable(),
+                "Read-only slider should not be usable");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerSliderView.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerSliderView.java
@@ -15,29 +15,20 @@
  */
 package com.vaadin.flow.component.slider;
 
-import com.vaadin.browserless.Tests;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
 
-/**
- * Tester for Slider components.
- *
- * @param <T>
- *            component type
- */
-@Tests(Slider.class)
-public class SliderTester<T extends Slider>
-        extends NumberSliderTester<T, Double> {
-    /**
-     * Wrap given component for testing.
-     *
-     * @param component
-     *            target component
-     */
-    public SliderTester(T component) {
-        super(component);
-    }
+@Tag("div")
+@Route(value = "integer-slider", registerAtStartup = false)
+public class IntegerSliderView extends Component implements HasComponents {
 
-    @Override
-    protected Double toValue(double value) {
-        return value;
+    IntegerSlider slider;
+
+    public IntegerSliderView() {
+        slider = new IntegerSlider(0, 100);
+        slider.setStep(10);
+        add(slider);
     }
 }

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/RangeSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/RangeSliderTesterTest.java
@@ -112,7 +112,7 @@ class RangeSliderTesterTest extends BrowserlessTest {
     @Test
     void setStart_usable_updatesStart() {
         test(view.rangeSlider).setValue(new RangeSliderValue(20.0, 80.0));
-        test(view.rangeSlider).setStart(40);
+        test(view.rangeSlider).setStart(40.0);
         Assertions.assertEquals(new RangeSliderValue(40.0, 80.0),
                 view.rangeSlider.getValue(), "Start should be updated");
     }
@@ -120,7 +120,7 @@ class RangeSliderTesterTest extends BrowserlessTest {
     @Test
     void setEnd_usable_updatesEnd() {
         test(view.rangeSlider).setValue(new RangeSliderValue(20.0, 80.0));
-        test(view.rangeSlider).setEnd(60);
+        test(view.rangeSlider).setEnd(60.0);
         Assertions.assertEquals(new RangeSliderValue(20.0, 60.0),
                 view.rangeSlider.getValue(), "End should be updated");
     }

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/RangeSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/RangeSliderTesterTest.java
@@ -129,14 +129,14 @@ class RangeSliderTesterTest extends BrowserlessTest {
     void setStart_exceedsEnd_throws() {
         test(view.rangeSlider).setValue(new RangeSliderValue(20.0, 50.0));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> test(view.rangeSlider).setStart(60));
+                () -> test(view.rangeSlider).setStart(60.0));
     }
 
     @Test
     void setEnd_belowStart_throws() {
         test(view.rangeSlider).setValue(new RangeSliderValue(50.0, 80.0));
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> test(view.rangeSlider).setEnd(40));
+                () -> test(view.rangeSlider).setEnd(40.0));
     }
 
     @Test

--- a/shared/src/main/java/com/vaadin/browserless/TesterWrappers.java
+++ b/shared/src/main/java/com/vaadin/browserless/TesterWrappers.java
@@ -113,6 +113,8 @@ import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.select.SelectTester;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavTester;
+import com.vaadin.flow.component.slider.IntegerRangeSlider;
+import com.vaadin.flow.component.slider.IntegerRangeSliderTester;
 import com.vaadin.flow.component.slider.IntegerSlider;
 import com.vaadin.flow.component.slider.IntegerSliderTester;
 import com.vaadin.flow.component.slider.RangeSlider;
@@ -318,14 +320,20 @@ public interface TesterWrappers {
                 rangeSlider);
     }
 
-    default IntegerSliderTester<IntegerSlider> test(
-            IntegerSlider integerSlider) {
-        return BaseBrowserlessTest.internalWrap(IntegerSliderTester.class,
-                integerSlider);
+    default IntegerRangeSliderTester<IntegerRangeSlider> test(
+            IntegerRangeSlider integerRangeSlider) {
+        return BaseBrowserlessTest.internalWrap(IntegerRangeSliderTester.class,
+                integerRangeSlider);
     }
 
     default SliderTester<Slider> test(Slider slider) {
         return BaseBrowserlessTest.internalWrap(SliderTester.class, slider);
+    }
+
+    default IntegerSliderTester<IntegerSlider> test(
+            IntegerSlider integerSlider) {
+        return BaseBrowserlessTest.internalWrap(IntegerSliderTester.class,
+                integerSlider);
     }
 
     default TabsTester<Tabs> test(Tabs tabs) {

--- a/shared/src/main/java/com/vaadin/browserless/TesterWrappers.java
+++ b/shared/src/main/java/com/vaadin/browserless/TesterWrappers.java
@@ -113,6 +113,8 @@ import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.select.SelectTester;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavTester;
+import com.vaadin.flow.component.slider.IntegerSlider;
+import com.vaadin.flow.component.slider.IntegerSliderTester;
 import com.vaadin.flow.component.slider.RangeSlider;
 import com.vaadin.flow.component.slider.RangeSliderTester;
 import com.vaadin.flow.component.slider.Slider;
@@ -314,6 +316,12 @@ public interface TesterWrappers {
     default RangeSliderTester<RangeSlider> test(RangeSlider rangeSlider) {
         return BaseBrowserlessTest.internalWrap(RangeSliderTester.class,
                 rangeSlider);
+    }
+
+    default IntegerSliderTester<IntegerSlider> test(
+            IntegerSlider integerSlider) {
+        return BaseBrowserlessTest.internalWrap(IntegerSliderTester.class,
+                integerSlider);
     }
 
     default SliderTester<Slider> test(Slider slider) {

--- a/shared/src/main/java/com/vaadin/flow/component/slider/IntegerRangeSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/IntegerRangeSliderTester.java
@@ -37,12 +37,12 @@ public class IntegerRangeSliderTester<T extends IntegerRangeSlider>
     }
 
     @Override
-    protected Integer toNumber(double value) {
+    protected Integer fromDouble(double value) {
         return (int) value;
     }
 
     @Override
-    protected IntegerRangeSliderValue createValue(Integer start, Integer end) {
+    protected IntegerRangeSliderValue createRange(Integer start, Integer end) {
         return new IntegerRangeSliderValue(start, end);
     }
 }

--- a/shared/src/main/java/com/vaadin/flow/component/slider/IntegerRangeSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/IntegerRangeSliderTester.java
@@ -18,31 +18,31 @@ package com.vaadin.flow.component.slider;
 import com.vaadin.browserless.Tests;
 
 /**
- * Tester for RangeSlider components.
+ * Tester for IntegerRangeSlider components.
  *
  * @param <T>
  *            component type
  */
-@Tests(RangeSlider.class)
-public class RangeSliderTester<T extends RangeSlider>
-        extends NumberRangeSliderTester<T, RangeSliderValue, Double> {
+@Tests(IntegerRangeSlider.class)
+public class IntegerRangeSliderTester<T extends IntegerRangeSlider>
+        extends NumberRangeSliderTester<T, IntegerRangeSliderValue, Integer> {
     /**
      * Wrap given component for testing.
      *
      * @param component
      *            target component
      */
-    public RangeSliderTester(T component) {
+    public IntegerRangeSliderTester(T component) {
         super(component);
     }
 
     @Override
-    protected Double toNumber(double value) {
-        return value;
+    protected Integer toNumber(double value) {
+        return (int) value;
     }
 
     @Override
-    protected RangeSliderValue createValue(Double start, Double end) {
-        return new RangeSliderValue(start, end);
+    protected IntegerRangeSliderValue createValue(Integer start, Integer end) {
+        return new IntegerRangeSliderValue(start, end);
     }
 }

--- a/shared/src/main/java/com/vaadin/flow/component/slider/IntegerSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/IntegerSliderTester.java
@@ -18,26 +18,26 @@ package com.vaadin.flow.component.slider;
 import com.vaadin.browserless.Tests;
 
 /**
- * Tester for Slider components.
+ * Tester for IntegerSlider components.
  *
  * @param <T>
  *            component type
  */
-@Tests(Slider.class)
-public class SliderTester<T extends Slider>
-        extends NumberSliderTester<T, Double> {
+@Tests(IntegerSlider.class)
+public class IntegerSliderTester<T extends IntegerSlider>
+        extends NumberSliderTester<T, Integer> {
     /**
      * Wrap given component for testing.
      *
      * @param component
      *            target component
      */
-    public SliderTester(T component) {
+    public IntegerSliderTester(T component) {
         super(component);
     }
 
     @Override
-    protected Double toValue(double value) {
-        return value;
+    protected Integer toValue(double value) {
+        return (int) value;
     }
 }

--- a/shared/src/main/java/com/vaadin/flow/component/slider/IntegerSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/IntegerSliderTester.java
@@ -37,7 +37,7 @@ public class IntegerSliderTester<T extends IntegerSlider>
     }
 
     @Override
-    protected Integer toValue(double value) {
+    protected Integer fromDouble(double value) {
         return (int) value;
     }
 }

--- a/shared/src/main/java/com/vaadin/flow/component/slider/NumberRangeSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/NumberRangeSliderTester.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.slider;
+
+import java.util.function.Consumer;
+
+import com.vaadin.browserless.ComponentTester;
+
+/**
+ * Base tester for {@link NumberRangeSlider} components.
+ *
+ * @param <T>
+ *            component type
+ * @param <TValue>
+ *            value type
+ * @param <TNumber>
+ *            numeric type for start, end, min, max, step
+ */
+abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TNumber>, TValue extends Range<TNumber>, TNumber extends Number & Comparable<TNumber>>
+        extends ComponentTester<T> {
+    /**
+     * Wrap given component for testing.
+     *
+     * @param component
+     *            target component
+     */
+    NumberRangeSliderTester(T component) {
+        super(component);
+    }
+
+    /**
+     * Simulates the user dragging both thumbs to set the range value.
+     * <p>
+     * Throws if the component is not usable, if start or end are outside the
+     * min/max range, or if start exceeds end.
+     *
+     * @param value
+     *            range value to set
+     * @throws IllegalArgumentException
+     *             if the value is invalid
+     */
+    public void setValue(TValue value) {
+        ensureComponentIsUsable();
+        if (value != null) {
+            validateRange(value.start(), value.end());
+        }
+        setValueAsUser(value);
+    }
+
+    /**
+     * Simulates the user dragging only the start (min) thumb.
+     *
+     * @param start
+     *            new start value
+     * @throws IllegalArgumentException
+     *             if start is outside min/max or exceeds current end
+     */
+    public void setStart(TNumber start) {
+        ensureComponentIsUsable();
+        TNumber end = getComponent().getValue().end();
+        validateRange(start, end);
+        setValueAsUser(createValue(start, end));
+    }
+
+    /**
+     * Simulates the user dragging only the end (max) thumb.
+     *
+     * @param end
+     *            new end value
+     * @throws IllegalArgumentException
+     *             if end is outside min/max or is below current start
+     */
+    public void setEnd(TNumber end) {
+        ensureComponentIsUsable();
+        TNumber start = getComponent().getValue().start();
+        validateRange(start, end);
+        setValueAsUser(createValue(start, end));
+    }
+
+    /**
+     * Simulates pressing the arrow key on the start thumb to increase start by
+     * one step. Clamped to end value.
+     */
+    public void incrementStart() {
+        incrementStartBy(1);
+    }
+
+    /**
+     * Simulates pressing the arrow key on the start thumb to decrease start by
+     * one step. Clamped to min.
+     */
+    public void decrementStart() {
+        decrementStartBy(1);
+    }
+
+    /**
+     * Simulates the user dragging the start thumb to increase start by the
+     * given number of steps. Clamped to end value.
+     *
+     * @param steps
+     *            number of steps to increment
+     */
+    public void incrementStartBy(int steps) {
+        ensureComponentIsUsable();
+        TValue current = getComponent().getValue();
+        double newStart = Math.min(
+                current.start().doubleValue()
+                        + steps * getComponent().getStep().doubleValue(),
+                current.end().doubleValue());
+        setValueAsUser(createValue(toNumber(newStart), current.end()));
+    }
+
+    /**
+     * Simulates the user dragging the start thumb to decrease start by the
+     * given number of steps. Clamped to min.
+     *
+     * @param steps
+     *            number of steps to decrement
+     */
+    public void decrementStartBy(int steps) {
+        ensureComponentIsUsable();
+        TValue current = getComponent().getValue();
+        double newStart = Math.max(
+                current.start().doubleValue()
+                        - steps * getComponent().getStep().doubleValue(),
+                getComponent().getMin().doubleValue());
+        setValueAsUser(createValue(toNumber(newStart), current.end()));
+    }
+
+    /**
+     * Simulates pressing the arrow key on the end thumb to increase end by one
+     * step. Clamped to max.
+     */
+    public void incrementEnd() {
+        incrementEndBy(1);
+    }
+
+    /**
+     * Simulates pressing the arrow key on the end thumb to decrease end by one
+     * step. Clamped to start value.
+     */
+    public void decrementEnd() {
+        decrementEndBy(1);
+    }
+
+    /**
+     * Simulates the user dragging the end thumb to increase end by the given
+     * number of steps. Clamped to max.
+     *
+     * @param steps
+     *            number of steps to increment
+     */
+    public void incrementEndBy(int steps) {
+        ensureComponentIsUsable();
+        TValue current = getComponent().getValue();
+        double newEnd = Math.min(
+                current.end().doubleValue()
+                        + steps * getComponent().getStep().doubleValue(),
+                getComponent().getMax().doubleValue());
+        setValueAsUser(createValue(current.start(), toNumber(newEnd)));
+    }
+
+    /**
+     * Simulates the user dragging the end thumb to decrease end by the given
+     * number of steps. Clamped to start value.
+     *
+     * @param steps
+     *            number of steps to decrement
+     */
+    public void decrementEndBy(int steps) {
+        ensureComponentIsUsable();
+        TValue current = getComponent().getValue();
+        double newEnd = Math.max(
+                current.end().doubleValue()
+                        - steps * getComponent().getStep().doubleValue(),
+                current.start().doubleValue());
+        setValueAsUser(createValue(current.start(), toNumber(newEnd)));
+    }
+
+    /**
+     * Converts a double value to the slider's numeric type.
+     *
+     * @param value
+     *            the double value to convert
+     * @return the converted value
+     */
+    protected abstract TNumber toNumber(double value);
+
+    /**
+     * Creates a range value from start and end values.
+     *
+     * @param start
+     *            the start value
+     * @param end
+     *            the end value
+     * @return the range value
+     */
+    protected abstract TValue createValue(TNumber start, TNumber end);
+
+    @Override
+    public boolean isUsable() {
+        return super.isUsable() && !getComponent().isReadOnly();
+    }
+
+    @Override
+    protected void notUsableReasons(Consumer<String> collector) {
+        super.notUsableReasons(collector);
+        if (getComponent().isReadOnly()) {
+            collector.accept("read only");
+        }
+    }
+
+    private void validateRange(TNumber start, TNumber end) {
+        double min = getComponent().getMin().doubleValue();
+        double max = getComponent().getMax().doubleValue();
+        if (start.doubleValue() < min) {
+            throw new IllegalArgumentException(
+                    "Start " + start + " is below minimum " + min);
+        }
+        if (end.doubleValue() > max) {
+            throw new IllegalArgumentException(
+                    "End " + end + " is above maximum " + max);
+        }
+        if (start.doubleValue() > end.doubleValue()) {
+            throw new IllegalArgumentException(
+                    "Start " + start + " exceeds end " + end);
+        }
+    }
+}

--- a/shared/src/main/java/com/vaadin/flow/component/slider/NumberRangeSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/NumberRangeSliderTester.java
@@ -29,7 +29,7 @@ import com.vaadin.browserless.ComponentTester;
  * @param <TNumber>
  *            numeric type for start, end, min, max, step
  */
-abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TNumber>, TValue extends Range<TNumber>, TNumber extends Number & Comparable<TNumber>>
+abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TNumber>, TValue extends Range<TNumber>, TNumber extends Number>
         extends ComponentTester<T> {
     /**
      * Wrap given component for testing.

--- a/shared/src/main/java/com/vaadin/flow/component/slider/NumberRangeSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/NumberRangeSliderTester.java
@@ -72,7 +72,7 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
         ensureComponentIsUsable();
         TNumber end = getComponent().getValue().end();
         validateRange(start, end);
-        setValueAsUser(createValue(start, end));
+        setValueAsUser(createRange(start, end));
     }
 
     /**
@@ -87,7 +87,7 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
         ensureComponentIsUsable();
         TNumber start = getComponent().getValue().start();
         validateRange(start, end);
-        setValueAsUser(createValue(start, end));
+        setValueAsUser(createRange(start, end));
     }
 
     /**
@@ -120,7 +120,7 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
                 current.start().doubleValue()
                         + steps * getComponent().getStep().doubleValue(),
                 current.end().doubleValue());
-        setValueAsUser(createValue(toNumber(newStart), current.end()));
+        setValueAsUser(createRange(fromDouble(newStart), current.end()));
     }
 
     /**
@@ -137,7 +137,7 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
                 current.start().doubleValue()
                         - steps * getComponent().getStep().doubleValue(),
                 getComponent().getMin().doubleValue());
-        setValueAsUser(createValue(toNumber(newStart), current.end()));
+        setValueAsUser(createRange(fromDouble(newStart), current.end()));
     }
 
     /**
@@ -170,7 +170,7 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
                 current.end().doubleValue()
                         + steps * getComponent().getStep().doubleValue(),
                 getComponent().getMax().doubleValue());
-        setValueAsUser(createValue(current.start(), toNumber(newEnd)));
+        setValueAsUser(createRange(current.start(), fromDouble(newEnd)));
     }
 
     /**
@@ -187,7 +187,7 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
                 current.end().doubleValue()
                         - steps * getComponent().getStep().doubleValue(),
                 current.start().doubleValue());
-        setValueAsUser(createValue(current.start(), toNumber(newEnd)));
+        setValueAsUser(createRange(current.start(), fromDouble(newEnd)));
     }
 
     /**
@@ -197,7 +197,7 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
      *            the double value to convert
      * @return the converted value
      */
-    protected abstract TNumber toNumber(double value);
+    protected abstract TNumber fromDouble(double value);
 
     /**
      * Creates a range value from start and end values.
@@ -208,7 +208,7 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
      *            the end value
      * @return the range value
      */
-    protected abstract TValue createValue(TNumber start, TNumber end);
+    protected abstract TValue createRange(TNumber start, TNumber end);
 
     @Override
     public boolean isUsable() {

--- a/shared/src/main/java/com/vaadin/flow/component/slider/NumberSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/NumberSliderTester.java
@@ -24,10 +24,10 @@ import com.vaadin.browserless.ComponentTester;
  *
  * @param <T>
  *            component type
- * @param <V>
+ * @param <TValue>
  *            value type
  */
-abstract class NumberSliderTester<T extends NumberSlider<?, V>, V extends Number & Comparable<V>>
+abstract class NumberSliderTester<T extends NumberSlider<?, TValue>, TValue extends Number>
         extends ComponentTester<T> {
     /**
      * Wrap given component for testing.
@@ -50,7 +50,7 @@ abstract class NumberSliderTester<T extends NumberSlider<?, V>, V extends Number
      * @throws IllegalArgumentException
      *             if the value is outside the min/max range
      */
-    public void setValue(V value) {
+    public void setValue(TValue value) {
         ensureComponentIsUsable();
         if (value != null) {
             if (value.doubleValue() < getComponent().getMin().doubleValue()) {
@@ -127,7 +127,7 @@ abstract class NumberSliderTester<T extends NumberSlider<?, V>, V extends Number
      *            the double value to convert
      * @return the converted value
      */
-    protected abstract V fromDouble(double value);
+    protected abstract TValue fromDouble(double value);
 
     @Override
     public boolean isUsable() {

--- a/shared/src/main/java/com/vaadin/flow/component/slider/NumberSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/NumberSliderTester.java
@@ -101,7 +101,7 @@ abstract class NumberSliderTester<T extends NumberSlider<?, V>, V extends Number
                 getComponent().getValue().doubleValue()
                         + steps * getComponent().getStep().doubleValue(),
                 getComponent().getMax().doubleValue());
-        setValueAsUser(toValue(newValue));
+        setValueAsUser(fromDouble(newValue));
     }
 
     /**
@@ -117,7 +117,7 @@ abstract class NumberSliderTester<T extends NumberSlider<?, V>, V extends Number
                 getComponent().getValue().doubleValue()
                         - steps * getComponent().getStep().doubleValue(),
                 getComponent().getMin().doubleValue());
-        setValueAsUser(toValue(newValue));
+        setValueAsUser(fromDouble(newValue));
     }
 
     /**
@@ -127,7 +127,7 @@ abstract class NumberSliderTester<T extends NumberSlider<?, V>, V extends Number
      *            the double value to convert
      * @return the converted value
      */
-    protected abstract V toValue(double value);
+    protected abstract V fromDouble(double value);
 
     @Override
     public boolean isUsable() {

--- a/shared/src/main/java/com/vaadin/flow/component/slider/NumberSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/NumberSliderTester.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.slider;
+
+import java.util.function.Consumer;
+
+import com.vaadin.browserless.ComponentTester;
+
+/**
+ * Base tester for {@link NumberSlider} components.
+ *
+ * @param <T>
+ *            component type
+ * @param <V>
+ *            value type
+ */
+abstract class NumberSliderTester<T extends NumberSlider<?, V>, V extends Number & Comparable<V>>
+        extends ComponentTester<T> {
+    /**
+     * Wrap given component for testing.
+     *
+     * @param component
+     *            target component
+     */
+    NumberSliderTester(T component) {
+        super(component);
+    }
+
+    /**
+     * Simulates the user dragging the slider handle to the given value.
+     * <p>
+     * Throws if the component is not usable or the value is outside the min/max
+     * range.
+     *
+     * @param value
+     *            value to set
+     * @throws IllegalArgumentException
+     *             if the value is outside the min/max range
+     */
+    public void setValue(V value) {
+        ensureComponentIsUsable();
+        if (value != null) {
+            if (value.doubleValue() < getComponent().getMin().doubleValue()) {
+                throw new IllegalArgumentException("Value " + value
+                        + " is below minimum " + getComponent().getMin());
+            }
+            if (value.doubleValue() > getComponent().getMax().doubleValue()) {
+                throw new IllegalArgumentException("Value " + value
+                        + " is above maximum " + getComponent().getMax());
+            }
+            if (!getComponent().isValueAlignedWithStep(value)) {
+                throw new IllegalArgumentException(
+                        "Value " + value + " is not aligned with step "
+                                + getComponent().getStep() + " (min: "
+                                + getComponent().getMin() + ", max: "
+                                + getComponent().getMax() + ")");
+            }
+        }
+        setValueAsUser(value);
+    }
+
+    /**
+     * Simulates the user pressing the Right/Up arrow key to increase the value
+     * by one step. The value is clamped to the maximum.
+     */
+    public void increment() {
+        incrementBy(1);
+    }
+
+    /**
+     * Simulates the user pressing the Left/Down arrow key to decrease the value
+     * by one step. The value is clamped to the minimum.
+     */
+    public void decrement() {
+        decrementBy(1);
+    }
+
+    /**
+     * Simulates the user dragging the slider handle to increase the value by
+     * the given number of steps. The value is clamped to the maximum.
+     *
+     * @param steps
+     *            number of steps to increment
+     */
+    public void incrementBy(int steps) {
+        ensureComponentIsUsable();
+        double newValue = Math.min(
+                getComponent().getValue().doubleValue()
+                        + steps * getComponent().getStep().doubleValue(),
+                getComponent().getMax().doubleValue());
+        setValueAsUser(toValue(newValue));
+    }
+
+    /**
+     * Simulates the user dragging the slider handle to decrease the value by
+     * the given number of steps. The value is clamped to the minimum.
+     *
+     * @param steps
+     *            number of steps to decrement
+     */
+    public void decrementBy(int steps) {
+        ensureComponentIsUsable();
+        double newValue = Math.max(
+                getComponent().getValue().doubleValue()
+                        - steps * getComponent().getStep().doubleValue(),
+                getComponent().getMin().doubleValue());
+        setValueAsUser(toValue(newValue));
+    }
+
+    /**
+     * Converts a double value to the slider's value type.
+     *
+     * @param value
+     *            the double value to convert
+     * @return the converted value
+     */
+    protected abstract V toValue(double value);
+
+    @Override
+    public boolean isUsable() {
+        return super.isUsable() && !getComponent().isReadOnly();
+    }
+
+    @Override
+    protected void notUsableReasons(Consumer<String> collector) {
+        super.notUsableReasons(collector);
+        if (getComponent().isReadOnly()) {
+            collector.accept("read only");
+        }
+    }
+}

--- a/shared/src/main/java/com/vaadin/flow/component/slider/RangeSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/RangeSliderTester.java
@@ -37,12 +37,12 @@ public class RangeSliderTester<T extends RangeSlider>
     }
 
     @Override
-    protected Double toNumber(double value) {
+    protected Double fromDouble(double value) {
         return value;
     }
 
     @Override
-    protected RangeSliderValue createValue(Double start, Double end) {
+    protected RangeSliderValue createRange(Double start, Double end) {
         return new RangeSliderValue(start, end);
     }
 }

--- a/shared/src/main/java/com/vaadin/flow/component/slider/SliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/SliderTester.java
@@ -37,7 +37,7 @@ public class SliderTester<T extends Slider>
     }
 
     @Override
-    protected Double toValue(double value) {
+    protected Double fromDouble(double value) {
         return value;
     }
 }


### PR DESCRIPTION
## Description

https://github.com/vaadin/flow-components/pull/9123 added the `IntegerSlider` / `IntegerRangeSlider` variants. This adds respective testers for the new component.

To reuse existing logic, this extracts abstract / generic `NumberSliderTester` / `NumberRangeSliderTester` component testers and bases the existing and new testers on top of them.

As a side-effect, getters and setters now use boxed values. This is a breaking change. We deem that acceptable as the Slider component is still considered experimental and is behind a feature flag.

Part of https://github.com/vaadin/flow-components/issues/8863

## Type of change

- Feature / Breaking change

Fixes #36 