### PR TITLE
WIP: alternative prototype for multi user/tab feature

### DIFF
--- a/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
@@ -25,10 +25,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.internal.Routes;
-import com.vaadin.browserless.internal.ShortcutsKt;
 import com.vaadin.browserless.mocks.MockedUI;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
@@ -36,7 +34,6 @@ import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.HasUrlParameter;
-import com.vaadin.flow.router.RouteParameters;
 
 /**
  * Abstract base for browserless JUnit 5 extensions. Holds all shared state and
@@ -145,8 +142,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return the instantiated view
      */
     public <T extends Component> T navigate(Class<T> target) {
-        getUI().navigate(target);
-        return validateNavigationTarget(target);
+        return BrowserlessDSL.navigate(getUI(), target);
     }
 
     /**
@@ -164,8 +160,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      */
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
             Class<T> target, C parameter) {
-        getUI().navigate(target, parameter);
-        return validateNavigationTarget(target);
+        return BrowserlessDSL.navigate(getUI(), target, parameter);
     }
 
     /**
@@ -181,8 +176,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      */
     public <T extends Component> T navigate(Class<T> target,
             Map<String, String> parameters) {
-        getUI().navigate(target, new RouteParameters(parameters));
-        return validateNavigationTarget(target);
+        return BrowserlessDSL.navigate(getUI(), target, parameters);
     }
 
     /**
@@ -198,8 +192,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      */
     public <T extends Component> T navigate(String location,
             Class<T> expectedTarget) {
-        getUI().navigate(location);
-        return validateNavigationTarget(expectedTarget);
+        return BrowserlessDSL.navigate(getUI(), location, expectedTarget);
     }
 
     /**
@@ -211,9 +204,8 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      *            component type
      * @return a component query
      */
-    public <T extends Component> ComponentQuery<T> $(Class<T> type) {
-        getUI();
-        return BaseBrowserlessTest.internalQuery(type);
+    public <T extends Component> ComponentQuery<T> find(Class<T> type) {
+        return BrowserlessDSL.find(getUI(), type);
     }
 
     /**
@@ -228,10 +220,9 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      *            component type
      * @return a component query scoped to the given component
      */
-    public <T extends Component> ComponentQuery<T> $(Class<T> type,
+    public <T extends Component> ComponentQuery<T> find(Class<T> type,
             Component fromThis) {
-        getUI();
-        return new ComponentQuery<>(type).from(fromThis);
+        return BrowserlessDSL.find(getUI(), type, fromThis);
     }
 
     /**
@@ -243,11 +234,8 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      *            component type
      * @return a component query scoped to the current view
      */
-    public <T extends Component> ComponentQuery<T> $view(Class<T> type) {
-        Component viewComponent = getCurrentView().getElement().getComponent()
-                .orElseThrow(() -> new AssertionError(
-                        "Cannot get Component instance for current view"));
-        return new ComponentQuery<>(type).from(viewComponent);
+    public <T extends Component> ComponentQuery<T> findView(Class<T> type) {
+        return BrowserlessDSL.findView(getUI(), type);
     }
 
     /**
@@ -256,14 +244,14 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return the current view
      */
     public HasElement getCurrentView() {
-        return getUI().getInternals().getActiveRouterTargetsChain().get(0);
+        return BrowserlessDSL.getCurrentView(getUI());
     }
 
     /**
      * Simulates a server round-trip, flushing pending component changes.
      */
     public void roundTrip() {
-        BaseBrowserlessTest.roundTrip();
+        BrowserlessDSL.roundTrip(getUI());
     }
 
     /**
@@ -273,7 +261,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return {@code true} if any pending Signals tasks were processed
      */
     public boolean runPendingSignalsTasks() {
-        return runPendingSignalsTasks(100, TimeUnit.MILLISECONDS);
+        return BrowserlessDSL.runPendingSignalsTasks(signalsTestEnvironment);
     }
 
     /**
@@ -287,10 +275,8 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return {@code true} if any pending Signals tasks were processed
      */
     public boolean runPendingSignalsTasks(long maxWaitTime, TimeUnit unit) {
-        if (signalsTestEnvironment != null) {
-            return signalsTestEnvironment.runPendingTasks(maxWaitTime, unit);
-        }
-        return false;
+        return BrowserlessDSL.runPendingSignalsTasks(signalsTestEnvironment,
+                maxWaitTime, unit);
     }
 
     /**
@@ -302,14 +288,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      *            key modifiers
      */
     public void fireShortcut(Key key, KeyModifier... modifiers) {
-        UI ui = getUI();
-        if (ui.hasModalComponent()) {
-            ShortcutsKt._fireShortcut(
-                    ui.getInternals().getActiveModalComponent(), key,
-                    modifiers);
-        } else {
-            ShortcutsKt.fireShortcut(key, modifiers);
-        }
+        BrowserlessDSL.fireShortcut(getUI(), key, modifiers);
     }
 
     private UI getUI() {
@@ -321,20 +300,5 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
                             + "before calling test DSL methods.");
         }
         return ui;
-    }
-
-    private <T extends Component> T validateNavigationTarget(Class<T> target) {
-        HasElement currentView = getCurrentView();
-        if (!target.isAssignableFrom(currentView.getClass())) {
-            if (currentView instanceof MockInternalSeverError) {
-                System.err.println(
-                        currentView.getElement().getProperty("stackTrace"));
-            }
-            throw new IllegalArgumentException(
-                    "Navigation resulted in unexpected class "
-                            + currentView.getClass().getName() + " instead of "
-                            + target.getName());
-        }
-        return target.cast(currentView);
     }
 }

