### PR TITLE
chore: minimize stale format-apply PR comments when formatting is fixed

### DIFF
--- a/.github/workflows/format-apply.yml
+++ b/.github/workflows/format-apply.yml
@@ -123,14 +123,15 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const hasChanges = '${{ steps.diff.outputs.has-changes }}';
             const jobStatus = '${{ job.status }}';
+            const marker = '<!-- format-apply-comment -->';
 
             let body;
             if (jobStatus === 'success' && hasChanges === 'true') {
-              body = `Formatting applied and pushed. :white_check_mark:\n\n[Workflow run](${runUrl})`;
+              body = `${marker}\nFormatting applied and pushed. :white_check_mark:\n\n[Workflow run](${runUrl})`;
             } else if (jobStatus === 'success' && hasChanges === 'false') {
-              body = `Code is already formatted correctly. :white_check_mark:\n\n[Workflow run](${runUrl})`;
+              body = `${marker}\nCode is already formatted correctly. :white_check_mark:\n\n[Workflow run](${runUrl})`;
             } else {
-              body = `Formatting failed. :x:\n\n[Workflow run](${runUrl})`;
+              body = `${marker}\nFormatting failed. :x:\n\n[Workflow run](${runUrl})`;
             }
 
             await github.rest.issues.createComment({

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -144,22 +144,45 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const marker = '<!-- format-check-comment -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number
             });
-            const formatComment = comments.find(c => c.body.includes(marker));
-            if (formatComment) {
+
+            // Delete the validation hint comment
+            const hintMarker = '<!-- format-check-comment -->';
+            const hintComment = comments.find(c => c.body.includes(hintMarker));
+            if (hintComment) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                comment_id: formatComment.id
+                comment_id: hintComment.id
               });
               console.log('Format hint comment removed.');
             } else {
-              console.log('No format hint comment found, nothing to remove.');
+              console.log('No format hint comment found.');
+            }
+
+            // Minimize format-apply comments and mark them as outdated
+            const applyMarker = '<!-- format-apply-comment -->';
+            const outdatedMarker = '<!-- format-apply-comment-outdated -->';
+            const applyComments = comments.filter(c => c.body.includes(applyMarker));
+            for (const comment of applyComments) {
+              await github.graphql(`
+                mutation($id: ID!) {
+                  minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                    minimizedComment { isMinimized }
+                  }
+                }
+              `, { id: comment.node_id });
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+                body: comment.body.replace(applyMarker, outdatedMarker)
+              });
+              console.log(`Minimized format-apply comment ${comment.id} as outdated.`);
             }
 
       - name: Post format hint comment


### PR DESCRIPTION
When `/format` workflow fails and the user fixes formatting manually, the validation workflow removes its own hint comment but leaves the format-apply result comment behind as stale noise.

Add an HTML marker to format-apply comments so they can be identified, and have the validation workflow minimize them as outdated (instead of deleting) when formatting passes. The marker is updated to prevent reprocessing on subsequent runs.