--- a/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.vaadin.browserless.internal.MockInternalSeverError;
+import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.ShortcutsKt;
+import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.RouteParameters;
+
+/**
+ * Abstract base for browserless JUnit 5 extensions. Holds all shared state and
+ * logic; concrete subclasses implement only the lifecycle callbacks they need.
+ */
+abstract class AbstractBrowserlessExtension implements TesterWrappers {
+
+    // Programmatic config (builder-style)
+    private final Set<String> viewPackages = new HashSet<>();
+    private final Set<Class<?>> services = new HashSet<>();
+    private final Set<String> componentTesterPackages = new HashSet<>();
+
+    // Runtime state
+    private TestSignalEnvironment signalsTestEnvironment;
+    private Runnable cleanupAction;
+
+    // --- Protected builder helpers ---
+
+    protected void addViewPackages(Class<?>... classes) {
+        Stream.of(classes).map(Class::getPackageName)
+                .forEach(viewPackages::add);
+    }
+
+    protected void addViewPackages(String... packages) {
+        viewPackages.addAll(Arrays.asList(packages));
+    }
+
+    protected void addServices(Class<?>... serviceClasses) {
+        services.addAll(Arrays.asList(serviceClasses));
+    }
+
+    protected void addComponentTesterPackages(String... packages) {
+        componentTesterPackages.addAll(Arrays.asList(packages));
+    }
+
+    // --- Lifecycle callbacks ---
+
+    protected void doInit(Object testInstance, ExtensionContext ctx) {
+        if (testInstance instanceof BaseBrowserlessTest base) {
+            base.initVaadinEnvironment();
+            cleanupAction = base::cleanVaadinEnvironment;
+        } else {
+            standaloneInit(ctx.getRequiredTestClass());
+            cleanupAction = this::standaloneCleanup;
+        }
+    }
+
+    protected void doCleanup() {
+        if (cleanupAction != null) {
+            cleanupAction.run();
+            cleanupAction = null;
+        }
+    }
+
+    private void standaloneCleanup() {
+        if (signalsTestEnvironment != null) {
+            signalsTestEnvironment.unregister();
+            signalsTestEnvironment = null;
+        }
+        MockVaadin.tearDown();
+    }
+
+    private void standaloneInit(Class<?> testClass) {
+        // Scan for additional component testers
+        Set<String> testerPkgs = new HashSet<>(componentTesterPackages);
+        ComponentTesterPackages testerAnnotation = testClass
+                .getAnnotation(ComponentTesterPackages.class);
+        if (testerAnnotation != null) {
+            testerPkgs.addAll(Arrays.asList(testerAnnotation.value()));
+        }
+        for (String pkg : testerPkgs) {
+            if (BaseBrowserlessTest.scanned.add(pkg)) {
+                BaseBrowserlessTest.testers
+                        .putAll(BaseBrowserlessTest.scanForTesters(pkg));
+            }
+        }
+
+        // Resolve view packages from annotation and programmatic config
+        Set<String> packages = new HashSet<>(viewPackages);
+        ViewPackages vpAnnotation = testClass.getAnnotation(ViewPackages.class);
+        if (vpAnnotation != null) {
+            Stream.of(vpAnnotation.classes()).map(Class::getPackageName)
+                    .forEach(packages::add);
+            packages.addAll(Arrays.asList(vpAnnotation.packages()));
+            // If annotation is present but empty, default to test class package
+            if (packages.isEmpty()) {
+                packages.add(testClass.getPackageName());
+            }
+        }
+        packages.removeIf(Objects::isNull);
+
+        Routes routes = BaseBrowserlessTest.discoverRoutes(packages);
+        MockVaadin.setup(routes, MockedUI::new, services);
+        signalsTestEnvironment = TestSignalEnvironment.register();
+    }
+
+    // --- Testing DSL ---
+
+    /**
+     * Navigates to the given view class.
+     *
+     * @param target
+     *            view class to navigate to
+     * @param <T>
+     *            view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(Class<T> target) {
+        getUI().navigate(target);
+        return validateNavigationTarget(target);
+    }
+
+    /**
+     * Navigates to the given view class with a URL parameter.
+     *
+     * @param target
+     *            view class to navigate to
+     * @param parameter
+     *            URL parameter
+     * @param <T>
+     *            view type
+     * @param <C>
+     *            parameter type
+     * @return the instantiated view
+     */
+    public <C, T extends Component & HasUrlParameter<C>> T navigate(
+            Class<T> target, C parameter) {
+        getUI().navigate(target, parameter);
+        return validateNavigationTarget(target);
+    }
+
+    /**
+     * Navigates to the given view class with route parameters.
+     *
+     * @param target
+     *            view class to navigate to
+     * @param parameters
+     *            route parameters
+     * @param <T>
+     *            view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(Class<T> target,
+            Map<String, String> parameters) {
+        getUI().navigate(target, new RouteParameters(parameters));
+        return validateNavigationTarget(target);
+    }
+
+    /**
+     * Navigates to the given location string and verifies the expected target.
+     *
+     * @param location
+     *            navigation location string
+     * @param expectedTarget
+     *            expected view class
+     * @param <T>
+     *            view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(String location,
+            Class<T> expectedTarget) {
+        getUI().navigate(location);
+        return validateNavigationTarget(expectedTarget);
+    }
+
+    /**
+     * Gets a query object for finding components of the given type in the UI.
+     *
+     * @param type
+     *            component type to search for
+     * @param <T>
+     *            component type
+     * @return a component query
+     */
+    public <T extends Component> ComponentQuery<T> $(Class<T> type) {
+        getUI();
+        return BaseBrowserlessTest.internalQuery(type);
+    }
+
+    /**
+     * Gets a query object for finding components nested inside a given
+     * component.
+     *
+     * @param type
+     *            component type to search for
+     * @param fromThis
+     *            starting component for search
+     * @param <T>
+     *            component type
+     * @return a component query scoped to the given component
+     */
+    public <T extends Component> ComponentQuery<T> $(Class<T> type,
+            Component fromThis) {
+        getUI();
+        return new ComponentQuery<>(type).from(fromThis);
+    }
+
+    /**
+     * Gets a query object for finding components inside the current view.
+     *
+     * @param type
+     *            component type to search for
+     * @param <T>
+     *            component type
+     * @return a component query scoped to the current view
+     */
+    public <T extends Component> ComponentQuery<T> $view(Class<T> type) {
+        Component viewComponent = getCurrentView().getElement().getComponent()
+                .orElseThrow(() -> new AssertionError(
+                        "Cannot get Component instance for current view"));
+        return new ComponentQuery<>(type).from(viewComponent);
+    }
+
+    /**
+     * Gets the current view instance shown in the UI.
+     *
+     * @return the current view
+     */
+    public HasElement getCurrentView() {
+        return getUI().getInternals().getActiveRouterTargetsChain().get(0);
+    }
+
+    /**
+     * Simulates a server round-trip, flushing pending component changes.
+     */
+    public void roundTrip() {
+        BaseBrowserlessTest.roundTrip();
+    }
+
+    /**
+     * Processes all pending Signals tasks with a default max wait of 100
+     * milliseconds.
+     *
+     * @return {@code true} if any pending Signals tasks were processed
+     */
+    public boolean runPendingSignalsTasks() {
+        return runPendingSignalsTasks(100, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Processes all pending Signals tasks, waiting up to the specified timeout
+     * for tasks to arrive.
+     *
+     * @param maxWaitTime
+     *            maximum time to wait for the first task
+     * @param unit
+     *            time unit for the timeout
+     * @return {@code true} if any pending Signals tasks were processed
+     */
+    public boolean runPendingSignalsTasks(long maxWaitTime, TimeUnit unit) {
+        if (signalsTestEnvironment != null) {
+            return signalsTestEnvironment.runPendingTasks(maxWaitTime, unit);
+        }
+        return false;
+    }
+
+    /**
+     * Simulates a keyboard shortcut performed on the browser.
+     *
+     * @param key
+     *            primary key of the shortcut
+     * @param modifiers
+     *            key modifiers
+     */
+    public void fireShortcut(Key key, KeyModifier... modifiers) {
+        UI ui = getUI();
+        if (ui.hasModalComponent()) {
+            ShortcutsKt._fireShortcut(
+                    ui.getInternals().getActiveModalComponent(), key,
+                    modifiers);
+        } else {
+            ShortcutsKt.fireShortcut(key, modifiers);
+        }
+    }
+
+    private UI getUI() {
+        UI ui = UI.getCurrent();
+        if (ui == null) {
+            throw new BrowserlessTestSetupException(
+                    "Test Vaadin environment is not initialized. "
+                            + "Make sure BrowserlessExtension is registered and active "
+                            + "before calling test DSL methods.");
+        }
+        return ui;
+    }
+
+    private <T extends Component> T validateNavigationTarget(Class<T> target) {
+        HasElement currentView = getCurrentView();
+        if (!target.isAssignableFrom(currentView.getClass())) {
+            if (currentView instanceof MockInternalSeverError) {
+                System.err.println(
+                        currentView.getElement().getProperty("stackTrace"));
+            }
+            throw new IllegalArgumentException(
+                    "Navigation resulted in unexpected class "
+                            + currentView.getClass().getName() + " instead of "
+                            + target.getName());
+        }
+        return target.cast(currentView);
+    }
+}

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessClassExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessClassExtension.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension for browserless Vaadin testing with per-class lifecycle.
+ *
+ * <p>
+ * The Vaadin environment is initialized once before all tests in the class and
+ * torn down after all tests. Use as a static field with
+ * {@code @RegisterExtension}:
+ *
+ * <pre>
+ * {@code
+ * class MyStatefulTest {
+ *     &#64;RegisterExtension
+ *     static BrowserlessClassExtension ext = new BrowserlessClassExtension()
+ *             .withViewPackages(MyView.class);
+ *
+ *     &#64;BeforeAll
+ *     static void setup() {
+ *         ext.navigate(MyView.class);
+ *     }
+ *
+ *     &#64;Test
+ *     void testA() {
+ *         /* same session *&#47; }
+ *
+ *     &#64;Test
+ *     void testB() {
+ *         /* same session *&#47; }
+ * }
+ * }
+ * </pre>
+ *
+ * <p>
+ * For a fresh environment per test method, use {@link BrowserlessExtension}
+ * instead.
+ *
+ * @see BrowserlessExtension
+ * @see BrowserlessTest
+ * @see ViewPackages
+ */
+public class BrowserlessClassExtension extends AbstractBrowserlessExtension
+        implements BeforeAllCallback, AfterAllCallback {
+
+    /**
+     * Creates a new extension with per-class lifecycle.
+     */
+    public BrowserlessClassExtension() {
+    }
+
+    /**
+     * Adds packages to scan for {@code @Route}-annotated views, derived from
+     * the given classes' packages.
+     *
+     * @param classes
+     *            classes whose packages should be scanned
+     * @return this extension instance
+     */
+    public BrowserlessClassExtension withViewPackages(Class<?>... classes) {
+        addViewPackages(classes);
+        return this;
+    }
+
+    /**
+     * Adds packages to scan for {@code @Route}-annotated views.
+     *
+     * @param packages
+     *            package names to scan
+     * @return this extension instance
+     */
+    public BrowserlessClassExtension withViewPackages(String... packages) {
+        addViewPackages(packages);
+        return this;
+    }
+
+    /**
+     * Adds Vaadin {@link com.vaadin.flow.di.Lookup} service implementation
+     * classes.
+     *
+     * @param serviceClasses
+     *            service implementation classes to register
+     * @return this extension instance
+     */
+    public BrowserlessClassExtension withServices(Class<?>... serviceClasses) {
+        addServices(serviceClasses);
+        return this;
+    }
+
+    /**
+     * Adds extra packages to scan for {@link ComponentTester} implementations.
+     *
+     * @param packages
+     *            package names to scan for testers
+     * @return this extension instance
+     */
+    public BrowserlessClassExtension withComponentTesterPackages(
+            String... packages) {
+        addComponentTesterPackages(packages);
+        return this;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext ctx) {
+        doInit(ctx.getTestInstance().orElse(null), ctx);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext ctx) {
+        doCleanup();
+    }
+}

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessExtension.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension for browserless Vaadin testing with per-method lifecycle.
+ *
+ * <p>
+ * A fresh Vaadin environment is initialized before each test method and torn
+ * down after. Use as an instance field with {@code @RegisterExtension}:
+ *
+ * <pre>
+ * {@code
+ * &#64;ViewPackages(classes = MyView.class)
+ * class MyTest {
+ *     &#64;RegisterExtension
+ *     BrowserlessExtension ext = new BrowserlessExtension()
+ *             .withServices(MyService.class);
+ *
+ *     &#64;Test
+ *     void test() {
+ *         MyView view = ext.navigate(MyView.class);
+ *         ext.test(view.getButton()).click();
+ *     }
+ * }
+ * }
+ * </pre>
+ *
+ * <p>
+ * For a shared Vaadin environment across all tests in a class, use
+ * {@link BrowserlessClassExtension} instead.
+ *
+ * @see BrowserlessClassExtension
+ * @see BrowserlessTest
+ * @see ViewPackages
+ */
+public class BrowserlessExtension extends AbstractBrowserlessExtension
+        implements BeforeEachCallback, AfterEachCallback {
+
+    /**
+     * Creates a new extension with per-method lifecycle.
+     */
+    public BrowserlessExtension() {
+    }
+
+    /**
+     * Adds packages to scan for {@code @Route}-annotated views, derived from
+     * the given classes' packages.
+     *
+     * @param classes
+     *            classes whose packages should be scanned
+     * @return this extension instance
+     */
+    public BrowserlessExtension withViewPackages(Class<?>... classes) {
+        addViewPackages(classes);
+        return this;
+    }
+
+    /**
+     * Adds packages to scan for {@code @Route}-annotated views.
+     *
+     * @param packages
+     *            package names to scan
+     * @return this extension instance
+     */
+    public BrowserlessExtension withViewPackages(String... packages) {
+        addViewPackages(packages);
+        return this;
+    }
+
+    /**
+     * Adds Vaadin {@link com.vaadin.flow.di.Lookup} service implementation
+     * classes.
+     *
+     * @param serviceClasses
+     *            service implementation classes to register
+     * @return this extension instance
+     */
+    public BrowserlessExtension withServices(Class<?>... serviceClasses) {
+        addServices(serviceClasses);
+        return this;
+    }
+
+    /**
+     * Adds extra packages to scan for {@link ComponentTester} implementations.
+     *
+     * @param packages
+     *            package names to scan for testers
+     * @return this extension instance
+     */
+    public BrowserlessExtension withComponentTesterPackages(
+            String... packages) {
+        addComponentTesterPackages(packages);
+        return this;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext ctx) {
+        doInit(ctx.getTestInstance().orElse(null), ctx);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext ctx) {
+        doCleanup();
+    }
+}

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessTest.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessTest.java
@@ -15,16 +15,15 @@
  */
 package com.vaadin.browserless;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Base JUnit 6 class for browserless tests.
  *
- * The class automatically scans classpath for routes and error views.
- * Subclasses should typically restrict classpath scanning to a specific
- * packages for faster bootstrap, by using {@link ViewPackages} annotation. If
- * the annotation is not present a full classpath scan is performed
+ * The class automatically scans the classpath for routes and error views.
+ * Subclasses should typically restrict classpath scanning to specific packages
+ * for faster bootstrap by using the {@link ViewPackages} annotation. If the
+ * annotation is not present, a full classpath scan is performed.
  *
  * <pre>
  * {@code
@@ -44,52 +43,43 @@ import org.junit.jupiter.api.BeforeEach;
  * }
  * </pre>
  *
- * Set up of Vaadin environment is performed before each test by {@link
- * #initVaadinEnvironment()} method, and will be executed before
- * {@code @BeforeEach} methods defined in subclasses. At the same way, cleanup
- * tasks operated by {@link #cleanVaadinEnvironment()} are executed after each
- * test, and after all {@code @AfterEach} annotated methods in subclasses.
+ * The Vaadin environment lifecycle is managed by {@link
+ * BrowserlessTestExtension}, which calls {@link #initVaadinEnvironment()}
+ * before each test and {@link #cleanVaadinEnvironment()} after each test via
+ * virtual dispatch. When the test class is annotated with
+ * {@code @TestInstance(TestInstance.Lifecycle.PER_CLASS)}, the environment is
+ * shared across all tests in the class (initialized once in {@code @BeforeAll},
+ * torn down in {@code @AfterAll}).
  *
- * Usually, it is not necessary to override {@link #initVaadinEnvironment()} or
- * {@link #cleanVaadinEnvironment()} methods, but if this is done it is
- * mandatory to add the {@code @BeforeEach} and {@code @AfterEach} annotations
- * in the subclass, in order to have hooks handled by testing framework.
- *
- * A use case for overriding {@link #initVaadinEnvironment()} is to provide
- * custom Flow service implementations supported by {@link
- * com.vaadin.flow.di.Lookup} SPI. Implementations can be provided overriding
- * {@link #initVaadinEnvironment()} and passing to super implementation the
- * service classes that should be initialized during setup.
+ * <p>
+ * To provide custom Flow service implementations via the {@link
+ * com.vaadin.flow.di.Lookup} SPI, override {@link #lookupServices()}:
  *
  * <pre>
  * {@code
- * &#64;BeforeEach
  * &#64;Override
- * void initVaadinEnvironment() {
- *     super.initVaadinEnvironment(CustomInstantiatorFactory.class);
+ * protected Set<Class<?>> lookupServices() {
+ *     return Set.of(CustomInstantiatorFactory.class);
  * }
  * }
  * </pre>
- * <p/>
- * To get a graphical ascii representation of the UI tree on failure add the
- * annotation {@code @ExtendWith(TreeOnFailureExtension.class)} to the test
- * class.
+ *
+ * <p>
+ * <strong>Note:</strong> Subclasses that override {@code initVaadinEnvironment}
+ * must NOT add {@code @BeforeEach} — the extension handles invocation via
+ * virtual dispatch.
+ *
+ * <p>
+ * To get a graphical ASCII representation of the UI tree on failure, add
+ * {@code @ExtendWith(TreeOnFailureExtension.class)} to the test class.
  *
  * @see ViewPackages
+ *
+ * @see BrowserlessExtension
  */
+@ExtendWith(BrowserlessTestExtension.class)
 public abstract class BrowserlessTest extends BaseBrowserlessTest
         implements TesterWrappers {
-
-    @BeforeEach
-    protected void initVaadinEnvironment() {
-        super.initVaadinEnvironment();
-    }
-
-    @AfterEach
-    @Override
-    protected void cleanVaadinEnvironment() {
-        super.cleanVaadinEnvironment();
-    }
 
     @Override
     protected final String testingEngine() {

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessTestExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessTestExtension.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Package-private extension used exclusively by {@code @ExtendWith} on
+ * {@link BrowserlessTest}. Auto-detects lifecycle from
+ * {@code @TestInstance(PER_CLASS)} on the test class.
+ */
+class BrowserlessTestExtension extends AbstractBrowserlessExtension
+        implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback,
+        AfterEachCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext ctx) {
+        if (isPerClass(ctx)) {
+            doInit(ctx.getTestInstance().orElse(null), ctx);
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext ctx) {
+        if (isPerClass(ctx)) {
+            doCleanup();
+        }
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext ctx) {
+        if (!isPerClass(ctx)) {
+            doInit(ctx.getTestInstance().orElse(null), ctx);
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext ctx) {
+        if (!isPerClass(ctx)) {
+            doCleanup();
+        }
+    }
+
+    private boolean isPerClass(ExtensionContext ctx) {
+        return ctx.getTestInstanceLifecycle()
+                .filter(l -> l == TestInstance.Lifecycle.PER_CLASS).isPresent();
+    }
+}

--- a/junit6/src/test/java/com/example/multiuser/ExternalNavigationView.java
+++ b/junit6/src/test/java/com/example/multiuser/ExternalNavigationView.java
@@ -29,33 +29,26 @@ import com.vaadin.flow.router.Route;
 public class ExternalNavigationView extends VerticalLayout {
 
     public ExternalNavigationView() {
-        Button setLocation = new Button("Go to Vaadin",
-                e -> UI.getCurrent().getPage()
-                        .setLocation("https://vaadin.com/"));
+        Button setLocation = new Button("Go to Vaadin", e -> UI.getCurrent()
+                .getPage().setLocation("https://vaadin.com/"));
 
-        Button openNew = new Button("Pay",
-                e -> UI.getCurrent().getPage()
-                        .open("https://payment.example.com/checkout?id=123"));
+        Button openNew = new Button("Pay", e -> UI.getCurrent().getPage()
+                .open("https://payment.example.com/checkout?id=123"));
 
-        Button openNamedWindow = new Button("Open Help",
-                e -> UI.getCurrent().getPage()
-                        .open("https://help.example.com/", "helpWindow"));
+        Button openNamedWindow = new Button("Open Help", e -> UI.getCurrent()
+                .getPage().open("https://help.example.com/", "helpWindow"));
 
-        Button openParent = new Button("Open Parent",
-                e -> UI.getCurrent().getPage()
-                        .open("https://parent.example.com/", "_parent"));
+        Button openParent = new Button("Open Parent", e -> UI.getCurrent()
+                .getPage().open("https://parent.example.com/", "_parent"));
 
-        Button openTop = new Button("Open Top",
-                e -> UI.getCurrent().getPage()
-                        .open("https://top.example.com/", "_top"));
+        Button openTop = new Button("Open Top", e -> UI.getCurrent().getPage()
+                .open("https://top.example.com/", "_top"));
 
-        Button openBlank1 = new Button("Open Tab 1",
-                e -> UI.getCurrent().getPage()
-                        .open("https://tab1.example.com/"));
+        Button openBlank1 = new Button("Open Tab 1", e -> UI.getCurrent()
+                .getPage().open("https://tab1.example.com/"));
 
-        Button openBlank2 = new Button("Open Tab 2",
-                e -> UI.getCurrent().getPage()
-                        .open("https://tab2.example.com/"));
+        Button openBlank2 = new Button("Open Tab 2", e -> UI.getCurrent()
+                .getPage().open("https://tab2.example.com/"));
 
         add(setLocation, openNew, openNamedWindow, openParent, openTop,
                 openBlank1, openBlank2);

--- a/junit6/src/test/java/com/example/multiuser/ExternalNavigationView.java
+++ b/junit6/src/test/java/com/example/multiuser/ExternalNavigationView.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.example.multiuser;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A view with buttons that trigger external navigation via
+ * {@link com.vaadin.flow.component.page.Page#setLocation(String)} and
+ * {@link com.vaadin.flow.component.page.Page#open(String)}.
+ */
+@Route("external-nav")
+public class ExternalNavigationView extends VerticalLayout {
+
+    public ExternalNavigationView() {
+        Button setLocation = new Button("Go to Vaadin",
+                e -> UI.getCurrent().getPage()
+                        .setLocation("https://vaadin.com/"));
+
+        Button openNew = new Button("Pay",
+                e -> UI.getCurrent().getPage()
+                        .open("https://payment.example.com/checkout?id=123"));
+
+        Button openNamedWindow = new Button("Open Help",
+                e -> UI.getCurrent().getPage()
+                        .open("https://help.example.com/", "helpWindow"));
+
+        Button openParent = new Button("Open Parent",
+                e -> UI.getCurrent().getPage()
+                        .open("https://parent.example.com/", "_parent"));
+
+        Button openTop = new Button("Open Top",
+                e -> UI.getCurrent().getPage()
+                        .open("https://top.example.com/", "_top"));
+
+        Button openBlank1 = new Button("Open Tab 1",
+                e -> UI.getCurrent().getPage()
+                        .open("https://tab1.example.com/"));
+
+        Button openBlank2 = new Button("Open Tab 2",
+                e -> UI.getCurrent().getPage()
+                        .open("https://tab2.example.com/"));
+
+        add(setLocation, openNew, openNamedWindow, openParent, openTop,
+                openBlank1, openBlank2);
+    }
+}

--- a/junit6/src/test/java/com/example/multiuser/SharedCounterView.java
+++ b/junit6/src/test/java/com/example/multiuser/SharedCounterView.java
@@ -23,16 +23,15 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
 /**
- * A view with a shared static counter, used for testing multi-user
- * scenarios where application-level state is shared across sessions.
+ * A view with a shared static counter, used for testing multi-user scenarios
+ * where application-level state is shared across sessions.
  */
 @Route("shared-counter")
 public class SharedCounterView extends VerticalLayout {
 
     public static final AtomicInteger counter = new AtomicInteger(0);
 
-    private final Paragraph display = new Paragraph(
-            "Count: " + counter.get());
+    private final Paragraph display = new Paragraph("Count: " + counter.get());
 
     public SharedCounterView() {
         Button increment = new Button("Increment", e -> {

--- a/junit6/src/test/java/com/example/multiuser/SharedCounterView.java
+++ b/junit6/src/test/java/com/example/multiuser/SharedCounterView.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.example.multiuser;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A view with a shared static counter, used for testing multi-user
+ * scenarios where application-level state is shared across sessions.
+ */
+@Route("shared-counter")
+public class SharedCounterView extends VerticalLayout {
+
+    public static final AtomicInteger counter = new AtomicInteger(0);
+
+    private final Paragraph display = new Paragraph(
+            "Count: " + counter.get());
+
+    public SharedCounterView() {
+        Button increment = new Button("Increment", e -> {
+            int value = counter.incrementAndGet();
+            display.setText("Count: " + value);
+        });
+
+        Button refresh = new Button("Refresh",
+                e -> display.setText("Count: " + counter.get()));
+
+        add(display, increment, refresh);
+    }
+}

--- a/junit6/src/test/java/com/example/multiuser/SimpleView.java
+++ b/junit6/src/test/java/com/example/multiuser/SimpleView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.example.multiuser;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("simple")
+public class SimpleView extends VerticalLayout {
+    public SimpleView() {
+        add(new Span("Simple view"));
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessBaseClassTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessBaseClassTest.java
@@ -78,6 +78,9 @@ class BrowserlessBaseClassTest {
             allViews.add(SingleParam.class);
             allViews.add(TemplatedParam.class);
             allViews.add(AutoLayoutView.class);
+            allViews.add(com.example.multiuser.SharedCounterView.class);
+            allViews.add(com.example.multiuser.ExternalNavigationView.class);
+            allViews.add(com.example.multiuser.SimpleView.class);
             Assertions.assertEquals(allViews.size(), routes.size());
             Assertions.assertTrue(routes.containsAll(allViews));
         }

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessExtensionPerClassTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessExtensionPerClassTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Verifies that {@link BrowserlessClassExtension} creates a single Vaadin
+ * environment shared across all test methods (same {@link UI} instance).
+ */
+@ViewPackages(classes = WelcomeView.class)
+class BrowserlessExtensionPerClassTest {
+
+    @RegisterExtension
+    static BrowserlessClassExtension ext = new BrowserlessClassExtension();
+
+    private static UI sharedUI;
+
+    @BeforeAll
+    static void captureUI() {
+        sharedUI = UI.getCurrent();
+        Assertions.assertNotNull(sharedUI,
+                "Expecting current UI to be available after per-class init");
+        ext.navigate(WelcomeView.class);
+    }
+
+    @Test
+    void firstTest_sameUIInstance() {
+        Assertions.assertSame(sharedUI, UI.getCurrent(),
+                "Per-class lifecycle must reuse the same UI across tests");
+        Assertions.assertInstanceOf(WelcomeView.class, ext.getCurrentView());
+    }
+
+    @Test
+    void secondTest_sameUIInstance() {
+        Assertions.assertSame(sharedUI, UI.getCurrent(),
+                "Per-class lifecycle must reuse the same UI across tests");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessExtensionPerMethodTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessExtensionPerMethodTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Verifies that {@link BrowserlessExtension} creates a fresh Vaadin environment
+ * for each test method (different {@link UI} instances).
+ */
+@ViewPackages(classes = WelcomeView.class)
+class BrowserlessExtensionPerMethodTest {
+
+    @RegisterExtension
+    BrowserlessExtension ext = new BrowserlessExtension();
+
+    private static final Set<UI> seenUIs = Collections
+            .synchronizedSet(new HashSet<>());
+
+    @Test
+    void firstTest_recordsUI() {
+        UI ui = UI.getCurrent();
+        Assertions.assertNotNull(ui, "Expecting current UI to be available");
+        ext.navigate(WelcomeView.class);
+        Assertions.assertInstanceOf(WelcomeView.class, ext.getCurrentView());
+        seenUIs.add(ui);
+    }
+
+    @Test
+    void secondTest_recordsUI() {
+        UI ui = UI.getCurrent();
+        Assertions.assertNotNull(ui, "Expecting current UI to be available");
+        seenUIs.add(ui);
+    }
+
+    @AfterAll
+    static void assertDistinctUIInstances() {
+        Assertions.assertEquals(2, seenUIs.size(),
+                "Per-method lifecycle must create a distinct UI for each test");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestPerClassLifecycleTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestPerClassLifecycleTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Verifies that {@link BrowserlessTest} combined with
+ * {@code @TestInstance(PER_CLASS)} reuses the same Vaadin environment across
+ * all test methods in the class.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ViewPackages(classes = WelcomeView.class)
+class BrowserlessTestPerClassLifecycleTest extends BrowserlessTest {
+
+    private UI sharedUI;
+
+    @BeforeAll
+    void captureUI() {
+        sharedUI = UI.getCurrent();
+        Assertions.assertNotNull(sharedUI,
+                "Expecting current UI to be available after PER_CLASS init");
+        navigate(WelcomeView.class);
+    }
+
+    @Test
+    void firstTest_sameUIInstance() {
+        Assertions.assertSame(sharedUI, UI.getCurrent(),
+                "PER_CLASS lifecycle must reuse the same UI across tests");
+        Assertions.assertInstanceOf(WelcomeView.class, getCurrentView());
+    }
+
+    @Test
+    void secondTest_sameUIInstance() {
+        Assertions.assertSame(sharedUI, UI.getCurrent(),
+                "PER_CLASS lifecycle must reuse the same UI across tests");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
@@ -70,8 +70,8 @@ class BrowserlessUIContextClosedTest {
         window.close();
 
         Assertions.assertThrows(IllegalStateException.class,
-                () -> window.$(Div.class),
-                "$() on a closed context should throw");
+                () -> window.find(Div.class),
+                "find() on a closed context should throw");
     }
 
     @Test

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.multiuser.SimpleView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.html.Div;
+
+/**
+ * Tests that calling methods on a closed {@link BrowserlessUIContext}
+ * throws {@link IllegalStateException}.
+ */
+class BrowserlessUIContextClosedTest {
+
+    private BrowserlessApplicationContext<Void> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews(
+                SimpleView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void activate_afterClose_throws() {
+        var window = app.newUser().newWindow();
+        window.close();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                window::activate,
+                "activate() on a closed context should throw");
+    }
+
+    @Test
+    void navigate_afterClose_throws() {
+        var window = app.newUser().newWindow();
+        window.close();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> window.navigate(SimpleView.class),
+                "navigate() on a closed context should throw");
+    }
+
+    @Test
+    void query_afterClose_throws() {
+        var window = app.newUser().newWindow();
+        window.close();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> window.$(Div.class),
+                "$() on a closed context should throw");
+    }
+
+    @Test
+    void close_isIdempotent() {
+        var window = app.newUser().newWindow();
+        window.close();
+        // Second close should not throw
+        Assertions.assertDoesNotThrow(window::close);
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
@@ -25,8 +25,8 @@ import com.vaadin.browserless.internal.Routes;
 import com.vaadin.flow.component.html.Div;
 
 /**
- * Tests that calling methods on a closed {@link BrowserlessUIContext}
- * throws {@link IllegalStateException}.
+ * Tests that calling methods on a closed {@link BrowserlessUIContext} throws
+ * {@link IllegalStateException}.
  */
 class BrowserlessUIContextClosedTest {
 
@@ -34,8 +34,8 @@ class BrowserlessUIContextClosedTest {
 
     @BeforeEach
     void setUp() {
-        Routes routes = new Routes().autoDiscoverViews(
-                SimpleView.class.getPackageName());
+        Routes routes = new Routes()
+                .autoDiscoverViews(SimpleView.class.getPackageName());
         app = BrowserlessApplicationContext.create(routes);
     }
 
@@ -49,8 +49,7 @@ class BrowserlessUIContextClosedTest {
         var window = app.newUser().newWindow();
         window.close();
 
-        Assertions.assertThrows(IllegalStateException.class,
-                window::activate,
+        Assertions.assertThrows(IllegalStateException.class, window::activate,
                 "activate() on a closed context should throw");
     }
 

--- a/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
@@ -73,8 +73,7 @@ class ExternalNavigationTest {
         ui.test(ui.find(Button.class).withText("Pay").single()).click();
 
         Assertions.assertNull(ui.getExternalNavigationURL());
-        Assertions.assertEquals(
-                "https://payment.example.com/checkout?id=123",
+        Assertions.assertEquals("https://payment.example.com/checkout?id=123",
                 ui.getExternalNavigationURL("_blank"));
     }
 
@@ -118,7 +117,8 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.find(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single())
+                .click();
         ui.test(ui.find(Button.class).withText("Open Parent").single()).click();
 
         // _parent is normalized to _self, so it overwrites the setLocation
@@ -131,7 +131,8 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.find(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single())
+                .click();
 
         // Calling multiple times returns the same value
         Assertions.assertEquals("https://vaadin.com/",
@@ -149,10 +150,8 @@ class ExternalNavigationTest {
         ui.test(ui.find(Button.class).withText("Open Tab 2").single()).click();
 
         Map<String, List<String>> opened = ui.getOpenedWindows();
-        Assertions.assertEquals(
-                List.of("https://tab1.example.com/",
-                        "https://tab2.example.com/"),
-                opened.get("_blank"));
+        Assertions.assertEquals(List.of("https://tab1.example.com/",
+                "https://tab2.example.com/"), opened.get("_blank"));
     }
 
     @Test
@@ -160,7 +159,8 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.find(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single())
+                .click();
         ui.test(ui.find(Button.class).withText("Open Parent").single()).click();
         ui.test(ui.find(Button.class).withText("Open Top").single()).click();
 
@@ -180,8 +180,7 @@ class ExternalNavigationTest {
                 "helpWindow");
 
         Map<String, List<String>> opened = ui.getOpenedWindows();
-        Assertions.assertEquals(
-                List.of("https://help.example.com/updated"),
+        Assertions.assertEquals(List.of("https://help.example.com/updated"),
                 opened.get("helpWindow"));
     }
 
@@ -190,7 +189,8 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.find(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single())
+                .click();
         ui.test(ui.find(Button.class).withText("Open Help").single()).click();
         ui.test(ui.find(Button.class).withText("Open Tab 1").single()).click();
         ui.test(ui.find(Button.class).withText("Open Tab 2").single()).click();
@@ -202,12 +202,9 @@ class ExternalNavigationTest {
         // openedWindows contains only non-self entries
         Map<String, List<String>> opened = ui.getOpenedWindows();
         Assertions.assertEquals(2, opened.size());
-        Assertions.assertEquals(
-                List.of("https://help.example.com/"),
+        Assertions.assertEquals(List.of("https://help.example.com/"),
                 opened.get("helpWindow"));
-        Assertions.assertEquals(
-                List.of("https://tab1.example.com/",
-                        "https://tab2.example.com/"),
-                opened.get("_blank"));
+        Assertions.assertEquals(List.of("https://tab1.example.com/",
+                "https://tab2.example.com/"), opened.get("_blank"));
     }
 }

--- a/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.List;
+import java.util.Map;
+
+import com.example.multiuser.ExternalNavigationView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.button.Button;
+
+/**
+ * Tests capturing external navigation URLs triggered by
+ * {@code Page.setLocation()} and {@code Page.open()}.
+ */
+class ExternalNavigationTest {
+
+    private BrowserlessApplicationContext<Void> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews(
+                ExternalNavigationView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void getExternalNavigationURL_capturesSetLocation() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        // No navigation yet
+        Assertions.assertNull(ui.getExternalNavigationURL());
+
+        // Click Page.setLocation button
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single())
+                .click();
+
+        Assertions.assertEquals("https://vaadin.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_capturesPageOpen() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        // Page.open() uses _blank, so getExternalNavigationURL() (which
+        // returns _self navigations) should remain null
+        ui.test(ui.$(Button.class).withText("Pay").single()).click();
+
+        Assertions.assertNull(ui.getExternalNavigationURL());
+        Assertions.assertEquals(
+                "https://payment.example.com/checkout?id=123",
+                ui.getExternalNavigationURL("_blank"));
+    }
+
+    @Test
+    void getExternalNavigationURL_namedWindow() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
+
+        Assertions.assertEquals("https://help.example.com/",
+                ui.getExternalNavigationURL("helpWindow"));
+        // Should not appear as a _self navigation
+        Assertions.assertNull(ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_parentNormalizesToSelf() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
+
+        Assertions.assertEquals("https://parent.example.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_topNormalizesToSelf() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Open Top").single()).click();
+
+        Assertions.assertEquals("https://top.example.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_setLocationOverwritesPrevious() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
+
+        // _parent is normalized to _self, so it overwrites the setLocation
+        Assertions.assertEquals("https://parent.example.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_isNonDestructive() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+
+        // Calling multiple times returns the same value
+        Assertions.assertEquals("https://vaadin.com/",
+                ui.getExternalNavigationURL());
+        Assertions.assertEquals("https://vaadin.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getOpenedWindows_blankAccumulatesAllCalls() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Open Tab 1").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Tab 2").single()).click();
+
+        Map<String, List<String>> opened = ui.getOpenedWindows();
+        Assertions.assertEquals(
+                List.of("https://tab1.example.com/",
+                        "https://tab2.example.com/"),
+                opened.get("_blank"));
+    }
+
+    @Test
+    void getOpenedWindows_excludesSelfNavigations() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Top").single()).click();
+
+        // All three are _self navigations, so openedWindows should be empty
+        Assertions.assertTrue(ui.getOpenedWindows().isEmpty());
+    }
+
+    @Test
+    void getOpenedWindows_namedWindowLastUrlWins() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        // Open two different URLs in the same named window
+        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
+        // Navigate the same named window to a different URL via setLocation
+        ui.getUI().getPage().open("https://help.example.com/updated",
+                "helpWindow");
+
+        Map<String, List<String>> opened = ui.getOpenedWindows();
+        Assertions.assertEquals(
+                List.of("https://help.example.com/updated"),
+                opened.get("helpWindow"));
+    }
+
+    @Test
+    void getOpenedWindows_mixedWindowTypes() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Tab 1").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Tab 2").single()).click();
+
+        // _self navigation captured separately
+        Assertions.assertEquals("https://vaadin.com/",
+                ui.getExternalNavigationURL());
+
+        // openedWindows contains only non-self entries
+        Map<String, List<String>> opened = ui.getOpenedWindows();
+        Assertions.assertEquals(2, opened.size());
+        Assertions.assertEquals(
+                List.of("https://help.example.com/"),
+                opened.get("helpWindow"));
+        Assertions.assertEquals(
+                List.of("https://tab1.example.com/",
+                        "https://tab2.example.com/"),
+                opened.get("_blank"));
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
@@ -56,7 +56,7 @@ class ExternalNavigationTest {
         Assertions.assertNull(ui.getExternalNavigationURL());
 
         // Click Page.setLocation button
-        ui.test(ui.$(Button.class).withText("Go to Vaadin").single())
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single())
                 .click();
 
         Assertions.assertEquals("https://vaadin.com/",
@@ -70,7 +70,7 @@ class ExternalNavigationTest {
 
         // Page.open() uses _blank, so getExternalNavigationURL() (which
         // returns _self navigations) should remain null
-        ui.test(ui.$(Button.class).withText("Pay").single()).click();
+        ui.test(ui.find(Button.class).withText("Pay").single()).click();
 
         Assertions.assertNull(ui.getExternalNavigationURL());
         Assertions.assertEquals(
@@ -83,7 +83,7 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Help").single()).click();
 
         Assertions.assertEquals("https://help.example.com/",
                 ui.getExternalNavigationURL("helpWindow"));
@@ -96,7 +96,7 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Parent").single()).click();
 
         Assertions.assertEquals("https://parent.example.com/",
                 ui.getExternalNavigationURL());
@@ -107,7 +107,7 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.$(Button.class).withText("Open Top").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Top").single()).click();
 
         Assertions.assertEquals("https://top.example.com/",
                 ui.getExternalNavigationURL());
@@ -118,8 +118,8 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
-        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Parent").single()).click();
 
         // _parent is normalized to _self, so it overwrites the setLocation
         Assertions.assertEquals("https://parent.example.com/",
@@ -131,7 +131,7 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single()).click();
 
         // Calling multiple times returns the same value
         Assertions.assertEquals("https://vaadin.com/",
@@ -145,8 +145,8 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.$(Button.class).withText("Open Tab 1").single()).click();
-        ui.test(ui.$(Button.class).withText("Open Tab 2").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Tab 1").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Tab 2").single()).click();
 
         Map<String, List<String>> opened = ui.getOpenedWindows();
         Assertions.assertEquals(
@@ -160,9 +160,9 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
-        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
-        ui.test(ui.$(Button.class).withText("Open Top").single()).click();
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Parent").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Top").single()).click();
 
         // All three are _self navigations, so openedWindows should be empty
         Assertions.assertTrue(ui.getOpenedWindows().isEmpty());
@@ -174,7 +174,7 @@ class ExternalNavigationTest {
         ui.navigate(ExternalNavigationView.class);
 
         // Open two different URLs in the same named window
-        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Help").single()).click();
         // Navigate the same named window to a different URL via setLocation
         ui.getUI().getPage().open("https://help.example.com/updated",
                 "helpWindow");
@@ -190,10 +190,10 @@ class ExternalNavigationTest {
         var ui = app.newUser().newWindow();
         ui.navigate(ExternalNavigationView.class);
 
-        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
-        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
-        ui.test(ui.$(Button.class).withText("Open Tab 1").single()).click();
-        ui.test(ui.$(Button.class).withText("Open Tab 2").single()).click();
+        ui.test(ui.find(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Help").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Tab 1").single()).click();
+        ui.test(ui.find(Button.class).withText("Open Tab 2").single()).click();
 
         // _self navigation captured separately
         Assertions.assertEquals("https://vaadin.com/",

--- a/junit6/src/test/java/com/vaadin/browserless/MultiTabTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiTabTest.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test;
 import com.vaadin.browserless.internal.Routes;
 
 /**
- * Tests multi-tab scenarios: one user with multiple windows
- * sharing a session but with independent UI state.
+ * Tests multi-tab scenarios: one user with multiple windows sharing a session
+ * but with independent UI state.
  */
 class MultiTabTest {
 
@@ -35,8 +35,8 @@ class MultiTabTest {
     @BeforeEach
     void setUp() {
         SharedCounterView.counter.set(0);
-        Routes routes = new Routes().autoDiscoverViews(
-                SharedCounterView.class.getPackageName());
+        Routes routes = new Routes()
+                .autoDiscoverViews(SharedCounterView.class.getPackageName());
         app = BrowserlessApplicationContext.create(routes);
     }
 
@@ -52,10 +52,8 @@ class MultiTabTest {
         var window2 = user.newWindow();
 
         // Same session
-        Assertions.assertSame(user.getSession(),
-                window1.getUI().getSession());
-        Assertions.assertSame(user.getSession(),
-                window2.getUI().getSession());
+        Assertions.assertSame(user.getSession(), window1.getUI().getSession());
+        Assertions.assertSame(user.getSession(), window2.getUI().getSession());
 
         // But different UI instances
         Assertions.assertNotSame(window1.getUI(), window2.getUI());
@@ -74,7 +72,6 @@ class MultiTabTest {
         // Each window shows its own view
         Assertions.assertInstanceOf(SharedCounterView.class,
                 window1.getCurrentView());
-        Assertions.assertInstanceOf(SimpleView.class,
-                window2.getCurrentView());
+        Assertions.assertInstanceOf(SimpleView.class, window2.getCurrentView());
     }
 }

--- a/junit6/src/test/java/com/vaadin/browserless/MultiTabTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiTabTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.multiuser.SharedCounterView;
+import com.example.multiuser.SimpleView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests multi-tab scenarios: one user with multiple windows
+ * sharing a session but with independent UI state.
+ */
+class MultiTabTest {
+
+    private BrowserlessApplicationContext<Void> app;
+
+    @BeforeEach
+    void setUp() {
+        SharedCounterView.counter.set(0);
+        Routes routes = new Routes().autoDiscoverViews(
+                SharedCounterView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void sameUser_multipleWindows_shareSession() {
+        var user = app.newUser();
+        var window1 = user.newWindow();
+        var window2 = user.newWindow();
+
+        // Same session
+        Assertions.assertSame(user.getSession(),
+                window1.getUI().getSession());
+        Assertions.assertSame(user.getSession(),
+                window2.getUI().getSession());
+
+        // But different UI instances
+        Assertions.assertNotSame(window1.getUI(), window2.getUI());
+    }
+
+    @Test
+    void sameUser_multipleWindows_independentViews() {
+        var user = app.newUser();
+        var window1 = user.newWindow();
+        var window2 = user.newWindow();
+
+        // Navigate to different views
+        window1.navigate(SharedCounterView.class);
+        window2.navigate(SimpleView.class);
+
+        // Each window shows its own view
+        Assertions.assertInstanceOf(SharedCounterView.class,
+                window1.getCurrentView());
+        Assertions.assertInstanceOf(SimpleView.class,
+                window2.getCurrentView());
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
@@ -57,18 +57,18 @@ class MultiUserTest {
         w2.navigate(SharedCounterView.class);
 
         // User1 increments counter
-        w1.test(w1.$(Button.class).withText("Increment").single()).click();
+        w1.test(w1.find(Button.class).withText("Increment").single()).click();
         Assertions.assertEquals("Count: 1",
-                w1.$(Paragraph.class).single().getText());
+                w1.find(Paragraph.class).single().getText());
 
         // User2 doesn't see the change yet (own UI state)
         Assertions.assertEquals("Count: 0",
-                w2.$(Paragraph.class).single().getText());
+                w2.find(Paragraph.class).single().getText());
 
         // User2 refreshes to see updated shared state
-        w2.test(w2.$(Button.class).withText("Refresh").single()).click();
+        w2.test(w2.find(Button.class).withText("Refresh").single()).click();
         Assertions.assertEquals("Count: 1",
-                w2.$(Paragraph.class).single().getText());
+                w2.find(Paragraph.class).single().getText());
     }
 
     @Test

--- a/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.multiuser.SharedCounterView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Paragraph;
+
+/**
+ * Tests multi-user scenarios: two independent users sharing
+ * application-level state via a static counter.
+ */
+class MultiUserTest {
+
+    private BrowserlessApplicationContext<Void> app;
+
+    @BeforeEach
+    void setUp() {
+        SharedCounterView.counter.set(0);
+        Routes routes = new Routes().autoDiscoverViews(
+                SharedCounterView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void twoUsers_shareApplicationState() {
+        var user1 = app.newUser();
+        var w1 = user1.newWindow();
+        w1.navigate(SharedCounterView.class);
+
+        var user2 = app.newUser();
+        var w2 = user2.newWindow();
+        w2.navigate(SharedCounterView.class);
+
+        // User1 increments counter
+        w1.test(w1.$(Button.class).withText("Increment").single()).click();
+        Assertions.assertEquals("Count: 1",
+                w1.$(Paragraph.class).single().getText());
+
+        // User2 doesn't see the change yet (own UI state)
+        Assertions.assertEquals("Count: 0",
+                w2.$(Paragraph.class).single().getText());
+
+        // User2 refreshes to see updated shared state
+        w2.test(w2.$(Button.class).withText("Refresh").single()).click();
+        Assertions.assertEquals("Count: 1",
+                w2.$(Paragraph.class).single().getText());
+    }
+
+    @Test
+    void users_haveIndependentSessions() {
+        var user1 = app.newUser();
+        var w1 = user1.newWindow();
+
+        var user2 = app.newUser();
+        var w2 = user2.newWindow();
+
+        Assertions.assertNotSame(user1.getSession(), user2.getSession(),
+                "Users should have independent sessions");
+        Assertions.assertNotSame(w1.getUI(), w2.getUI(),
+                "Windows should have independent UIs");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
@@ -26,8 +26,8 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Paragraph;
 
 /**
- * Tests multi-user scenarios: two independent users sharing
- * application-level state via a static counter.
+ * Tests multi-user scenarios: two independent users sharing application-level
+ * state via a static counter.
  */
 class MultiUserTest {
 
@@ -36,8 +36,8 @@ class MultiUserTest {
     @BeforeEach
     void setUp() {
         SharedCounterView.counter.set(0);
-        Routes routes = new Routes().autoDiscoverViews(
-                SharedCounterView.class.getPackageName());
+        Routes routes = new Routes()
+                .autoDiscoverViews(SharedCounterView.class.getPackageName());
         app = BrowserlessApplicationContext.create(routes);
     }
 

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -123,6 +123,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import java.util.Set;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.UIFactory;
+import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
+
+/**
+ * Factory for creating a Quarkus-integrated
+ * {@link BrowserlessApplicationContext}.
+ * <p>
+ * Configures the context with a Quarkus-aware servlet, security context
+ * handling, and lookup services.
+ *
+ * <pre>
+ * var app = QuarkusBrowserlessApplicationContext.create(routes);
+ * var admin = app.newUser(securityIdentity);
+ * var window = admin.newWindow();
+ * window.navigate(ProtectedView.class);
+ * </pre>
+ *
+ * @see BrowserlessApplicationContext
+ * @see QuarkusSecurityContextHandler
+ */
+public final class QuarkusBrowserlessApplicationContext {
+
+    private QuarkusBrowserlessApplicationContext() {
+    }
+
+    /**
+     * Creates a Quarkus-integrated application context.
+     *
+     * @param routes the discovered routes
+     * @return a new application context configured for Quarkus
+     */
+    public static BrowserlessApplicationContext<SecurityIdentity> create(
+            Routes routes) {
+        return create(routes, () -> new MockedUI());
+    }
+
+    /**
+     * Creates a Quarkus-integrated application context with a custom UI
+     * factory.
+     *
+     * @param routes    the discovered routes
+     * @param uiFactory the UI factory
+     * @return a new application context configured for Quarkus
+     */
+    public static BrowserlessApplicationContext<SecurityIdentity> create(
+            Routes routes, UIFactory uiFactory) {
+        return BrowserlessApplicationContext
+                .<SecurityIdentity>builder(routes)
+                .withServletFactory(r -> new MockQuarkusServlet(r,
+                        CDI.current().getBeanManager(), uiFactory))
+                .withUIFactory(uiFactory)
+                .withLookupServices(
+                        Set.of(QuarkusTestLookupInitializer.class))
+                .withSecurityContextHandler(
+                        new QuarkusSecurityContextHandler())
+                .build();
+    }
+}

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
@@ -52,7 +52,8 @@ public final class QuarkusBrowserlessApplicationContext {
     /**
      * Creates a Quarkus-integrated application context.
      *
-     * @param routes the discovered routes
+     * @param routes
+     *            the discovered routes
      * @return a new application context configured for Quarkus
      */
     public static BrowserlessApplicationContext<SecurityIdentity> create(
@@ -64,21 +65,20 @@ public final class QuarkusBrowserlessApplicationContext {
      * Creates a Quarkus-integrated application context with a custom UI
      * factory.
      *
-     * @param routes    the discovered routes
-     * @param uiFactory the UI factory
+     * @param routes
+     *            the discovered routes
+     * @param uiFactory
+     *            the UI factory
      * @return a new application context configured for Quarkus
      */
     public static BrowserlessApplicationContext<SecurityIdentity> create(
             Routes routes, UIFactory uiFactory) {
-        return BrowserlessApplicationContext
-                .<SecurityIdentity>builder(routes)
+        return BrowserlessApplicationContext.<SecurityIdentity> builder(routes)
                 .withServletFactory(r -> new MockQuarkusServlet(r,
                         CDI.current().getBeanManager(), uiFactory))
                 .withUIFactory(uiFactory)
-                .withLookupServices(
-                        Set.of(QuarkusTestLookupInitializer.class))
-                .withSecurityContextHandler(
-                        new QuarkusSecurityContextHandler())
+                .withLookupServices(Set.of(QuarkusTestLookupInitializer.class))
+                .withSecurityContextHandler(new QuarkusSecurityContextHandler())
                 .build();
     }
 }

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
@@ -19,9 +19,11 @@ import jakarta.enterprise.inject.spi.CDI;
 
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import com.vaadin.browserless.BrowserlessTest;
+import com.vaadin.browserless.BaseBrowserlessTest;
+import com.vaadin.browserless.TesterWrappers;
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.mocks.MockedUI;
 import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
@@ -36,14 +38,13 @@ import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
  * work.
  *
  * With Quarkus testing framework, setting up the CDI environment can be
- * achieved by annotating the {@link BrowserlessTest} class with
- * {@code @QuarkusTest}. The annotation registers a JUnit extension that deploys
- * and starts the whole application, including the initialization of the CDI
- * container. The drawback of this approach is that the application also starts
- * the HTTP server, effectively initializing the entire Vaadin application.
- * Tests are still performed in a mocked environment, but it is not possible
- * out-of-the-box to run them in isolation, with only the components needed by
- * the test.
+ * achieved by annotating the test class with {@code @QuarkusTest}. The
+ * annotation registers a JUnit extension that deploys and starts the whole
+ * application, including the initialization of the CDI container. The drawback
+ * of this approach is that the application also starts the HTTP server,
+ * effectively initializing the entire Vaadin application. Tests are still
+ * performed in a mocked environment, but it is not possible out-of-the-box to
+ * run them in isolation, with only the components needed by the test.
  *
  * <pre>
  * {
@@ -68,16 +69,38 @@ import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
  * may still be removed by the CDI container because considered unused or not
  * found because of missing bean defining annotations. For the above reasons,
  * currently, using {@code @QuarkusComponentTest} is not recommended.
+ *
+ * <p>
+ * This class extends {@link BaseBrowserlessTest} directly (not
+ * {@code BrowserlessTest}) to avoid inheriting
+ * {@code @ExtendWith(BrowserlessTestExtension.class)}. The Vaadin environment
+ * lifecycle is instead managed by {@code @BeforeEach}/{@code @AfterEach}
+ * methods, which JUnit 5 fires <em>after</em> all extension {@code beforeEach}
+ * callbacks — in particular after {@code QuarkusTestExtension.beforeEach()},
+ * which activates the CDI request scope and applies {@code @TestSecurity}
+ * identities.
  */
+public abstract class QuarkusBrowserlessTest extends BaseBrowserlessTest
+        implements TesterWrappers {
 
-public abstract class QuarkusBrowserlessTest extends BrowserlessTest {
+    @Override
+    protected final String testingEngine() {
+        return "JUnit 6";
+    }
 
     @BeforeEach
+    @Override
     protected void initVaadinEnvironment() {
         scanTesters();
         MockQuarkusServlet servlet = new MockQuarkusServlet(discoverRoutes(),
                 CDI.current().getBeanManager(), MockedUI::new);
         MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+    }
+
+    @AfterEach
+    @Override
+    protected void cleanVaadinEnvironment() {
+        super.cleanVaadinEnvironment();
     }
 
     @Override

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+import com.vaadin.browserless.SecurityContextHandler;
+
+/**
+ * Quarkus Security implementation of {@link SecurityContextHandler}.
+ * <p>
+ * Manages the {@link SecurityIdentity} via
+ * {@link CurrentIdentityAssociation} for multi-user test isolation.
+ * <p>
+ * The {@link #setupAuthentication(Object)} method expects a
+ * {@link SecurityIdentity} instance as the credentials parameter.
+ *
+ * @see SecurityContextHandler
+ * @see QuarkusBrowserlessApplicationContext
+ */
+public class QuarkusSecurityContextHandler
+        implements SecurityContextHandler<SecurityIdentity> {
+
+    @Override
+    public void setupAuthentication(SecurityIdentity credentials) {
+        if (credentials != null) {
+            getIdentityAssociation().setIdentity(credentials);
+        }
+    }
+
+    @Override
+    public Object saveContext() {
+        try {
+            return CurrentIdentityAssociation.current();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void restoreContext(Object snapshot) {
+        if (snapshot instanceof SecurityIdentity identity) {
+            getIdentityAssociation().setIdentity(identity);
+        } else {
+            clearContext();
+        }
+    }
+
+    @Override
+    public void clearContext() {
+        getIdentityAssociation().setIdentity(
+                QuarkusSecurityIdentity.builder()
+                        .setAnonymous(true).build());
+    }
+
+    private CurrentIdentityAssociation getIdentityAssociation() {
+        return CDI.current().select(CurrentIdentityAssociation.class).get();
+    }
+}

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -26,8 +26,8 @@ import com.vaadin.browserless.SecurityContextHandler;
 /**
  * Quarkus Security implementation of {@link SecurityContextHandler}.
  * <p>
- * Manages the {@link SecurityIdentity} via
- * {@link CurrentIdentityAssociation} for multi-user test isolation.
+ * Manages the {@link SecurityIdentity} via {@link CurrentIdentityAssociation}
+ * for multi-user test isolation.
  * <p>
  * The {@link #setupAuthentication(Object)} method expects a
  * {@link SecurityIdentity} instance as the credentials parameter.
@@ -66,8 +66,7 @@ public class QuarkusSecurityContextHandler
     @Override
     public void clearContext() {
         getIdentityAssociation().setIdentity(
-                QuarkusSecurityIdentity.builder()
-                        .setAnonymous(true).build());
+                QuarkusSecurityIdentity.builder().setAnonymous(true).build());
     }
 
     private CurrentIdentityAssociation getIdentityAssociation() {

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
@@ -30,11 +30,11 @@ public class QuarkusSecurityCustomizer implements MockRequestCustomizer {
 
     @Override
     public void apply(MockRequest request) {
-        request.setUserPrincipalProvider(() -> {
+        request.principalProvider(() -> {
             SecurityIdentity current = CurrentIdentityAssociation.current();
             return current.isAnonymous() ? null : current.getPrincipal();
         });
-        request.setUserInRole((principal, role) -> {
+        request.roleChecker((principal, role) -> {
             SecurityIdentity current = CurrentIdentityAssociation.current();
             return !current.isAnonymous()
                     && current.getPrincipal().equals(principal)

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
@@ -30,16 +30,16 @@ public class QuarkusSecurityCustomizer implements MockRequestCustomizer {
 
     @Override
     public void apply(MockRequest request) {
-        SecurityIdentity current = CurrentIdentityAssociation.current();
-        if (current.isAnonymous()) {
-            request.setUserPrincipalInt(null);
-            request.setUserInRole((principal, role) -> false);
-        } else {
-            request.setUserPrincipalInt(current.getPrincipal());
-            request.setUserInRole((principal,
-                    role) -> current.getPrincipal().equals(principal)
-                            && hasRole(current, role));
-        }
+        request.setUserPrincipalProvider(() -> {
+            SecurityIdentity current = CurrentIdentityAssociation.current();
+            return current.isAnonymous() ? null : current.getPrincipal();
+        });
+        request.setUserInRole((principal, role) -> {
+            SecurityIdentity current = CurrentIdentityAssociation.current();
+            return !current.isAnonymous()
+                    && current.getPrincipal().equals(principal)
+                    && hasRole(current, role);
+        });
     }
 
     // This method should be removed after implementing a proper solution

--- a/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
+++ b/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
@@ -38,10 +38,8 @@ import io.github.classgraph.ScanResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.internal.Routes;
-import com.vaadin.browserless.internal.ShortcutsKt;
 import com.vaadin.browserless.internal.UtilsKt;
 import com.vaadin.browserless.mocks.MockedUI;
 import com.vaadin.flow.component.Component;
@@ -50,7 +48,6 @@ import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.HasUrlParameter;
-import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -254,24 +251,7 @@ public abstract class BaseBrowserlessTest {
      * @return instantiated view
      */
     public <T extends Component> T navigate(Class<T> navigationTarget) {
-        verifyAndGetUI().navigate(navigationTarget);
-        return validateNavigationTarget(navigationTarget);
-    }
-
-    private <T extends Component> T validateNavigationTarget(
-            Class<T> navigationTarget) {
-        final HasElement currentView = getCurrentView();
-        if (!navigationTarget.isAssignableFrom(currentView.getClass())) {
-            if (currentView instanceof MockInternalSeverError) {
-                System.err.println(
-                        currentView.getElement().getProperty("stackTrace"));
-            }
-            throw new IllegalArgumentException(
-                    "Navigation resulted in unexpected class "
-                            + currentView.getClass().getName() + " instead of "
-                            + navigationTarget.getName());
-        }
-        return navigationTarget.cast(currentView);
+        return BrowserlessDSL.navigate(verifyAndGetUI(), navigationTarget);
     }
 
     /**
@@ -289,8 +269,8 @@ public abstract class BaseBrowserlessTest {
      */
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
             Class<T> navigationTarget, C parameter) {
-        verifyAndGetUI().navigate(navigationTarget, parameter);
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(verifyAndGetUI(), navigationTarget,
+                parameter);
     }
 
     /**
@@ -307,9 +287,8 @@ public abstract class BaseBrowserlessTest {
      */
     public <T extends Component> T navigate(Class<T> navigationTarget,
             Map<String, String> parameters) {
-        verifyAndGetUI().navigate(navigationTarget,
-                new RouteParameters(parameters));
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(verifyAndGetUI(), navigationTarget,
+                parameters);
     }
 
     /**
@@ -326,8 +305,8 @@ public abstract class BaseBrowserlessTest {
      */
     public <T extends Component> T navigate(String location,
             Class<T> expectedTarget) {
-        verifyAndGetUI().navigate(location);
-        return validateNavigationTarget(expectedTarget);
+        return BrowserlessDSL.navigate(verifyAndGetUI(), location,
+                expectedTarget);
     }
 
     /**
@@ -340,15 +319,7 @@ public abstract class BaseBrowserlessTest {
      *            Key modifiers. Can be empty.
      */
     public void fireShortcut(Key key, KeyModifier... modifiers) {
-        UI ui = verifyAndGetUI();
-        // TODO: should this logic be moved to ShortcutsKt.fireShortcut?
-        if (ui.hasModalComponent()) {
-            ShortcutsKt._fireShortcut(
-                    ui.getInternals().getActiveModalComponent(), key,
-                    modifiers);
-        } else {
-            ShortcutsKt.fireShortcut(key, modifiers);
-        }
+        BrowserlessDSL.fireShortcut(verifyAndGetUI(), key, modifiers);
     }
 
     /**
@@ -357,8 +328,7 @@ public abstract class BaseBrowserlessTest {
      * @return current view
      */
     public HasElement getCurrentView() {
-        return verifyAndGetUI().getInternals().getActiveRouterTargetsChain()
-                .get(0);
+        return BrowserlessDSL.getCurrentView(verifyAndGetUI());
     }
 
     // Protected for access by adapter subclass in legacy module
@@ -427,7 +397,7 @@ public abstract class BaseBrowserlessTest {
     }
 
     /**
-     * Gets a query object for finding a component inside the UI
+     * Gets a query object for finding a component inside the UI.
      *
      * @param componentType
      *            the type of the component(s) to search for
@@ -435,9 +405,9 @@ public abstract class BaseBrowserlessTest {
      *            the type of the component(s) to search for
      * @return a query object for finding components
      */
-    public <T extends Component> ComponentQuery<T> $(Class<T> componentType) {
-        verifyAndGetUI();
-        return internalQuery(componentType);
+    public <T extends Component> ComponentQuery<T> find(
+            Class<T> componentType) {
+        return BrowserlessDSL.find(verifyAndGetUI(), componentType);
     }
 
     /**
@@ -452,14 +422,13 @@ public abstract class BaseBrowserlessTest {
      *            the type of the component(s) to search for
      * @return a query object for finding components
      */
-    public <T extends Component> ComponentQuery<T> $(Class<T> componentType,
-            Component fromThis) {
-        verifyAndGetUI();
-        return new ComponentQuery<>(componentType).from(fromThis);
+    public <T extends Component> ComponentQuery<T> find(
+            Class<T> componentType, Component fromThis) {
+        return BrowserlessDSL.find(verifyAndGetUI(), componentType, fromThis);
     }
 
     /**
-     * Gets a query object for finding a component inside the current view
+     * Gets a query object for finding a component inside the current view.
      *
      * @param componentType
      *            the type of the component(s) to search for
@@ -467,12 +436,35 @@ public abstract class BaseBrowserlessTest {
      *            the type of the component(s) to search for
      * @return a query object for finding components
      */
+    public <T extends Component> ComponentQuery<T> findView(
+            Class<T> componentType) {
+        return BrowserlessDSL.findView(verifyAndGetUI(), componentType);
+    }
+
+    /**
+     * @deprecated Use {@link #find(Class)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public <T extends Component> ComponentQuery<T> $(Class<T> componentType) {
+        return find(componentType);
+    }
+
+    /**
+     * @deprecated Use {@link #find(Class, Component)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public <T extends Component> ComponentQuery<T> $(Class<T> componentType,
+            Component fromThis) {
+        return find(componentType, fromThis);
+    }
+
+    /**
+     * @deprecated Use {@link #findView(Class)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public <T extends Component> ComponentQuery<T> $view(
             Class<T> componentType) {
-        Component viewComponent = getCurrentView().getElement().getComponent()
-                .orElseThrow(() -> new AssertionError(
-                        "Cannot get Component instance for current view"));
-        return new ComponentQuery<>(componentType).from(viewComponent);
+        return findView(componentType);
     }
 
     /**
@@ -505,13 +497,14 @@ public abstract class BaseBrowserlessTest {
 
     /**
      * Simulates a server round-trip, flushing pending component changes.
+     *
+     * @deprecated Use the instance method on {@link BrowserlessUIContext} or
+     *             the extension DSL instead. This static method is kept for
+     *             backward compatibility.
      */
+    @Deprecated(forRemoval = true)
     protected static void roundTrip() {
-        UI.getCurrent().getInternals().getStateTree()
-                .collectChanges(nodeChange -> {
-                });
-        UI.getCurrent().getInternals().getStateTree()
-                .runExecutionsBeforeClientResponse();
+        BrowserlessDSL.roundTrip(UI.getCurrent());
     }
 
     /**
@@ -535,7 +528,7 @@ public abstract class BaseBrowserlessTest {
      * @see TestSignalEnvironment#runPendingTasks(long, TimeUnit)
      */
     protected final boolean runPendingSignalsTasks() {
-        return runPendingSignalsTasks(100, TimeUnit.MILLISECONDS);
+        return BrowserlessDSL.runPendingSignalsTasks(signalsTestEnvironment);
     }
 
     /**
@@ -567,11 +560,8 @@ public abstract class BaseBrowserlessTest {
      */
     protected final boolean runPendingSignalsTasks(long maxWaitTime,
             TimeUnit unit) {
-        if (this.signalsTestEnvironment != null) {
-            return this.signalsTestEnvironment.runPendingTasks(maxWaitTime,
-                    unit);
-        }
-        return false;
+        return BrowserlessDSL.runPendingSignalsTasks(signalsTestEnvironment,
+                maxWaitTime, unit);
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
+++ b/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
@@ -422,8 +422,8 @@ public abstract class BaseBrowserlessTest {
      *            the type of the component(s) to search for
      * @return a query object for finding components
      */
-    public <T extends Component> ComponentQuery<T> find(
-            Class<T> componentType, Component fromThis) {
+    public <T extends Component> ComponentQuery<T> find(Class<T> componentType,
+            Component fromThis) {
         return BrowserlessDSL.find(verifyAndGetUI(), componentType, fromThis);
     }
 

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -34,14 +34,14 @@ import com.vaadin.flow.server.VaadinServletService;
 /**
  * Application-level context for multi-user browserless testing.
  * <p>
- * Manages a shared {@link VaadinServletService} and servlet that are
- * shared across all users and their windows. This models the application
- * level of the Vaadin hierarchy: one application contains multiple user
- * sessions, each with multiple UI instances (browser tabs).
+ * Manages a shared {@link VaadinServletService} and servlet that are shared
+ * across all users and their windows. This models the application level of the
+ * Vaadin hierarchy: one application contains multiple user sessions, each with
+ * multiple UI instances (browser tabs).
  * <p>
  * Create instances via {@link #create(Routes)} for plain Java or use the
- * {@link #builder(Routes)} for full customization. Framework-specific
- * modules (Spring, Quarkus) provide their own convenience factory methods.
+ * {@link #builder(Routes)} for full customization. Framework-specific modules
+ * (Spring, Quarkus) provide their own convenience factory methods.
  *
  * <pre>
  * var app = BrowserlessApplicationContext.create(routes);
@@ -76,18 +76,21 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     /**
      * Creates a plain Java application context with default settings.
      *
-     * @param routes the discovered routes
+     * @param routes
+     *            the discovered routes
      * @return a new application context
      */
     public static BrowserlessApplicationContext<Void> create(Routes routes) {
-        return BrowserlessApplicationContext.<Void>builder(routes).build();
+        return BrowserlessApplicationContext.<Void> builder(routes).build();
     }
 
     /**
      * Creates a builder for customizing the application context.
      *
-     * @param <C>    the credentials type for the security context handler
-     * @param routes the discovered routes
+     * @param <C>
+     *            the credentials type for the security context handler
+     * @param routes
+     *            the discovered routes
      * @return a new builder
      */
     public static <C> Builder<C> builder(Routes routes) {
@@ -97,10 +100,10 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     /**
      * Creates a new user context representing an independent user session.
      * <p>
-     * The returned context has its own {@link com.vaadin.flow.server.VaadinSession},
-     * HTTP request, and response. If credentials are provided and a
-     * {@link SecurityContextHandler} is configured, authentication is set up
-     * automatically.
+     * The returned context has its own
+     * {@link com.vaadin.flow.server.VaadinSession}, HTTP request, and response.
+     * If credentials are provided and a {@link SecurityContextHandler} is
+     * configured, authentication is set up automatically.
      *
      * @return the new user context
      */
@@ -113,12 +116,13 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
      * <p>
      * The credentials are passed to
      * {@link SecurityContextHandler#setupAuthentication(Object)
-     * SecurityContextHandler.setupAuthentication()} if a
-     * handler is configured. The security context is then automatically
-     * captured as the user's initial snapshot.
+     * SecurityContextHandler.setupAuthentication()} if a handler is configured.
+     * The security context is then automatically captured as the user's initial
+     * snapshot.
      *
-     * @param credentials framework-specific credentials, or {@code null}
-     *                    for an anonymous user
+     * @param credentials
+     *            framework-specific credentials, or {@code null} for an
+     *            anonymous user
      * @return the new user context
      */
     public BrowserlessUserContext newUser(C credentials) {
@@ -188,8 +192,8 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         /**
          * Sets the security context handler for multi-user auth isolation.
          *
-         * @param handler the handler, or {@code null} for no security
-         *                management
+         * @param handler
+         *            the handler, or {@code null} for no security management
          * @return this builder
          */
         public Builder<C> withSecurityContextHandler(
@@ -199,10 +203,11 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         }
 
         /**
-         * Sets a custom servlet factory. The factory receives the routes
-         * and must return a fully configured {@link VaadinServlet}.
+         * Sets a custom servlet factory. The factory receives the routes and
+         * must return a fully configured {@link VaadinServlet}.
          *
-         * @param factory the servlet factory
+         * @param factory
+         *            the servlet factory
          * @return this builder
          */
         public Builder<C> withServletFactory(
@@ -214,7 +219,8 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         /**
          * Sets the UI factory for creating new UI instances.
          *
-         * @param uiFactory the UI factory
+         * @param uiFactory
+         *            the UI factory
          * @return this builder
          */
         public Builder<C> withUIFactory(UIFactory uiFactory) {
@@ -225,7 +231,8 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         /**
          * Sets the Vaadin Lookup service classes.
          *
-         * @param services the service implementation classes
+         * @param services
+         *            the service implementation classes
          * @return this builder
          */
         public Builder<C> withLookupServices(Set<Class<?>> services) {

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.UIFactory;
+import com.vaadin.browserless.mocks.MockVaadinServlet;
+import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletService;
+
+/**
+ * Application-level context for multi-user browserless testing.
+ * <p>
+ * Manages a shared {@link VaadinServletService} and servlet that are
+ * shared across all users and their windows. This models the application
+ * level of the Vaadin hierarchy: one application contains multiple user
+ * sessions, each with multiple UI instances (browser tabs).
+ * <p>
+ * Create instances via {@link #create(Routes)} for plain Java or use the
+ * {@link #builder(Routes)} for full customization. Framework-specific
+ * modules (Spring, Quarkus) provide their own convenience factory methods.
+ *
+ * <pre>
+ * var app = BrowserlessApplicationContext.create(routes);
+ * var user1 = app.newUser();
+ * var window1 = user1.newWindow();
+ * window1.navigate(MyView.class);
+ * // ...
+ * app.close();
+ * </pre>
+ *
+ * @see BrowserlessUserContext
+ * @see BrowserlessUIContext
+ */
+public class BrowserlessApplicationContext<C> implements AutoCloseable {
+
+    private final VaadinServletService service;
+    private final VaadinServlet servlet;
+    private final UIFactory uiFactory;
+    private final SecurityContextHandler<C> securityContextHandler;
+    private final List<BrowserlessUserContext> users = new ArrayList<>();
+    private boolean closed;
+
+    private BrowserlessApplicationContext(VaadinServletService service,
+            VaadinServlet servlet, UIFactory uiFactory,
+            SecurityContextHandler<C> securityContextHandler) {
+        this.service = service;
+        this.servlet = servlet;
+        this.uiFactory = uiFactory;
+        this.securityContextHandler = securityContextHandler;
+    }
+
+    /**
+     * Creates a plain Java application context with default settings.
+     *
+     * @param routes the discovered routes
+     * @return a new application context
+     */
+    public static BrowserlessApplicationContext<Void> create(Routes routes) {
+        return BrowserlessApplicationContext.<Void>builder(routes).build();
+    }
+
+    /**
+     * Creates a builder for customizing the application context.
+     *
+     * @param <C>    the credentials type for the security context handler
+     * @param routes the discovered routes
+     * @return a new builder
+     */
+    public static <C> Builder<C> builder(Routes routes) {
+        return new Builder<>(routes);
+    }
+
+    /**
+     * Creates a new user context representing an independent user session.
+     * <p>
+     * The returned context has its own {@link com.vaadin.flow.server.VaadinSession},
+     * HTTP request, and response. If credentials are provided and a
+     * {@link SecurityContextHandler} is configured, authentication is set up
+     * automatically.
+     *
+     * @return the new user context
+     */
+    public BrowserlessUserContext newUser() {
+        return newUser(null);
+    }
+
+    /**
+     * Creates a new user context with the given credentials.
+     * <p>
+     * The credentials are passed to
+     * {@link SecurityContextHandler#setupAuthentication(Object)
+     * SecurityContextHandler.setupAuthentication()} if a
+     * handler is configured. The security context is then automatically
+     * captured as the user's initial snapshot.
+     *
+     * @param credentials framework-specific credentials, or {@code null}
+     *                    for an anonymous user
+     * @return the new user context
+     */
+    public BrowserlessUserContext newUser(C credentials) {
+        checkNotClosed();
+        var user = new BrowserlessUserContext(this, credentials);
+        users.add(user);
+        return user;
+    }
+
+    /**
+     * Closes this application context and all its user contexts.
+     * <p>
+     * Fires service destroy listeners and clears thread-local state.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        for (var user : users) {
+            user.close();
+        }
+        users.clear();
+        MockVaadin.fireServiceDestroy(service);
+        VaadinService.setCurrent(null);
+    }
+
+    VaadinServletService getService() {
+        return service;
+    }
+
+    VaadinServlet getServlet() {
+        return servlet;
+    }
+
+    UIFactory getUIFactory() {
+        return uiFactory;
+    }
+
+    SecurityContextHandler<C> getSecurityContextHandler() {
+        return securityContextHandler;
+    }
+
+    private void checkNotClosed() {
+        if (closed) {
+            throw new IllegalStateException(
+                    "BrowserlessApplicationContext is already closed");
+        }
+    }
+
+    /**
+     * Builder for creating a customized {@link BrowserlessApplicationContext}.
+     */
+    public static class Builder<C> {
+
+        private final Routes routes;
+        private SecurityContextHandler<C> securityContextHandler;
+        private Function<Routes, VaadinServlet> servletFactory;
+        private UIFactory uiFactory = () -> new MockedUI();
+        private Set<Class<?>> lookupServices = Collections.emptySet();
+
+        Builder(Routes routes) {
+            this.routes = Objects.requireNonNull(routes);
+        }
+
+        /**
+         * Sets the security context handler for multi-user auth isolation.
+         *
+         * @param handler the handler, or {@code null} for no security
+         *                management
+         * @return this builder
+         */
+        public Builder<C> withSecurityContextHandler(
+                SecurityContextHandler<C> handler) {
+            this.securityContextHandler = handler;
+            return this;
+        }
+
+        /**
+         * Sets a custom servlet factory. The factory receives the routes
+         * and must return a fully configured {@link VaadinServlet}.
+         *
+         * @param factory the servlet factory
+         * @return this builder
+         */
+        public Builder<C> withServletFactory(
+                Function<Routes, VaadinServlet> factory) {
+            this.servletFactory = Objects.requireNonNull(factory);
+            return this;
+        }
+
+        /**
+         * Sets the UI factory for creating new UI instances.
+         *
+         * @param uiFactory the UI factory
+         * @return this builder
+         */
+        public Builder<C> withUIFactory(UIFactory uiFactory) {
+            this.uiFactory = Objects.requireNonNull(uiFactory);
+            return this;
+        }
+
+        /**
+         * Sets the Vaadin Lookup service classes.
+         *
+         * @param services the service implementation classes
+         * @return this builder
+         */
+        public Builder<C> withLookupServices(Set<Class<?>> services) {
+            this.lookupServices = Objects.requireNonNull(services);
+            return this;
+        }
+
+        /**
+         * Builds the application context.
+         *
+         * @return a new application context
+         */
+        public BrowserlessApplicationContext<C> build() {
+            VaadinServlet servlet = servletFactory != null
+                    ? servletFactory.apply(routes)
+                    : new MockVaadinServlet(routes, uiFactory);
+            VaadinServletService service = MockVaadin.setupServlet(servlet,
+                    lookupServices);
+            return new BrowserlessApplicationContext<>(service, servlet,
+                    uiFactory, securityContextHandler);
+        }
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessDSL.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessDSL.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.vaadin.browserless.internal.MockInternalSeverError;
+import com.vaadin.browserless.internal.ShortcutsKt;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.RouteParameters;
+
+/**
+ * Shared DSL logic for browserless testing. All methods are static utilities
+ * that take a {@link UI} parameter, so callers can supply the UI from
+ * thread-locals or from a stored reference as appropriate.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+final class BrowserlessDSL {
+
+    private BrowserlessDSL() {
+    }
+
+    static <T extends Component> T navigate(UI ui, Class<T> target) {
+        ui.navigate(target);
+        return validateNavigationTarget(ui, target);
+    }
+
+    static <C, T extends Component & HasUrlParameter<C>> T navigate(UI ui,
+            Class<T> target, C parameter) {
+        ui.navigate(target, parameter);
+        return validateNavigationTarget(ui, target);
+    }
+
+    static <T extends Component> T navigate(UI ui, Class<T> target,
+            Map<String, String> parameters) {
+        ui.navigate(target, new RouteParameters(parameters));
+        return validateNavigationTarget(ui, target);
+    }
+
+    static <T extends Component> T navigate(UI ui, String location,
+            Class<T> expectedTarget) {
+        ui.navigate(location);
+        return validateNavigationTarget(ui, expectedTarget);
+    }
+
+    static <T extends Component> T validateNavigationTarget(UI ui,
+            Class<T> target) {
+        HasElement currentView = getCurrentView(ui);
+        if (!target.isAssignableFrom(currentView.getClass())) {
+            if (currentView instanceof MockInternalSeverError) {
+                System.err.println(
+                        currentView.getElement().getProperty("stackTrace"));
+            }
+            throw new IllegalArgumentException(
+                    "Navigation resulted in unexpected class "
+                            + currentView.getClass().getName() + " instead of "
+                            + target.getName());
+        }
+        return target.cast(currentView);
+    }
+
+    static HasElement getCurrentView(UI ui) {
+        return ui.getInternals().getActiveRouterTargetsChain().get(0);
+    }
+
+    static <T extends Component> ComponentQuery<T> find(UI ui,
+            Class<T> componentType) {
+        return new ComponentQuery<>(componentType);
+    }
+
+    static <T extends Component> ComponentQuery<T> find(UI ui,
+            Class<T> componentType, Component fromThis) {
+        return new ComponentQuery<>(componentType).from(fromThis);
+    }
+
+    static <T extends Component> ComponentQuery<T> findView(UI ui,
+            Class<T> componentType) {
+        Component viewComponent = getCurrentView(ui).getElement().getComponent()
+                .orElseThrow(() -> new AssertionError(
+                        "Cannot get Component instance for current view"));
+        return new ComponentQuery<>(componentType).from(viewComponent);
+    }
+
+    static void fireShortcut(UI ui, Key key, KeyModifier... modifiers) {
+        if (ui.hasModalComponent()) {
+            ShortcutsKt._fireShortcut(
+                    ui.getInternals().getActiveModalComponent(), key,
+                    modifiers);
+        } else {
+            ShortcutsKt.fireShortcut(key, modifiers);
+        }
+    }
+
+    static void roundTrip(UI ui) {
+        ui.getInternals().getStateTree().collectChanges(nodeChange -> {
+        });
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+    }
+
+    static boolean runPendingSignalsTasks(
+            TestSignalEnvironment signalsTestEnvironment) {
+        return runPendingSignalsTasks(signalsTestEnvironment, 100,
+                TimeUnit.MILLISECONDS);
+    }
+
+    static boolean runPendingSignalsTasks(
+            TestSignalEnvironment signalsTestEnvironment, long maxWaitTime,
+            TimeUnit unit) {
+        if (signalsTestEnvironment != null) {
+            return signalsTestEnvironment.runPendingTasks(maxWaitTime, unit);
+        }
+        return false;
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -35,12 +35,11 @@ import com.vaadin.flow.server.VaadinSession;
 /**
  * UI-level context for multi-user browserless testing.
  * <p>
- * Represents a single browser window/tab (one {@link UI} instance).
- * All DSL methods ({@link #navigate}, {@link #find(Class)},
- * {@link #findView(Class)}, {@link #test}) automatically call
- * {@link #activate()} before executing,
- * which transparently switches the thread-local Vaadin state and security
- * context to this window's user.
+ * Represents a single browser window/tab (one {@link UI} instance). All DSL
+ * methods ({@link #navigate}, {@link #find(Class)}, {@link #findView(Class)},
+ * {@link #test}) automatically call {@link #activate()} before executing, which
+ * transparently switches the thread-local Vaadin state and security context to
+ * this window's user.
  * <p>
  * This means you can freely interleave calls on different windows without
  * explicit context switching:
@@ -83,9 +82,9 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * context belonged to a different user, the outgoing user's security
      * context is automatically saved and this user's context is restored.
      * <p>
-     * This method is called automatically by all DSL methods. You only
-     * need to call it explicitly if you are accessing Vaadin APIs directly
-     * (e.g. {@code UI.getCurrent()}).
+     * This method is called automatically by all DSL methods. You only need to
+     * call it explicitly if you are accessing Vaadin APIs directly (e.g.
+     * {@code UI.getCurrent()}).
      */
     public void activate() {
         if (closed) {
@@ -119,8 +118,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Navigates this window to the given view class.
      *
-     * @param navigationTarget the view class to navigate to
-     * @param <T>              the view type
+     * @param navigationTarget
+     *            the view class to navigate to
+     * @param <T>
+     *            the view type
      * @return the instantiated view
      */
     public <T extends Component> T navigate(Class<T> navigationTarget) {
@@ -131,10 +132,14 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Navigates this window to the given view class with a URL parameter.
      *
-     * @param navigationTarget the view class to navigate to
-     * @param parameter        the URL parameter
-     * @param <T>              the view type
-     * @param <C>              the parameter type
+     * @param navigationTarget
+     *            the view class to navigate to
+     * @param parameter
+     *            the URL parameter
+     * @param <T>
+     *            the view type
+     * @param <C>
+     *            the parameter type
      * @return the instantiated view
      */
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
@@ -146,9 +151,12 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Navigates this window to the given view class with route parameters.
      *
-     * @param navigationTarget the view class to navigate to
-     * @param parameters       the route parameters
-     * @param <T>              the view type
+     * @param navigationTarget
+     *            the view class to navigate to
+     * @param parameters
+     *            the route parameters
+     * @param <T>
+     *            the view type
      * @return the instantiated view
      */
     public <T extends Component> T navigate(Class<T> navigationTarget,
@@ -158,12 +166,15 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Navigates this window to the given location and validates the
-     * resulting view.
+     * Navigates this window to the given location and validates the resulting
+     * view.
      *
-     * @param location       the navigation location string
-     * @param expectedTarget the expected view class
-     * @param <T>            the view type
+     * @param location
+     *            the navigation location string
+     * @param expectedTarget
+     *            the expected view class
+     * @param <T>
+     *            the view type
      * @return the instantiated view
      */
     public <T extends Component> T navigate(String location,
@@ -173,11 +184,13 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Gets a query object for finding components of the given type in
-     * this window's UI.
+     * Gets a query object for finding components of the given type in this
+     * window's UI.
      *
-     * @param componentType the type of component to search for
-     * @param <T>           the component type
+     * @param componentType
+     *            the type of component to search for
+     * @param <T>
+     *            the component type
      * @return a query object
      */
     public <T extends Component> ComponentQuery<T> find(
@@ -187,26 +200,31 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Gets a query object for finding components of the given type
-     * nested inside the specified component.
+     * Gets a query object for finding components of the given type nested
+     * inside the specified component.
      *
-     * @param componentType the type of component to search for
-     * @param fromThis      the component to search within
-     * @param <T>           the component type
+     * @param componentType
+     *            the type of component to search for
+     * @param fromThis
+     *            the component to search within
+     * @param <T>
+     *            the component type
      * @return a query object
      */
-    public <T extends Component> ComponentQuery<T> find(
-            Class<T> componentType, Component fromThis) {
+    public <T extends Component> ComponentQuery<T> find(Class<T> componentType,
+            Component fromThis) {
         activate();
         return BrowserlessDSL.find(ui, componentType, fromThis);
     }
 
     /**
-     * Gets a query object for finding components of the given type
-     * inside the current view.
+     * Gets a query object for finding components of the given type inside the
+     * current view.
      *
-     * @param componentType the type of component to search for
-     * @param <T>           the component type
+     * @param componentType
+     *            the type of component to search for
+     * @param <T>
+     *            the component type
      * @return a query object
      */
     public <T extends Component> ComponentQuery<T> findView(
@@ -216,14 +234,16 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Wraps a component with the best matching
-     * {@link ComponentTester}. This generic fallback is used for
-     * component types not covered by the specific {@link TesterWrappers}
-     * defaults.
+     * Wraps a component with the best matching {@link ComponentTester}. This
+     * generic fallback is used for component types not covered by the specific
+     * {@link TesterWrappers} defaults.
      *
-     * @param component the component to wrap
-     * @param <T>       the tester type
-     * @param <Y>       the component type
+     * @param component
+     *            the component to wrap
+     * @param <T>
+     *            the tester type
+     * @param <Y>
+     *            the component type
      * @return the component wrapped in a tester
      */
     public <T extends ComponentTester<Y>, Y extends Component> T test(
@@ -253,9 +273,11 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Simulates a keyboard shortcut performed on the browser.
      *
-     * @param key       primary key of the shortcut. This must not be a
-     *                  {@link KeyModifier}.
-     * @param modifiers key modifiers. Can be empty.
+     * @param key
+     *            primary key of the shortcut. This must not be a
+     *            {@link KeyModifier}.
+     * @param modifiers
+     *            key modifiers. Can be empty.
      */
     public void fireShortcut(Key key, KeyModifier... modifiers) {
         activate();
@@ -267,9 +289,9 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * {@link com.vaadin.flow.component.page.Page#setLocation(String)} or
      * {@link com.vaadin.flow.component.page.Page#open(String)}.
      * <p>
-     * This captures URLs where the window name is {@code _self}, {@code _parent},
-     * {@code _top}, empty, or {@code null} (all of which navigate the current
-     * window). To query URLs opened in other windows, use
+     * This captures URLs where the window name is {@code _self},
+     * {@code _parent}, {@code _top}, empty, or {@code null} (all of which
+     * navigate the current window). To query URLs opened in other windows, use
      * {@link #getExternalNavigationURL(String)} or {@link #getOpenedWindows()}.
      *
      * @return the external navigation URL, or {@code null} if no external
@@ -286,10 +308,11 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Returns the last URL opened with the given window name.
      * <p>
-     * For {@code _blank}, returns the URL from the most recent call.
-     * For named windows, returns the last URL that targeted that name.
+     * For {@code _blank}, returns the URL from the most recent call. For named
+     * windows, returns the last URL that targeted that name.
      *
-     * @param windowName the window name to look up
+     * @param windowName
+     *            the window name to look up
      * @return the last URL for the given window name, or {@code null} if none
      */
     public String getExternalNavigationURL(String windowName) {
@@ -307,10 +330,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * excluding navigations that target the current window ({@code _self},
      * {@code _parent}, {@code _top}, empty, or {@code null}).
      * <p>
-     * The map keys are window names, and values are lists of URLs opened
-     * under that name. For {@code _blank}, the list contains all URLs
-     * (each call opens a new window). For named windows, the list
-     * typically contains a single entry (the last URL).
+     * The map keys are window names, and values are lists of URLs opened under
+     * that name. For {@code _blank}, the list contains all URLs (each call
+     * opens a new window). For named windows, the list typically contains a
+     * single entry (the last URL).
      *
      * @return an unmodifiable map of window names to URL lists
      */
@@ -363,8 +386,8 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Returns the currently active UI context for the calling thread,
-     * or {@code null} if none is active.
+     * Returns the currently active UI context for the calling thread, or
+     * {@code null} if none is active.
      *
      * @return the active context, or {@code null}
      */

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import com.vaadin.browserless.internal.MockPage;
+import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.MockInternalSeverError;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * UI-level context for multi-user browserless testing.
+ * <p>
+ * Represents a single browser window/tab (one {@link UI} instance).
+ * All DSL methods ({@link #navigate}, {@link #$}, {@link #$view},
+ * {@link #test}) automatically call {@link #activate()} before executing,
+ * which transparently switches the thread-local Vaadin state and security
+ * context to this window's user.
+ * <p>
+ * This means you can freely interleave calls on different windows without
+ * explicit context switching:
+ *
+ * <pre>
+ * window1.navigate(ViewA.class);
+ * window2.navigate(ViewB.class); // auto-switches to window2's user
+ * window1.$(Button.class).first(); // auto-switches back to window1's user
+ * </pre>
+ *
+ * @see BrowserlessUserContext#newWindow()
+ * @see BrowserlessApplicationContext
+ */
+public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
+
+    private static final ThreadLocal<BrowserlessUIContext> activeContext = new ThreadLocal<>();
+
+    private final BrowserlessUserContext user;
+    private UI ui;
+    private boolean closed;
+
+    BrowserlessUIContext(BrowserlessUserContext user) {
+        this.user = user;
+
+        // Activate this context (sets thread-locals + restores security)
+        activate();
+
+        // Create the UI
+        MockVaadin.createUI(user.getApp().getUIFactory(), user.getSession());
+        this.ui = UI.getCurrent();
+    }
+
+    /**
+     * Activates this UI context on the current thread.
+     * <p>
+     * Sets all Vaadin thread-locals ({@link VaadinService},
+     * {@link VaadinSession}, {@link UI}, {@link VaadinRequest},
+     * {@link VaadinResponse}) to this window's values. If a
+     * {@link SecurityContextHandler} is configured and the previous active
+     * context belonged to a different user, the outgoing user's security
+     * context is automatically saved and this user's context is restored.
+     * <p>
+     * This method is called automatically by all DSL methods. You only
+     * need to call it explicitly if you are accessing Vaadin APIs directly
+     * (e.g. {@code UI.getCurrent()}).
+     */
+    public void activate() {
+        if (closed) {
+            throw new IllegalStateException(
+                    "BrowserlessUIContext is already closed");
+        }
+        BrowserlessUIContext previous = activeContext.get();
+
+        // Save outgoing user's security context on user switch
+        if (previous != null && previous != this
+                && previous.user != this.user) {
+            previous.user.saveSecurityContext();
+        }
+
+        // Set Vaadin thread-locals
+        VaadinService.setCurrent(user.getApp().getService());
+        VaadinSession.setCurrent(user.getSession());
+        UI.setCurrent(ui);
+        CurrentInstance.set(VaadinRequest.class, user.getRequest());
+        CurrentInstance.set(VaadinResponse.class, user.getResponse());
+
+        // Restore security context on user switch or first activation
+        boolean switchingUser = previous == null || previous.user != this.user;
+        if (switchingUser) {
+            user.restoreSecurityContext();
+        }
+
+        activeContext.set(this);
+    }
+
+    /**
+     * Navigates this window to the given view class.
+     *
+     * @param navigationTarget the view class to navigate to
+     * @param <T>              the view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(Class<T> navigationTarget) {
+        activate();
+        ui.navigate(navigationTarget);
+        return validateNavigationTarget(navigationTarget);
+    }
+
+    /**
+     * Navigates this window to the given view class with a URL parameter.
+     *
+     * @param navigationTarget the view class to navigate to
+     * @param parameter        the URL parameter
+     * @param <T>              the view type
+     * @param <C>              the parameter type
+     * @return the instantiated view
+     */
+    public <C, T extends Component & HasUrlParameter<C>> T navigate(
+            Class<T> navigationTarget, C parameter) {
+        activate();
+        ui.navigate(navigationTarget, parameter);
+        return validateNavigationTarget(navigationTarget);
+    }
+
+    /**
+     * Navigates this window to the given view class with route parameters.
+     *
+     * @param navigationTarget the view class to navigate to
+     * @param parameters       the route parameters
+     * @param <T>              the view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(Class<T> navigationTarget,
+            Map<String, String> parameters) {
+        activate();
+        ui.navigate(navigationTarget, new RouteParameters(parameters));
+        return validateNavigationTarget(navigationTarget);
+    }
+
+    /**
+     * Navigates this window to the given location and validates the
+     * resulting view.
+     *
+     * @param location       the navigation location string
+     * @param expectedTarget the expected view class
+     * @param <T>            the view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(String location,
+            Class<T> expectedTarget) {
+        activate();
+        ui.navigate(location);
+        return validateNavigationTarget(expectedTarget);
+    }
+
+    /**
+     * Gets a query object for finding components of the given type in
+     * this window's UI.
+     *
+     * @param componentType the type of component to search for
+     * @param <T>           the component type
+     * @return a query object
+     */
+    public <T extends Component> ComponentQuery<T> $(
+            Class<T> componentType) {
+        activate();
+        return new ComponentQuery<>(componentType);
+    }
+
+    /**
+     * Gets a query object for finding components of the given type
+     * nested inside the specified component.
+     *
+     * @param componentType the type of component to search for
+     * @param fromThis      the component to search within
+     * @param <T>           the component type
+     * @return a query object
+     */
+    public <T extends Component> ComponentQuery<T> $(
+            Class<T> componentType, Component fromThis) {
+        activate();
+        return new ComponentQuery<>(componentType).from(fromThis);
+    }
+
+    /**
+     * Gets a query object for finding components of the given type
+     * inside the current view.
+     *
+     * @param componentType the type of component to search for
+     * @param <T>           the component type
+     * @return a query object
+     */
+    public <T extends Component> ComponentQuery<T> $view(
+            Class<T> componentType) {
+        activate();
+        Component viewComponent = getCurrentView().getElement().getComponent()
+                .orElseThrow(() -> new AssertionError(
+                        "Cannot get Component instance for current view"));
+        return new ComponentQuery<>(componentType).from(viewComponent);
+    }
+
+    /**
+     * Alias for {@link #$(Class)} — Java-idiomatic name.
+     */
+    public <T extends Component> ComponentQuery<T> get(
+            Class<T> componentType) {
+        return $(componentType);
+    }
+
+    /**
+     * Alias for {@link #$(Class, Component)} — Java-idiomatic name.
+     */
+    public <T extends Component> ComponentQuery<T> get(
+            Class<T> componentType, Component fromThis) {
+        return $(componentType, fromThis);
+    }
+
+    /**
+     * Alias for {@link #$view(Class)} — Java-idiomatic name.
+     */
+    public <T extends Component> ComponentQuery<T> getView(
+            Class<T> componentType) {
+        return $view(componentType);
+    }
+
+    /**
+     * Wraps a component with the best matching
+     * {@link ComponentTester}. This generic fallback is used for
+     * component types not covered by the specific {@link TesterWrappers}
+     * defaults.
+     *
+     * @param component the component to wrap
+     * @param <T>       the tester type
+     * @param <Y>       the component type
+     * @return the component wrapped in a tester
+     */
+    public <T extends ComponentTester<Y>, Y extends Component> T test(
+            Y component) {
+        activate();
+        return BaseBrowserlessTest.internalWrap(component);
+    }
+
+    /**
+     * Gets the current view displayed in this window.
+     *
+     * @return the current view
+     */
+    public HasElement getCurrentView() {
+        activate();
+        return ui.getInternals().getActiveRouterTargetsChain().get(0);
+    }
+
+    /**
+     * Simulates a server round-trip, flushing pending component changes.
+     */
+    public void roundTrip() {
+        activate();
+        BaseBrowserlessTest.roundTrip();
+    }
+
+    /**
+     * Returns the URL from the last external navigation triggered by
+     * {@link com.vaadin.flow.component.page.Page#setLocation(String)} or
+     * {@link com.vaadin.flow.component.page.Page#open(String)}.
+     * <p>
+     * This captures URLs where the window name is {@code _self}, {@code _parent},
+     * {@code _top}, empty, or {@code null} (all of which navigate the current
+     * window). To query URLs opened in other windows, use
+     * {@link #getExternalNavigationURL(String)} or {@link #getOpenedWindows()}.
+     *
+     * @return the external navigation URL, or {@code null} if no external
+     *         navigation has occurred
+     */
+    public String getExternalNavigationURL() {
+        activate();
+        if (ui.getPage() instanceof MockPage mockPage) {
+            return mockPage.getLastExternalNavigationURL();
+        }
+        return null;
+    }
+
+    /**
+     * Returns the last URL opened with the given window name.
+     * <p>
+     * For {@code _blank}, returns the URL from the most recent call.
+     * For named windows, returns the last URL that targeted that name.
+     *
+     * @param windowName the window name to look up
+     * @return the last URL for the given window name, or {@code null} if none
+     */
+    public String getExternalNavigationURL(String windowName) {
+        activate();
+        if (ui.getPage() instanceof MockPage mockPage) {
+            return mockPage.getExternalNavigationURL(windowName);
+        }
+        return null;
+    }
+
+    /**
+     * Returns a map of all windows opened via
+     * {@link com.vaadin.flow.component.page.Page#open(String)} or
+     * {@link com.vaadin.flow.component.page.Page#open(String, String)},
+     * excluding navigations that target the current window ({@code _self},
+     * {@code _parent}, {@code _top}, empty, or {@code null}).
+     * <p>
+     * The map keys are window names, and values are lists of URLs opened
+     * under that name. For {@code _blank}, the list contains all URLs
+     * (each call opens a new window). For named windows, the list
+     * typically contains a single entry (the last URL).
+     *
+     * @return an unmodifiable map of window names to URL lists
+     */
+    public Map<String, List<String>> getOpenedWindows() {
+        activate();
+        if (ui.getPage() instanceof MockPage mockPage) {
+            return mockPage.getOpenedWindows();
+        }
+        return Map.of();
+    }
+
+    /**
+     * Returns the UI managed by this context.
+     *
+     * @return the UI instance
+     */
+    public UI getUI() {
+        return ui;
+    }
+
+    /**
+     * Returns the user context that owns this window.
+     *
+     * @return the parent user context
+     */
+    public BrowserlessUserContext getUser() {
+        return user;
+    }
+
+    /**
+     * Closes this UI context and detaches the UI.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (activeContext.get() == this) {
+            activeContext.remove();
+        }
+        if (ui != null) {
+            // Set thread-locals to properly close the UI
+            VaadinService.setCurrent(user.getApp().getService());
+            VaadinSession.setCurrent(user.getSession());
+            UI.setCurrent(ui);
+            MockVaadin.closeCurrentUI(true);
+            ui = null;
+        }
+    }
+
+    private <T extends Component> T validateNavigationTarget(
+            Class<T> navigationTarget) {
+        HasElement currentView = getCurrentView();
+        if (!navigationTarget.isAssignableFrom(currentView.getClass())) {
+            if (currentView instanceof MockInternalSeverError) {
+                System.err.println(
+                        currentView.getElement().getProperty("stackTrace"));
+            }
+            throw new IllegalArgumentException(
+                    "Navigation resulted in unexpected class "
+                            + currentView.getClass().getName()
+                            + " instead of " + navigationTarget.getName());
+        }
+        return navigationTarget.cast(currentView);
+    }
+
+    /**
+     * Returns the currently active UI context for the calling thread,
+     * or {@code null} if none is active.
+     *
+     * @return the active context, or {@code null}
+     */
+    static BrowserlessUIContext getActive() {
+        return activeContext.get();
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -15,19 +15,18 @@
  */
 package com.vaadin.browserless;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
 import com.vaadin.browserless.internal.MockPage;
 import com.vaadin.browserless.internal.MockVaadin;
-import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.router.HasUrlParameter;
-import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
@@ -37,8 +36,9 @@ import com.vaadin.flow.server.VaadinSession;
  * UI-level context for multi-user browserless testing.
  * <p>
  * Represents a single browser window/tab (one {@link UI} instance).
- * All DSL methods ({@link #navigate}, {@link #$}, {@link #$view},
- * {@link #test}) automatically call {@link #activate()} before executing,
+ * All DSL methods ({@link #navigate}, {@link #find(Class)},
+ * {@link #findView(Class)}, {@link #test}) automatically call
+ * {@link #activate()} before executing,
  * which transparently switches the thread-local Vaadin state and security
  * context to this window's user.
  * <p>
@@ -48,7 +48,7 @@ import com.vaadin.flow.server.VaadinSession;
  * <pre>
  * window1.navigate(ViewA.class);
  * window2.navigate(ViewB.class); // auto-switches to window2's user
- * window1.$(Button.class).first(); // auto-switches back to window1's user
+ * window1.find(Button.class).first(); // auto-switches back to window1's user
  * </pre>
  *
  * @see BrowserlessUserContext#newWindow()
@@ -125,8 +125,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      */
     public <T extends Component> T navigate(Class<T> navigationTarget) {
         activate();
-        ui.navigate(navigationTarget);
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(ui, navigationTarget);
     }
 
     /**
@@ -141,8 +140,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
             Class<T> navigationTarget, C parameter) {
         activate();
-        ui.navigate(navigationTarget, parameter);
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(ui, navigationTarget, parameter);
     }
 
     /**
@@ -156,8 +154,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <T extends Component> T navigate(Class<T> navigationTarget,
             Map<String, String> parameters) {
         activate();
-        ui.navigate(navigationTarget, new RouteParameters(parameters));
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(ui, navigationTarget, parameters);
     }
 
     /**
@@ -172,8 +169,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <T extends Component> T navigate(String location,
             Class<T> expectedTarget) {
         activate();
-        ui.navigate(location);
-        return validateNavigationTarget(expectedTarget);
+        return BrowserlessDSL.navigate(ui, location, expectedTarget);
     }
 
     /**
@@ -184,10 +180,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * @param <T>           the component type
      * @return a query object
      */
-    public <T extends Component> ComponentQuery<T> $(
+    public <T extends Component> ComponentQuery<T> find(
             Class<T> componentType) {
         activate();
-        return new ComponentQuery<>(componentType);
+        return BrowserlessDSL.find(ui, componentType);
     }
 
     /**
@@ -199,10 +195,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * @param <T>           the component type
      * @return a query object
      */
-    public <T extends Component> ComponentQuery<T> $(
+    public <T extends Component> ComponentQuery<T> find(
             Class<T> componentType, Component fromThis) {
         activate();
-        return new ComponentQuery<>(componentType).from(fromThis);
+        return BrowserlessDSL.find(ui, componentType, fromThis);
     }
 
     /**
@@ -213,37 +209,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * @param <T>           the component type
      * @return a query object
      */
-    public <T extends Component> ComponentQuery<T> $view(
+    public <T extends Component> ComponentQuery<T> findView(
             Class<T> componentType) {
         activate();
-        Component viewComponent = getCurrentView().getElement().getComponent()
-                .orElseThrow(() -> new AssertionError(
-                        "Cannot get Component instance for current view"));
-        return new ComponentQuery<>(componentType).from(viewComponent);
-    }
-
-    /**
-     * Alias for {@link #$(Class)} — Java-idiomatic name.
-     */
-    public <T extends Component> ComponentQuery<T> get(
-            Class<T> componentType) {
-        return $(componentType);
-    }
-
-    /**
-     * Alias for {@link #$(Class, Component)} — Java-idiomatic name.
-     */
-    public <T extends Component> ComponentQuery<T> get(
-            Class<T> componentType, Component fromThis) {
-        return $(componentType, fromThis);
-    }
-
-    /**
-     * Alias for {@link #$view(Class)} — Java-idiomatic name.
-     */
-    public <T extends Component> ComponentQuery<T> getView(
-            Class<T> componentType) {
-        return $view(componentType);
+        return BrowserlessDSL.findView(ui, componentType);
     }
 
     /**
@@ -270,7 +239,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      */
     public HasElement getCurrentView() {
         activate();
-        return ui.getInternals().getActiveRouterTargetsChain().get(0);
+        return BrowserlessDSL.getCurrentView(ui);
     }
 
     /**
@@ -278,7 +247,19 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      */
     public void roundTrip() {
         activate();
-        BaseBrowserlessTest.roundTrip();
+        BrowserlessDSL.roundTrip(ui);
+    }
+
+    /**
+     * Simulates a keyboard shortcut performed on the browser.
+     *
+     * @param key       primary key of the shortcut. This must not be a
+     *                  {@link KeyModifier}.
+     * @param modifiers key modifiers. Can be empty.
+     */
+    public void fireShortcut(Key key, KeyModifier... modifiers) {
+        activate();
+        BrowserlessDSL.fireShortcut(ui, key, modifiers);
     }
 
     /**
@@ -379,22 +360,6 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             MockVaadin.closeCurrentUI(true);
             ui = null;
         }
-    }
-
-    private <T extends Component> T validateNavigationTarget(
-            Class<T> navigationTarget) {
-        HasElement currentView = getCurrentView();
-        if (!navigationTarget.isAssignableFrom(currentView.getClass())) {
-            if (currentView instanceof MockInternalSeverError) {
-                System.err.println(
-                        currentView.getElement().getProperty("stackTrace"));
-            }
-            throw new IllegalArgumentException(
-                    "Navigation resulted in unexpected class "
-                            + currentView.getClass().getName()
-                            + " instead of " + navigationTarget.getName());
-        }
-        return navigationTarget.cast(currentView);
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.SessionObjects;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * User-level context for multi-user browserless testing.
+ * <p>
+ * Represents a single logical user with their own
+ * {@link VaadinSession}, HTTP request, and response. Each user context
+ * can have multiple windows (UI instances) via {@link #newWindow()}.
+ * <p>
+ * Security context (if a {@link SecurityContextHandler} is configured on
+ * the parent {@link BrowserlessApplicationContext}) is automatically
+ * captured when this context is created and saved/restored when switching
+ * between users' windows.
+ *
+ * @see BrowserlessApplicationContext#newUser()
+ * @see BrowserlessUIContext
+ */
+public class BrowserlessUserContext implements AutoCloseable {
+
+    private final BrowserlessApplicationContext<?> app;
+    private final VaadinSession session;
+    private final VaadinRequest request;
+    private final VaadinResponse response;
+    private final List<BrowserlessUIContext> windows = new ArrayList<>();
+    private Object securitySnapshot;
+    private boolean closed;
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    BrowserlessUserContext(BrowserlessApplicationContext<?> app,
+            Object credentials) {
+        this.app = app;
+
+        // Save current thread-local state so we can restore it after setup
+        VaadinService previousService = VaadinService.getCurrent();
+        VaadinSession previousSession = VaadinSession.getCurrent();
+        VaadinRequest previousRequest = VaadinRequest.getCurrent();
+        VaadinResponse previousResponse = VaadinResponse.getCurrent();
+        SecurityContextHandler handler = (SecurityContextHandler) app.getSecurityContextHandler();
+        Object previousSecuritySnapshot = handler != null
+                ? handler.saveContext() : null;
+
+        try {
+            // Set service as current (needed for session creation)
+            VaadinService.setCurrent(app.getService());
+
+            // Create session objects without setting thread-locals
+            SessionObjects objs = MockVaadin
+                    .createSessionObjects(app.getService());
+            this.session = objs.getSession();
+            this.request = objs.getRequest();
+            this.response = objs.getResponse();
+
+            // Install thread-locals temporarily for session init listeners
+            VaadinSession.setCurrent(session);
+            CurrentInstance.set(VaadinRequest.class, request);
+            CurrentInstance.set(VaadinResponse.class, response);
+
+            // Fire session init listeners
+            MockVaadin.fireSessionInit(app.getService(), session, request);
+
+            // Set up authentication for this user
+            if (handler != null) {
+                // Start with a clean security context for this user
+                handler.clearContext();
+                if (credentials != null) {
+                    handler.setupAuthentication(credentials);
+                }
+                // Capture as this user's initial security snapshot
+                securitySnapshot = handler.saveContext();
+            }
+        } finally {
+            // Restore previous thread-local state
+            VaadinService.setCurrent(previousService);
+            VaadinSession.setCurrent(previousSession);
+            CurrentInstance.set(VaadinRequest.class, previousRequest);
+            CurrentInstance.set(VaadinResponse.class, previousResponse);
+            // Restore previous security context
+            if (handler != null) {
+                if (previousSecuritySnapshot != null) {
+                    handler.restoreContext(previousSecuritySnapshot);
+                } else {
+                    handler.clearContext();
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a new window (UI instance) for this user.
+     * <p>
+     * The window is automatically activated (thread-locals set) and a new
+     * UI is created. If a route target for {@code ""} is registered, the UI
+     * will navigate to it.
+     *
+     * @return the new UI context
+     */
+    public BrowserlessUIContext newWindow() {
+        checkNotClosed();
+        var window = new BrowserlessUIContext(this);
+        windows.add(window);
+        return window;
+    }
+
+    /**
+     * Closes this user context and all its windows.
+     * <p>
+     * Destroys the Vaadin session and clears associated state.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        for (var window : windows) {
+            window.close();
+        }
+        windows.clear();
+
+        // Destroy session
+        VaadinService.setCurrent(app.getService());
+        VaadinSession.setCurrent(session);
+        app.getService().fireSessionDestroy(session);
+        VaadinSession.setCurrent(null);
+        VaadinService.setCurrent(null);
+    }
+
+    /**
+     * Returns the Vaadin session associated with this user.
+     *
+     * @return the Vaadin session
+     */
+    public VaadinSession getSession() {
+        return session;
+    }
+
+    BrowserlessApplicationContext<?> getApp() {
+        return app;
+    }
+
+    VaadinRequest getRequest() {
+        return request;
+    }
+
+    VaadinResponse getResponse() {
+        return response;
+    }
+
+    /**
+     * Saves the current thread's security context into this user's
+     * snapshot. Called automatically by {@link BrowserlessUIContext#activate()}
+     * when switching away from this user.
+     */
+    void saveSecurityContext() {
+        SecurityContextHandler<?> handler = app.getSecurityContextHandler();
+        if (handler != null) {
+            securitySnapshot = handler.saveContext();
+        }
+    }
+
+    /**
+     * Restores this user's security context onto the current thread.
+     * Called automatically by {@link BrowserlessUIContext#activate()}
+     * when switching to this user.
+     */
+    void restoreSecurityContext() {
+        SecurityContextHandler<?> handler = app.getSecurityContextHandler();
+        if (handler != null) {
+            if (securitySnapshot != null) {
+                handler.restoreContext(securitySnapshot);
+            } else {
+                handler.clearContext();
+            }
+        }
+    }
+
+    private void checkNotClosed() {
+        if (closed) {
+            throw new IllegalStateException(
+                    "BrowserlessUserContext is already closed");
+        }
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -29,14 +29,14 @@ import com.vaadin.flow.server.VaadinSession;
 /**
  * User-level context for multi-user browserless testing.
  * <p>
- * Represents a single logical user with their own
- * {@link VaadinSession}, HTTP request, and response. Each user context
- * can have multiple windows (UI instances) via {@link #newWindow()}.
+ * Represents a single logical user with their own {@link VaadinSession}, HTTP
+ * request, and response. Each user context can have multiple windows (UI
+ * instances) via {@link #newWindow()}.
  * <p>
- * Security context (if a {@link SecurityContextHandler} is configured on
- * the parent {@link BrowserlessApplicationContext}) is automatically
- * captured when this context is created and saved/restored when switching
- * between users' windows.
+ * Security context (if a {@link SecurityContextHandler} is configured on the
+ * parent {@link BrowserlessApplicationContext}) is automatically captured when
+ * this context is created and saved/restored when switching between users'
+ * windows.
  *
  * @see BrowserlessApplicationContext#newUser()
  * @see BrowserlessUIContext
@@ -61,9 +61,11 @@ public class BrowserlessUserContext implements AutoCloseable {
         VaadinSession previousSession = VaadinSession.getCurrent();
         VaadinRequest previousRequest = VaadinRequest.getCurrent();
         VaadinResponse previousResponse = VaadinResponse.getCurrent();
-        SecurityContextHandler handler = (SecurityContextHandler) app.getSecurityContextHandler();
+        SecurityContextHandler handler = (SecurityContextHandler) app
+                .getSecurityContextHandler();
         Object previousSecuritySnapshot = handler != null
-                ? handler.saveContext() : null;
+                ? handler.saveContext()
+                : null;
 
         try {
             // Set service as current (needed for session creation)
@@ -114,9 +116,9 @@ public class BrowserlessUserContext implements AutoCloseable {
     /**
      * Creates a new window (UI instance) for this user.
      * <p>
-     * The window is automatically activated (thread-locals set) and a new
-     * UI is created. If a route target for {@code ""} is registered, the UI
-     * will navigate to it.
+     * The window is automatically activated (thread-locals set) and a new UI is
+     * created. If a route target for {@code ""} is registered, the UI will
+     * navigate to it.
      *
      * @return the new UI context
      */
@@ -173,9 +175,9 @@ public class BrowserlessUserContext implements AutoCloseable {
     }
 
     /**
-     * Saves the current thread's security context into this user's
-     * snapshot. Called automatically by {@link BrowserlessUIContext#activate()}
-     * when switching away from this user.
+     * Saves the current thread's security context into this user's snapshot.
+     * Called automatically by {@link BrowserlessUIContext#activate()} when
+     * switching away from this user.
      */
     void saveSecurityContext() {
         SecurityContextHandler<?> handler = app.getSecurityContextHandler();
@@ -185,9 +187,9 @@ public class BrowserlessUserContext implements AutoCloseable {
     }
 
     /**
-     * Restores this user's security context onto the current thread.
-     * Called automatically by {@link BrowserlessUIContext#activate()}
-     * when switching to this user.
+     * Restores this user's security context onto the current thread. Called
+     * automatically by {@link BrowserlessUIContext#activate()} when switching
+     * to this user.
      */
     void restoreSecurityContext() {
         SecurityContextHandler<?> handler = app.getSecurityContextHandler();

--- a/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
+++ b/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+/**
+ * Abstracts per-user security context management for multi-user testing.
+ * <p>
+ * Framework modules (Spring, Quarkus) provide implementations that bridge
+ * their security infrastructure (e.g. Spring's {@code SecurityContextHolder},
+ * Quarkus's {@code CurrentIdentityAssociation}) with the browserless
+ * multi-user context hierarchy.
+ * <p>
+ * Implementations must be thread-safe with respect to the thread-local
+ * security state they manage.
+ *
+ * @see BrowserlessApplicationContext.Builder#withSecurityContextHandler(SecurityContextHandler)
+ */
+public interface SecurityContextHandler<C> {
+
+    /**
+     * Sets up authentication for a new user from the given credentials.
+     * <p>
+     * The type parameter {@code C} is determined by the framework
+     * implementation. For example, Spring uses
+     * {@code org.springframework.security.core.Authentication} and Quarkus
+     * uses {@code io.quarkus.security.identity.SecurityIdentity}.
+     *
+     * @param credentials framework-specific credentials object
+     */
+    void setupAuthentication(C credentials);
+
+    /**
+     * Captures the current thread's security context as an opaque snapshot.
+     * <p>
+     * Called automatically when switching away from a user context to
+     * preserve its security state.
+     *
+     * @return an opaque snapshot of the current security context, or
+     *         {@code null} if no security context is active
+     */
+    Object saveContext();
+
+    /**
+     * Restores a previously saved security context snapshot onto the
+     * current thread.
+     *
+     * @param snapshot a snapshot previously returned by {@link #saveContext()},
+     *                 or {@code null} to clear the context
+     */
+    void restoreContext(Object snapshot);
+
+    /**
+     * Clears the security context from the current thread.
+     */
+    void clearContext();
+}

--- a/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
+++ b/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
@@ -18,13 +18,13 @@ package com.vaadin.browserless;
 /**
  * Abstracts per-user security context management for multi-user testing.
  * <p>
- * Framework modules (Spring, Quarkus) provide implementations that bridge
- * their security infrastructure (e.g. Spring's {@code SecurityContextHolder},
- * Quarkus's {@code CurrentIdentityAssociation}) with the browserless
- * multi-user context hierarchy.
+ * Framework modules (Spring, Quarkus) provide implementations that bridge their
+ * security infrastructure (e.g. Spring's {@code SecurityContextHolder},
+ * Quarkus's {@code CurrentIdentityAssociation}) with the browserless multi-user
+ * context hierarchy.
  * <p>
- * Implementations must be thread-safe with respect to the thread-local
- * security state they manage.
+ * Implementations must be thread-safe with respect to the thread-local security
+ * state they manage.
  *
  * @see BrowserlessApplicationContext.Builder#withSecurityContextHandler(SecurityContextHandler)
  */
@@ -35,18 +35,19 @@ public interface SecurityContextHandler<C> {
      * <p>
      * The type parameter {@code C} is determined by the framework
      * implementation. For example, Spring uses
-     * {@code org.springframework.security.core.Authentication} and Quarkus
-     * uses {@code io.quarkus.security.identity.SecurityIdentity}.
+     * {@code org.springframework.security.core.Authentication} and Quarkus uses
+     * {@code io.quarkus.security.identity.SecurityIdentity}.
      *
-     * @param credentials framework-specific credentials object
+     * @param credentials
+     *            framework-specific credentials object
      */
     void setupAuthentication(C credentials);
 
     /**
      * Captures the current thread's security context as an opaque snapshot.
      * <p>
-     * Called automatically when switching away from a user context to
-     * preserve its security state.
+     * Called automatically when switching away from a user context to preserve
+     * its security state.
      *
      * @return an opaque snapshot of the current security context, or
      *         {@code null} if no security context is active
@@ -54,11 +55,12 @@ public interface SecurityContextHandler<C> {
     Object saveContext();
 
     /**
-     * Restores a previously saved security context snapshot onto the
-     * current thread.
+     * Restores a previously saved security context snapshot onto the current
+     * thread.
      *
-     * @param snapshot a snapshot previously returned by {@link #saveContext()},
-     *                 or {@code null} to clear the context
+     * @param snapshot
+     *            a snapshot previously returned by {@link #saveContext()}, or
+     *            {@code null} to clear the context
      */
     void restoreContext(Object snapshot);
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -50,6 +50,18 @@ import com.vaadin.browserless.mocks.createVaadinServletRequest
 import com.vaadin.browserless.mocks.createVaadinServletResponse
 import com.vaadin.browserless.mocks.serviceSafe
 
+/**
+ * Holds the objects created during session initialization, before they are
+ * installed as thread-locals. Used by [MockVaadin.createSessionObjects] to
+ * allow callers (e.g. multi-user context) to manage thread-locals themselves.
+ */
+data class SessionObjects(
+    val session: VaadinSession,
+    val request: VaadinRequest,
+    val response: VaadinResponse,
+    val httpSession: MockHttpSession
+)
+
 object MockVaadin {
     // prevent GC on Vaadin Session and Vaadin UI as they are only soft-referenced from the Vaadin itself.
     // use ThreadLocals so that multiple threads may initialize fresh Vaadin instances at the same time.
@@ -113,6 +125,24 @@ object MockVaadin {
     fun setup(uiFactory: UIFactory = UIFactory { MockedUI() }, servlet: VaadinServlet,
               lookupServices: Set<Class<*>> = emptySet()
     ) {
+        val service = setupServlet(servlet, lookupServices)
+        VaadinService.setCurrent(service)
+
+        // init Vaadin Session
+        createSession(servlet.servletContext, uiFactory)
+    }
+
+    /**
+     * Initializes the given [servlet] and its service, but does NOT create a
+     * session, UI, or set any thread-locals. Call this when you need to share
+     * a single service across multiple independent sessions (multi-user testing).
+     *
+     * @return the initialized [VaadinServletService]
+     */
+    @JvmStatic
+    fun setupServlet(servlet: VaadinServlet,
+                     lookupServices: Set<Class<*>> = emptySet()
+    ): VaadinServletService {
         if (!servlet.isInitialized) {
             val ctx: ServletContext = MockVaadinHelper.createMockContext(lookupServices)
             val config = MockServletConfig(ctx)
@@ -121,16 +151,14 @@ object MockVaadin {
         }
         val service: VaadinServletService = checkNotNull(servlet.serviceSafe)
         check(service.router != null) { "$servlet failed to call VaadinServletService.init() in createServletService()" }
-        VaadinService.setCurrent(service)
-
-        // init Vaadin Session
-        createSession(servlet.servletContext, uiFactory)
+        return service
     }
 
     /**
      * Properly closes the current UI and fire the detach event on it.
      * Does nothing if there is no current UI.
      */
+    @JvmStatic
     fun closeCurrentUI(fireUIDetach: Boolean) {
         val ui: UI = UI.getCurrent() ?: return
         lastNavigation.set(ui.internals.activeViewLocation)
@@ -202,50 +230,67 @@ object MockVaadin {
      */
     var mockRequestFactory: (MockHttpSession) -> MockRequest = { MockRequest(it) }
 
-    private fun createSession(ctx: ServletContext, uiFactory: UIFactory) {
-        val service: VaadinServletService = checkNotNull(VaadinService.getCurrent()) as VaadinServletService
-        val httpSession: MockHttpSession = MockHttpSession.create(ctx)
+    /**
+     * Creates a new session, request and response for the given [service],
+     * but does NOT set any thread-locals or create a UI.
+     *
+     * Use this when you need to create multiple independent sessions for
+     * multi-user testing. The caller is responsible for setting thread-locals
+     * (via [VaadinSession.setCurrent], [CurrentInstance], etc.) and for
+     * creating the UI via [createUI].
+     *
+     * @param service the initialized Vaadin service (from [setupServlet])
+     * @return the created session objects
+     */
+    @JvmStatic
+    fun createSessionObjects(service: VaadinServletService): SessionObjects {
+        val httpSession: MockHttpSession = MockHttpSession.create(service.servlet.servletContext)
 
         // init Vaadin Request
         val mockRequest = mockRequestFactory(httpSession)
-        // so that session.browser.updateRequestDetails() also creates browserDetails
         mockRequest.headers["User-Agent"] = listOf(userAgent)
         service.context.getAttribute(Lookup::class.java)
                 .lookup(MockRequestCustomizer::class.java)?.apply(mockRequest)
         val request = createVaadinServletRequest(mockRequest, service)
-        strongRefReq.set(request)
-        CurrentInstance.set(VaadinRequest::class.java, request)
 
         // init Session.
-        // Use the underlying Service to create the Vaadin Session; however
-        // you MUST mock certain things in order for browserless testing to work.
-        // See MockSession for more details. By default the service is a MockService
-        // which creates MockSession.
-        val session: VaadinSession = service._createVaadinSession(VaadinRequest.getCurrent())
+        val session: VaadinSession = service._createVaadinSession(request)
         httpSession.setAttribute(service.serviceName + ".lock", ReentrantLock().apply { lock() })
         httpSession.setAttribute(VaadinSession::class.java.name + "." + service.serviceName, session)
         session.refreshTransients(WrappedHttpSession(httpSession), service)
         check(session.lockInstance != null) { "$session created from $service has null lock. See the MockSession class on how to mock locks properly" }
         check((session.lockInstance as ReentrantLock).isLocked) { "$session created from $service: lock must be locked!" }
 
-        VaadinSession.setCurrent(session)
-        strongRefSession.set(session)
         session.browser = WebBrowser(request)
         checkNotNull(session.browser.browserApplication) { "The WebBrowser has not been mocked properly" }
 
         // init Vaadin Response
         val response = createVaadinServletResponse(MockResponse(), service)
-        strongRefRes.set(response)
-        CurrentInstance.set(VaadinResponse::class.java, response)
 
-        // fire session init listeners
-        service.fireSessionInitListeners(SessionInitEvent(service, session, request))
-
-        // create UI
-        createUI(uiFactory, session)
+        return SessionObjects(session, request, response, httpSession)
     }
 
-    internal fun createUI(uiFactory: UIFactory, session: VaadinSession) {
+    private fun createSession(ctx: ServletContext, uiFactory: UIFactory) {
+        val service: VaadinServletService = checkNotNull(VaadinService.getCurrent()) as VaadinServletService
+        val objs = createSessionObjects(service)
+
+        // install thread-locals
+        strongRefReq.set(objs.request)
+        CurrentInstance.set(VaadinRequest::class.java, objs.request)
+        VaadinSession.setCurrent(objs.session)
+        strongRefSession.set(objs.session)
+        strongRefRes.set(objs.response)
+        CurrentInstance.set(VaadinResponse::class.java, objs.response)
+
+        // fire session init listeners
+        service.fireSessionInitListeners(SessionInitEvent(service, objs.session, objs.request))
+
+        // create UI
+        createUI(uiFactory, objs.session)
+    }
+
+    @JvmStatic
+    fun createUI(uiFactory: UIFactory, session: VaadinSession) {
         val request: VaadinRequest = checkNotNull(VaadinRequest.getCurrent())
         val ui: UI = uiFactory()
         require(ui.session == null) {
@@ -403,6 +448,34 @@ object MockVaadin {
             createSession(mockSession.servletContext, uiFactory)
         }
     }
+
+    /**
+     * Fires session init listeners on the given service.
+     * Java-friendly static wrapper for the internal extension function.
+     */
+    @JvmStatic
+    fun fireSessionInit(service: VaadinService, session: VaadinSession, request: VaadinRequest) {
+        service.fireSessionInitListeners(SessionInitEvent(service, session, request))
+    }
+
+    /**
+     * Fires service destroy listeners on the given service.
+     * Java-friendly static wrapper for the internal extension function.
+     */
+    @JvmStatic
+    fun fireServiceDestroy(service: VaadinService) {
+        service.fireServiceDestroyListeners(ServiceDestroyEvent(service))
+    }
+
+    /**
+     * Clears the current UI from thread-locals without firing detach events.
+     * Useful for multi-user context where UIs are managed independently.
+     */
+    @JvmStatic
+    fun clearCurrentUI() {
+        UI.setCurrent(null)
+        strongRefUI.remove()
+    }
 }
 
 private val _VaadinService_sessionInitListeners: Field by lazy(LazyThreadSafetyMode.PUBLICATION) {
@@ -411,7 +484,7 @@ private val _VaadinService_sessionInitListeners: Field by lazy(LazyThreadSafetyM
     field
 }
 
-private fun VaadinService.fireSessionInitListeners(event: SessionInitEvent) {
+internal fun VaadinService.fireSessionInitListeners(event: SessionInitEvent) {
     @Suppress("UNCHECKED_CAST")
     val sessionInitListeners: Collection<SessionInitListener> =
             _VaadinService_sessionInitListeners.get(this) as Collection<SessionInitListener>
@@ -426,7 +499,7 @@ private val _VaadinService_sessionDestroyListeners: Field by lazy(LazyThreadSafe
     field
 }
 
-private fun VaadinService.fireServiceDestroyListeners(event: ServiceDestroyEvent) {
+internal fun VaadinService.fireServiceDestroyListeners(event: ServiceDestroyEvent) {
     @Suppress("UNCHECKED_CAST")
     val listeners: Collection<ServiceDestroyListener> =
             _VaadinService_sessionDestroyListeners.get(this) as Collection<ServiceDestroyListener>
@@ -435,13 +508,43 @@ private fun VaadinService.fireServiceDestroyListeners(event: ServiceDestroyEvent
     }
 }
 
-private class MockPage(ui: UI, private val uiFactory: UIFactory, private val session: VaadinSession) : Page(ui) {
+internal class MockPage(ui: UI, private val uiFactory: UIFactory, private val session: VaadinSession) : Page(ui) {
+
+    private companion object {
+        private val SELF_NAMES = setOf("_self", "_parent", "_top", "")
+    }
+
+    private val navigations: MutableMap<String, MutableList<String>> = mutableMapOf()
+
+    val lastExternalNavigationURL: String?
+        get() = navigations["_self"]?.lastOrNull()
+
+    fun getExternalNavigationURL(windowName: String): String? =
+        navigations[normalizeWindowName(windowName)]?.lastOrNull()
+
+    val openedWindows: Map<String, List<String>>
+        get() = navigations.filterKeys { it != "_self" }
+            .mapValues { (_, urls) -> urls.toList() }
+
+    override fun open(url: String, windowName: String) {
+        val normalized = normalizeWindowName(windowName)
+        if (normalized == "_blank") {
+            navigations.getOrPut(normalized) { mutableListOf() }.add(url)
+        } else {
+            navigations[normalized] = mutableListOf(url)
+        }
+        super.open(url, windowName)
+    }
+
     override fun reload() {
         // recreate the UI on reload(), to simulate browser's F5
         super.reload()
         MockVaadin.closeCurrentUI(true)
         MockVaadin.createUI(uiFactory, session)
     }
+
+    private fun normalizeWindowName(windowName: String?): String =
+        if (windowName == null || windowName in SELF_NAMES) "_self" else windowName
 }
 
 fun interface MockRequestCustomizer {

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
@@ -217,9 +217,17 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
     var userPrincipalInt: Principal? = null
 
     /**
-     * Set via [userPrincipalInt].
+     * Optional provider for [getUserPrincipal]. When set, takes precedence over
+     * [userPrincipalInt], allowing the principal to be resolved lazily at
+     * call time (e.g. from a security context that is populated after setup).
      */
-    override fun getUserPrincipal(): Principal? = userPrincipalInt
+    var userPrincipalProvider: (() -> Principal?)? = null
+
+    /**
+     * Returns the principal from [userPrincipalProvider] if set, otherwise
+     * falls back to [userPrincipalInt].
+     */
+    override fun getUserPrincipal(): Principal? = userPrincipalProvider?.invoke() ?: userPrincipalInt
 
     override fun getReader(): BufferedReader {
         throw UnsupportedOperationException("not implemented")

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
@@ -175,6 +175,14 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
     var isUserInRole: (Principal, role: String) -> Boolean = { _, _ -> false }
 
     /**
+     * Sets the user-in-role checker using a [java.util.function.BiPredicate].
+     * Java-friendly alternative to setting [isUserInRole] directly.
+     */
+    fun roleChecker(checker: java.util.function.BiPredicate<Principal, String>) {
+        isUserInRole = { principal, role -> checker.test(principal, role) }
+    }
+
+    /**
      * Set [isUserInRole] to modify the outcome of this function.
      */
     override fun isUserInRole(role: String): Boolean {
@@ -222,6 +230,14 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
      * call time (e.g. from a security context that is populated after setup).
      */
     var userPrincipalProvider: (() -> Principal?)? = null
+
+    /**
+     * Sets the user principal provider using a [java.util.function.Supplier].
+     * Java-friendly alternative to setting [userPrincipalProvider] directly.
+     */
+    fun principalProvider(supplier: java.util.function.Supplier<Principal?>) {
+        userPrincipalProvider = { supplier.get() }
+    }
 
     /**
      * Returns the principal from [userPrincipalProvider] if set, otherwise

--- a/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -89,11 +89,12 @@ public class BrowserlessTestSpringLookupInitializer
     /**
      * Sets the application context to be used by the lookup initializer.
      * <p>
-     * This is used by {@code SpringBrowserlessApplicationContext} to
-     * configure the Spring context for multi-user testing without relying
-     * on the {@link TestExecutionListener} lifecycle.
+     * This is used by {@code SpringBrowserlessApplicationContext} to configure
+     * the Spring context for multi-user testing without relying on the
+     * {@link TestExecutionListener} lifecycle.
      *
-     * @param appCtx the Spring application context
+     * @param appCtx
+     *            the Spring application context
      */
     public static void setApplicationContext(ApplicationContext appCtx) {
         applicationContext.set(appCtx);

--- a/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -48,10 +48,29 @@ public class BrowserlessTestSpringLookupInitializer
     private static final ThreadLocal<ApplicationContext> applicationContext = new ThreadLocal<>();
 
     @Override
-    public void beforeTestMethod(TestContext testContext) throws Exception {
+    public void prepareTestInstance(TestContext testContext) throws Exception {
         // SpringLookup requires a WebApplicationContext. Store current test
         // ApplicationContext so that it can be adapted later on by this
-        // initializer
+        // initializer. This must be done in prepareTestInstance so the
+        // ThreadLocal is populated before any JUnit 5 extension
+        // beforeAll/beforeEach callbacks fire.
+        setApplicationContext(testContext);
+    }
+
+    @Override
+    public void beforeTestMethod(TestContext testContext) throws Exception {
+        // Re-set ThreadLocal per test method: afterTestMethod clears it, so
+        // for @TestInstance(PER_CLASS) (where prepareTestInstance runs only
+        // once) this ensures subsequent methods still see the context.
+        setApplicationContext(testContext);
+    }
+
+    @Override
+    public void afterTestMethod(TestContext testContext) throws Exception {
+        BrowserlessTestSpringLookupInitializer.applicationContext.remove();
+    }
+
+    private void setApplicationContext(TestContext testContext) {
         BrowserlessTestSpringLookupInitializer.applicationContext
                 .set(testContext.getApplicationContext());
         ApplicationContext appCtx = testContext.getApplicationContext();
@@ -65,11 +84,6 @@ public class BrowserlessTestSpringLookupInitializer
                             SpringSecurityRequestCustomizer.class.getName(),
                             new SpringSecurityRequestCustomizer());
         }
-    }
-
-    @Override
-    public void afterTestMethod(TestContext testContext) throws Exception {
-        BrowserlessTestSpringLookupInitializer.applicationContext.remove();
     }
 
     @Override

--- a/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -86,6 +86,27 @@ public class BrowserlessTestSpringLookupInitializer
         }
     }
 
+    /**
+     * Sets the application context to be used by the lookup initializer.
+     * <p>
+     * This is used by {@code SpringBrowserlessApplicationContext} to
+     * configure the Spring context for multi-user testing without relying
+     * on the {@link TestExecutionListener} lifecycle.
+     *
+     * @param appCtx the Spring application context
+     */
+    public static void setApplicationContext(ApplicationContext appCtx) {
+        applicationContext.set(appCtx);
+        if (appCtx instanceof ConfigurableApplicationContext
+                && !appCtx.containsBean(
+                        SpringSecurityRequestCustomizer.class.getName())) {
+            ((ConfigurableApplicationContext) appCtx).getBeanFactory()
+                    .registerSingleton(
+                            SpringSecurityRequestCustomizer.class.getName(),
+                            new SpringSecurityRequestCustomizer());
+        }
+    }
+
     @Override
     public void initialize(VaadinContext context,
             Map<Class<?>, Collection<Class<?>>> services,

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -30,8 +30,8 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  * Factory for creating a Spring-integrated
  * {@link BrowserlessApplicationContext}.
  * <p>
- * Configures the context with Spring-aware servlet, security context
- * handling, and lookup services.
+ * Configures the context with Spring-aware servlet, security context handling,
+ * and lookup services.
  *
  * <pre>
  * var app = SpringBrowserlessApplicationContext.create(routes, springCtx);
@@ -51,8 +51,10 @@ public final class SpringBrowserlessApplicationContext {
     /**
      * Creates a Spring-integrated application context.
      *
-     * @param routes the discovered routes
-     * @param applicationContext the Spring application context
+     * @param routes
+     *            the discovered routes
+     * @param applicationContext
+     *            the Spring application context
      * @return a new application context configured for Spring
      */
     public static BrowserlessApplicationContext<Authentication> create(
@@ -61,12 +63,14 @@ public final class SpringBrowserlessApplicationContext {
     }
 
     /**
-     * Creates a Spring-integrated application context with a custom UI
-     * factory.
+     * Creates a Spring-integrated application context with a custom UI factory.
      *
-     * @param routes the discovered routes
-     * @param applicationContext the Spring application context
-     * @param uiFactory the UI factory
+     * @param routes
+     *            the discovered routes
+     * @param applicationContext
+     *            the Spring application context
+     * @param uiFactory
+     *            the UI factory
      * @return a new application context configured for Spring
      */
     public static BrowserlessApplicationContext<Authentication> create(
@@ -76,16 +80,14 @@ public final class SpringBrowserlessApplicationContext {
         BrowserlessTestSpringLookupInitializer
                 .setApplicationContext(applicationContext);
 
-        return BrowserlessApplicationContext
-                .<Authentication>builder(routes)
+        return BrowserlessApplicationContext.<Authentication> builder(routes)
                 .withServletFactory(r -> new MockSpringServlet(r,
                         applicationContext, uiFactory))
                 .withUIFactory(uiFactory)
-                .withLookupServices(Set.of(
-                        BrowserlessTestSpringLookupInitializer.class,
-                        SpringSecurityRequestCustomizer.class))
-                .withSecurityContextHandler(
-                        new SpringSecurityContextHandler())
+                .withLookupServices(
+                        Set.of(BrowserlessTestSpringLookupInitializer.class,
+                                SpringSecurityRequestCustomizer.class))
+                .withSecurityContextHandler(new SpringSecurityContextHandler())
                 .build();
     }
 }

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Set;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.core.Authentication;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.UIFactory;
+import com.vaadin.browserless.mocks.MockSpringServlet;
+import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
+
+/**
+ * Factory for creating a Spring-integrated
+ * {@link BrowserlessApplicationContext}.
+ * <p>
+ * Configures the context with Spring-aware servlet, security context
+ * handling, and lookup services.
+ *
+ * <pre>
+ * var app = SpringBrowserlessApplicationContext.create(routes, springCtx);
+ * var admin = app.newUser(adminAuth);
+ * var window = admin.newWindow();
+ * window.navigate(ProtectedView.class);
+ * </pre>
+ *
+ * @see BrowserlessApplicationContext
+ * @see SpringSecurityContextHandler
+ */
+public final class SpringBrowserlessApplicationContext {
+
+    private SpringBrowserlessApplicationContext() {
+    }
+
+    /**
+     * Creates a Spring-integrated application context.
+     *
+     * @param routes the discovered routes
+     * @param applicationContext the Spring application context
+     * @return a new application context configured for Spring
+     */
+    public static BrowserlessApplicationContext<Authentication> create(
+            Routes routes, ApplicationContext applicationContext) {
+        return create(routes, applicationContext, () -> new MockedUI());
+    }
+
+    /**
+     * Creates a Spring-integrated application context with a custom UI
+     * factory.
+     *
+     * @param routes the discovered routes
+     * @param applicationContext the Spring application context
+     * @param uiFactory the UI factory
+     * @return a new application context configured for Spring
+     */
+    public static BrowserlessApplicationContext<Authentication> create(
+            Routes routes, ApplicationContext applicationContext,
+            UIFactory uiFactory) {
+        // Set the Spring application context for the lookup initializer
+        BrowserlessTestSpringLookupInitializer
+                .setApplicationContext(applicationContext);
+
+        return BrowserlessApplicationContext
+                .<Authentication>builder(routes)
+                .withServletFactory(r -> new MockSpringServlet(r,
+                        applicationContext, uiFactory))
+                .withUIFactory(uiFactory)
+                .withLookupServices(Set.of(
+                        BrowserlessTestSpringLookupInitializer.class,
+                        SpringSecurityRequestCustomizer.class))
+                .withSecurityContextHandler(
+                        new SpringSecurityContextHandler())
+                .build();
+    }
+}

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
@@ -17,6 +17,7 @@ package com.vaadin.browserless;
 
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,11 +51,12 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  * class ViewTest extends SpringBrowserlessTest {
  *
  * }
+ *
  * &#64;Configuration
  * class ViewTestConfig {
  *     &#64;Bean
  *     MyService myService() {
- *         return new my MockMyService();
+ *         return new MockMyService();
  *     }
  * }
  * }
@@ -62,10 +64,16 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  */
 @ExtendWith({ SpringExtension.class })
 @TestExecutionListeners(listeners = BrowserlessTestSpringLookupInitializer.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-public abstract class SpringBrowserlessTest extends BrowserlessTest {
+public abstract class SpringBrowserlessTest extends BaseBrowserlessTest
+        implements TesterWrappers {
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Override
+    protected final String testingEngine() {
+        return "JUnit 6";
+    }
 
     @Override
     protected Set<Class<?>> lookupServices() {
@@ -73,11 +81,25 @@ public abstract class SpringBrowserlessTest extends BrowserlessTest {
                 SpringSecurityRequestCustomizer.class);
     }
 
+    /**
+     * Sets up the mock Vaadin Spring environment before each test. Runs as a
+     * {@code @BeforeEach} method so that it fires <em>after</em> all JUnit 5
+     * extension {@code beforeEach} callbacks — in particular after
+     * {@code SpringExtension.beforeEach()}, which populates the Spring Security
+     * context for annotations such as {@code @WithMockUser}.
+     */
     @BeforeEach
+    @Override
     protected void initVaadinEnvironment() {
         scanTesters();
         MockSpringServlet servlet = new MockSpringServlet(discoverRoutes(),
                 applicationContext, MockedUI::new);
         MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+    }
+
+    @AfterEach
+    @Override
+    protected void cleanVaadinEnvironment() {
+        super.cleanVaadinEnvironment();
     }
 }

--- a/spring/src/main/java/com/vaadin/browserless/SpringSecurityContextHandler.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringSecurityContextHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Spring Security implementation of {@link SecurityContextHandler}.
+ * <p>
+ * Manages the thread-local {@link SecurityContext} via
+ * {@link SecurityContextHolder} for multi-user test isolation.
+ * <p>
+ * The {@link #setupAuthentication(Object)} method expects an
+ * {@link Authentication} instance as the credentials parameter.
+ *
+ * @see SecurityContextHandler
+ * @see SpringBrowserlessApplicationContext
+ */
+public class SpringSecurityContextHandler
+        implements SecurityContextHandler<Authentication> {
+
+    @Override
+    public void setupAuthentication(Authentication credentials) {
+        if (credentials != null) {
+            SecurityContext ctx = SecurityContextHolder.getContext();
+            if (ctx == null) {
+                ctx = SecurityContextHolder.createEmptyContext();
+                SecurityContextHolder.setContext(ctx);
+            }
+            ctx.setAuthentication(credentials);
+        }
+    }
+
+    @Override
+    public Object saveContext() {
+        SecurityContext current = SecurityContextHolder.getContext();
+        SecurityContext copy = SecurityContextHolder.createEmptyContext();
+        copy.setAuthentication(current.getAuthentication());
+        return copy;
+    }
+
+    @Override
+    public void restoreContext(Object snapshot) {
+        if (snapshot instanceof SecurityContext ctx) {
+            SecurityContextHolder.setContext(ctx);
+        } else {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Override
+    public void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
+++ b/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
@@ -129,24 +129,21 @@ public class MockSpringServlet extends SpringServlet {
             HttpServletRequest wrappedRequest = SpringSecuritySupport.springSecurityRequestWrapper
                     .apply(request);
             if (wrappedRequest instanceof MockRequest) {
-                // Spring Security Web not on classpath
-                applySimplifiedSpringSecurity(request);
+                // Spring Security Web not on classpath: read
+                // SecurityContextHolder lazily
+                request.setUserPrincipalProvider(
+                        SpringSecuritySupport::currentPrincipal);
+                request.setUserInRole(SpringSecuritySupport::isGranted);
             } else {
-                request.setUserPrincipalInt(wrappedRequest.getUserPrincipal());
+                // Spring Security Web on classpath: delegate to
+                // SecurityContextHolderAwareRequestWrapper lazily so that
+                // security context populated after setup (e.g. @WithMockUser)
+                // is picked up at test execution time
+                request.setUserPrincipalProvider(
+                        wrappedRequest::getUserPrincipal);
                 request.setUserInRole(
                         (principal, role) -> wrappedRequest.isUserInRole(role));
             }
-        }
-    }
-
-    private static void applySimplifiedSpringSecurity(MockRequest request) {
-        Authentication authentication = SpringSecuritySupport.authentication();
-        if (authentication == null || authentication.getPrincipal() == null) {
-            request.setUserPrincipalInt(null);
-            request.setUserInRole((principal, role) -> false);
-        } else {
-            request.setUserPrincipalInt(authentication);
-            request.setUserInRole(SpringSecuritySupport::isGranted);
         }
     }
 
@@ -156,8 +153,10 @@ public class MockSpringServlet extends SpringServlet {
         private static final boolean SPRING_SECURITY_PRESENT = hasSpringSecurity();
         private static final UnaryOperator<HttpServletRequest> springSecurityRequestWrapper = springSecurityRequestWrapper();
 
-        private static Authentication authentication() {
-            return SecurityContextHolder.getContext().getAuthentication();
+        private static Principal currentPrincipal() {
+            Authentication auth = SecurityContextHolder.getContext()
+                    .getAuthentication();
+            return (auth != null && auth.getPrincipal() != null) ? auth : null;
         }
 
         private static boolean hasSpringSecurity() {

--- a/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.List;
+
+import com.testapp.security.LoginView;
+import com.testapp.security.ProtectedView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests multi-user security context isolation with Spring Security.
+ * Verifies that switching between users' windows correctly saves and
+ * restores Spring SecurityContext.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
+class MultiUserSecurityTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private BrowserlessApplicationContext<Authentication> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews(
+                "com.testapp.security");
+        app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void authenticatedUser_seesProtectedView() {
+        var adminAuth = new UsernamePasswordAuthenticationToken("john",
+                "secret",
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+        var admin = app.newUser(adminAuth);
+        var adminWindow = admin.newWindow();
+
+        // Authenticated user sees the protected view
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+    }
+
+    @Test
+    void anonymousUser_redirectedToLogin() {
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Anonymous user is redirected to login
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> anonWindow.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                anonWindow.getCurrentView());
+    }
+
+    @Test
+    void multipleUsers_securityContextIsolated() {
+        var adminAuth = new UsernamePasswordAuthenticationToken("john",
+                "secret",
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+        var admin = app.newUser(adminAuth);
+        var adminWindow = admin.newWindow();
+
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Admin sees protected view
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+
+        // Anonymous user is redirected to login
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> anonWindow.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                anonWindow.getCurrentView());
+
+        // Switch back to admin — security context should be restored
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView(),
+                "Admin's security context should be restored after switching back");
+    }
+}

--- a/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
@@ -35,9 +35,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.vaadin.browserless.internal.Routes;
 
 /**
- * Tests multi-user security context isolation with Spring Security.
- * Verifies that switching between users' windows correctly saves and
- * restores Spring SecurityContext.
+ * Tests multi-user security context isolation with Spring Security. Verifies
+ * that switching between users' windows correctly saves and restores Spring
+ * SecurityContext.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
@@ -50,8 +50,7 @@ class MultiUserSecurityTest {
 
     @BeforeEach
     void setUp() {
-        Routes routes = new Routes().autoDiscoverViews(
-                "com.testapp.security");
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
         app = SpringBrowserlessApplicationContext.create(routes,
                 applicationContext);
     }
@@ -64,8 +63,7 @@ class MultiUserSecurityTest {
     @Test
     void authenticatedUser_seesProtectedView() {
         var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret",
-                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
         var admin = app.newUser(adminAuth);
         var adminWindow = admin.newWindow();
@@ -91,8 +89,7 @@ class MultiUserSecurityTest {
     @Test
     void multipleUsers_securityContextIsolated() {
         var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret",
-                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
         var admin = app.newUser(adminAuth);
         var adminWindow = admin.newWindow();

--- a/spring/src/test/java/com/vaadin/browserless/SpringBrowserlessPerClassLifecycleTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringBrowserlessPerClassLifecycleTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ContextConfiguration(classes = SpringBrowserlessPerClassLifecycleTest.TestConfig.class)
+class SpringBrowserlessPerClassLifecycleTest extends SpringBrowserlessTest {
+
+    @Test
+    void perClassLifecycle_firstTest_vaadinEnvironmentIsSetup() {
+        Assertions.assertNotNull(VaadinService.getCurrent(),
+                "VaadinService should be available with PER_CLASS lifecycle");
+        Assertions.assertNotNull(VaadinSession.getCurrent(),
+                "VaadinSession should be available with PER_CLASS lifecycle");
+    }
+
+    @Test
+    void perClassLifecycle_secondTest_vaadinEnvironmentIsSetup() {
+        Assertions.assertNotNull(VaadinService.getCurrent(),
+                "VaadinService should be available with PER_CLASS lifecycle");
+        Assertions.assertNotNull(VaadinSession.getCurrent(),
+                "VaadinSession should be available with PER_CLASS lifecycle");
+    }
+
+    @Configuration
+    static class TestConfig {
+    }
+}

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
@@ -35,9 +35,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.vaadin.browserless.internal.Routes;
 
 /**
- * Tests that the Spring security context snapshot is a defensive copy,
- * not a mutable reference. Mutating the live SecurityContext on the
- * thread after switching users must not corrupt the saved snapshot.
+ * Tests that the Spring security context snapshot is a defensive copy, not a
+ * mutable reference. Mutating the live SecurityContext on the thread after
+ * switching users must not corrupt the saved snapshot.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
@@ -63,8 +63,7 @@ class SpringSecuritySnapshotTest {
     @Test
     void mutatingLiveContext_doesNotCorruptSavedSnapshot() {
         var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret",
-                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
         // Create admin user and verify access
         var admin = app.newUser(adminAuth);

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.List;
+
+import com.testapp.security.ProtectedView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests that the Spring security context snapshot is a defensive copy,
+ * not a mutable reference. Mutating the live SecurityContext on the
+ * thread after switching users must not corrupt the saved snapshot.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
+class SpringSecuritySnapshotTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private BrowserlessApplicationContext<Authentication> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
+        app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void mutatingLiveContext_doesNotCorruptSavedSnapshot() {
+        var adminAuth = new UsernamePasswordAuthenticationToken("john",
+                "secret",
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+        // Create admin user and verify access
+        var admin = app.newUser(adminAuth);
+        var adminWindow = admin.newWindow();
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+
+        // Switch to anonymous user (saves admin's snapshot)
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Mutate the live SecurityContext on the thread
+        SecurityContextHolder.getContext().setAuthentication(null);
+
+        // Switch back to admin — snapshot should NOT be corrupted
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView(),
+                "Admin snapshot should survive mutation of the live"
+                        + " SecurityContext");
+    }
+}


### PR DESCRIPTION
This draft is meant as a starting point for separated commits to implement new features for browserless testing.
It's mostly a refactoring of @mstahv work in #30 

* support shared Vaadin environment across tests and composition-based setup
* add multi-user and multi-tab testing support  (plus quarkus support)
* shared DSL utility class to reduce duplicated code
