### PR TITLE
feat: add multi-user and multi-tab testing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ end-to-end testing) by covering the fast-feedback layer of the testing pyramid.
   Spring context support, including `@WithMockUser` security testing
 - **Quarkus integration** — `QuarkusBrowserlessTest` base class with CDI
   injection and `@TestSecurity` support
+- **Multi-user / multi-window testing** — drive multiple users and multiple
+  browser windows per user against a shared application within a single test;
+  Vaadin thread-locals and per-user security context are switched
+  automatically as you interact with each window
+- **External navigation capture** — assert URLs triggered by
+  `Page.setLocation()` and `Page.open()` (including `_blank`, named, and
+  `_self` / `_parent` / `_top` targets) without leaving the test
 - **Custom testers** — create your own `ComponentTester` implementations and
   register them with `@Tests`
 
@@ -180,6 +187,211 @@ class CartViewTest extends BrowserlessTest {
     }
 }
 ```
+
+## Multi-user and multi-window testing
+
+For tests that need to drive multiple users — or multiple browser windows for
+the same user — against a single application, Browserless Test exposes a
+layered context API that mirrors the Vaadin hierarchy:
+
+| Context                            | Maps to                          | Created via                                                                          |
+|------------------------------------|----------------------------------|--------------------------------------------------------------------------------------|
+| `BrowserlessApplicationContext<C>` | shared `VaadinServletService`    | `BrowserlessApplicationContext.create(routes)` (or a framework factory, see below)   |
+| `BrowserlessUserContext`           | one `VaadinSession` (one user)   | `app.newUser()` / `app.newUser(credentials)` / `app.newUser(username, roles...)`     |
+| `BrowserlessUIContext`             | one `UI` (one browser window)    | `user.newWindow()`                                                                   |
+
+`BrowserlessUIContext` exposes the same DSL as `BrowserlessTest` (`navigate`,
+`$`, `$view`, `test`, `roundTrip`). Every DSL call automatically activates the
+context: Vaadin thread-locals (`VaadinService`, `VaadinSession`, `UI`,
+`VaadinRequest`, `VaadinResponse`) are switched to the target window, and on a
+user-switch the outgoing user's security context is saved and the incoming
+user's snapshot is restored. You can interleave operations on different
+windows freely without manual context switching.
+
+The application context is `AutoCloseable`: closing it (typically via
+`try-with-resources`) closes every user and every window in the right order,
+fires destroy listeners, and clears Vaadin and security thread-locals.
+
+### Plain Java
+
+```java
+import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Paragraph;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SharedCounterTest {
+
+    @Test
+    void twoUsersShareApplicationState() {
+        Routes routes = new Routes()
+                .autoDiscoverViews(SharedCounterView.class.getPackageName());
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            var w1 = app.newUser().newWindow();
+            var w2 = app.newUser().newWindow();
+
+            w1.navigate(SharedCounterView.class);
+            w2.navigate(SharedCounterView.class);
+
+            // user 1 increments — only their UI reflects it locally
+            w1.test(w1.$(Button.class).withText("Increment").single()).click();
+            assertEquals("Count: 1", w1.$(Paragraph.class).single().getText());
+            assertEquals("Count: 0", w2.$(Paragraph.class).single().getText());
+
+            // user 2 refreshes to observe the shared application state
+            w2.test(w2.$(Button.class).withText("Refresh").single()).click();
+            assertEquals("Count: 1", w2.$(Paragraph.class).single().getText());
+        }
+    }
+}
+```
+
+### Spring
+
+`SpringBrowserlessApplicationContext.create(routes, springCtx)` wires the
+application context to the Spring `ApplicationContext` and (when Spring
+Security is on the classpath) installs a `SecurityContextHandler` so per-user
+authentication is automatically isolated across windows. The
+`newUser(username, roles...)` shorthand mirrors `@WithMockUser`.
+
+```java
+import com.testapp.security.LoginView;
+import com.testapp.security.ProtectedView;
+import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.SpringBrowserlessApplicationContext;
+import com.vaadin.browserless.internal.Routes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SecurityTestConfig.class)
+class MultiUserSecurityTest {
+
+    @Autowired
+    private ApplicationContext springCtx;
+
+    @Test
+    void securityContextIsIsolatedPerUser() {
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
+        try (BrowserlessApplicationContext<Authentication> app =
+                SpringBrowserlessApplicationContext.create(routes, springCtx)) {
+
+            var adminWindow = app.newUser("john", "USER").newWindow();
+            var anonWindow = app.newUser().newWindow();
+
+            adminWindow.navigate(ProtectedView.class);
+            assertInstanceOf(ProtectedView.class, adminWindow.getCurrentView());
+
+            // Anonymous user is redirected to the login view
+            assertThrows(IllegalArgumentException.class,
+                    () -> anonWindow.navigate(ProtectedView.class));
+            assertInstanceOf(LoginView.class, anonWindow.getCurrentView());
+
+            // Switch back — admin's SecurityContext is restored automatically
+            adminWindow.navigate(ProtectedView.class);
+            assertInstanceOf(ProtectedView.class, adminWindow.getCurrentView());
+        }
+    }
+}
+```
+
+For full control over the principal, `app.newUser(authentication)` accepts a
+hand-built `Authentication` token.
+
+### Quarkus
+
+`QuarkusBrowserlessApplicationContext.create(routes)` resolves Quarkus beans
+through CDI and installs a `SecurityContextHandler` backed by
+`CurrentIdentityAssociation`. The `newUser(username, roles...)` shorthand
+builds a matching `QuarkusSecurityIdentity`.
+
+```java
+import com.testapp.security.LoginView;
+import com.testapp.security.ProtectedView;
+import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.quarkus.QuarkusBrowserlessApplicationContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class MultiUserSecurityTest {
+
+    @Test
+    void securityContextIsIsolatedPerUser() {
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
+        try (BrowserlessApplicationContext<SecurityIdentity> app =
+                QuarkusBrowserlessApplicationContext.create(routes)) {
+
+            var adminWindow = app.newUser("john", "USER").newWindow();
+            var anonWindow = app.newUser().newWindow();
+
+            adminWindow.navigate(ProtectedView.class);
+            assertInstanceOf(ProtectedView.class, adminWindow.getCurrentView());
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> anonWindow.navigate(ProtectedView.class));
+            assertInstanceOf(LoginView.class, anonWindow.getCurrentView());
+
+            adminWindow.navigate(ProtectedView.class);
+            assertInstanceOf(ProtectedView.class, adminWindow.getCurrentView());
+        }
+    }
+}
+```
+
+For a hand-built identity, pass it directly:
+`app.newUser(QuarkusSecurityIdentity.builder()...build())`.
+
+### Capturing external navigation
+
+When a view triggers `Page.setLocation()` or `Page.open()`, the URL is
+captured on the window's mock `Page` and can be asserted directly:
+
+```java
+var w = app.newUser().newWindow();
+w.navigate(CheckoutView.class);
+
+// Page.setLocation("https://vaadin.com/") — _self navigation
+w.test(w.$(Button.class).withText("Go to Vaadin").single()).click();
+assertEquals("https://vaadin.com/", w.getExternalNavigationURL());
+
+// Page.open("https://payment.example.com/checkout?id=123") — _blank
+w.test(w.$(Button.class).withText("Pay").single()).click();
+assertEquals("https://payment.example.com/checkout?id=123",
+        w.getExternalNavigationURL("_blank"));
+
+// All windows opened by name (excluding _self / _parent / _top navigations)
+Map<String, List<String>> opened = w.getOpenedWindows();
+```
+
+`getExternalNavigationURL()` (no argument) covers same-window navigations
+(`_self`, `_parent`, `_top`, empty, or `null`);
+`getExternalNavigationURL(name)` and `getOpenedWindows()` cover named windows
+and `_blank`.
+
+### Notes
+
+- `app.newUser(username, roles...)` requires the application context to be
+  configured with a `SecurityContextHandler`; the Spring and Quarkus
+  factories install one by default.
+- The per-user security snapshot is captured at user-switch time (not on
+  every activate), so mutations made while the user is active persist on the
+  thread until you switch to a different user — at which point the live
+  state is captured into that user's snapshot and restored on every
+  subsequent activation.
+- Same-user window switches don't touch the snapshot, so per-window UI state
+  is preserved across interleaved operations within one user.
 
 ## License
 

--- a/junit6/src/test/java/com/example/multiuser/ExternalNavigationView.java
+++ b/junit6/src/test/java/com/example/multiuser/ExternalNavigationView.java
@@ -29,33 +29,26 @@ import com.vaadin.flow.router.Route;
 public class ExternalNavigationView extends VerticalLayout {
 
     public ExternalNavigationView() {
-        Button setLocation = new Button("Go to Vaadin",
-                e -> UI.getCurrent().getPage()
-                        .setLocation("https://vaadin.com/"));
+        Button setLocation = new Button("Go to Vaadin", e -> UI.getCurrent()
+                .getPage().setLocation("https://vaadin.com/"));
 
-        Button openNew = new Button("Pay",
-                e -> UI.getCurrent().getPage()
-                        .open("https://payment.example.com/checkout?id=123"));
+        Button openNew = new Button("Pay", e -> UI.getCurrent().getPage()
+                .open("https://payment.example.com/checkout?id=123"));
 
-        Button openNamedWindow = new Button("Open Help",
-                e -> UI.getCurrent().getPage()
-                        .open("https://help.example.com/", "helpWindow"));
+        Button openNamedWindow = new Button("Open Help", e -> UI.getCurrent()
+                .getPage().open("https://help.example.com/", "helpWindow"));
 
-        Button openParent = new Button("Open Parent",
-                e -> UI.getCurrent().getPage()
-                        .open("https://parent.example.com/", "_parent"));
+        Button openParent = new Button("Open Parent", e -> UI.getCurrent()
+                .getPage().open("https://parent.example.com/", "_parent"));
 
-        Button openTop = new Button("Open Top",
-                e -> UI.getCurrent().getPage()
-                        .open("https://top.example.com/", "_top"));
+        Button openTop = new Button("Open Top", e -> UI.getCurrent().getPage()
+                .open("https://top.example.com/", "_top"));
 
-        Button openBlank1 = new Button("Open Tab 1",
-                e -> UI.getCurrent().getPage()
-                        .open("https://tab1.example.com/"));
+        Button openBlank1 = new Button("Open Tab 1", e -> UI.getCurrent()
+                .getPage().open("https://tab1.example.com/"));
 
-        Button openBlank2 = new Button("Open Tab 2",
-                e -> UI.getCurrent().getPage()
-                        .open("https://tab2.example.com/"));
+        Button openBlank2 = new Button("Open Tab 2", e -> UI.getCurrent()
+                .getPage().open("https://tab2.example.com/"));
 
         add(setLocation, openNew, openNamedWindow, openParent, openTop,
                 openBlank1, openBlank2);

--- a/junit6/src/test/java/com/example/multiuser/ExternalNavigationView.java
+++ b/junit6/src/test/java/com/example/multiuser/ExternalNavigationView.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.example.multiuser;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A view with buttons that trigger external navigation via
+ * {@link com.vaadin.flow.component.page.Page#setLocation(String)} and
+ * {@link com.vaadin.flow.component.page.Page#open(String)}.
+ */
+@Route("external-nav")
+public class ExternalNavigationView extends VerticalLayout {
+
+    public ExternalNavigationView() {
+        Button setLocation = new Button("Go to Vaadin",
+                e -> UI.getCurrent().getPage()
+                        .setLocation("https://vaadin.com/"));
+
+        Button openNew = new Button("Pay",
+                e -> UI.getCurrent().getPage()
+                        .open("https://payment.example.com/checkout?id=123"));
+
+        Button openNamedWindow = new Button("Open Help",
+                e -> UI.getCurrent().getPage()
+                        .open("https://help.example.com/", "helpWindow"));
+
+        Button openParent = new Button("Open Parent",
+                e -> UI.getCurrent().getPage()
+                        .open("https://parent.example.com/", "_parent"));
+
+        Button openTop = new Button("Open Top",
+                e -> UI.getCurrent().getPage()
+                        .open("https://top.example.com/", "_top"));
+
+        Button openBlank1 = new Button("Open Tab 1",
+                e -> UI.getCurrent().getPage()
+                        .open("https://tab1.example.com/"));
+
+        Button openBlank2 = new Button("Open Tab 2",
+                e -> UI.getCurrent().getPage()
+                        .open("https://tab2.example.com/"));
+
+        add(setLocation, openNew, openNamedWindow, openParent, openTop,
+                openBlank1, openBlank2);
+    }
+}

--- a/junit6/src/test/java/com/example/multiuser/SharedCounterView.java
+++ b/junit6/src/test/java/com/example/multiuser/SharedCounterView.java
@@ -23,16 +23,15 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
 /**
- * A view with a shared static counter, used for testing multi-user
- * scenarios where application-level state is shared across sessions.
+ * A view with a shared static counter, used for testing multi-user scenarios
+ * where application-level state is shared across sessions.
  */
 @Route("shared-counter")
 public class SharedCounterView extends VerticalLayout {
 
     public static final AtomicInteger counter = new AtomicInteger(0);
 
-    private final Paragraph display = new Paragraph(
-            "Count: " + counter.get());
+    private final Paragraph display = new Paragraph("Count: " + counter.get());
 
     public SharedCounterView() {
         Button increment = new Button("Increment", e -> {

--- a/junit6/src/test/java/com/example/multiuser/SharedCounterView.java
+++ b/junit6/src/test/java/com/example/multiuser/SharedCounterView.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.example.multiuser;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A view with a shared static counter, used for testing multi-user
+ * scenarios where application-level state is shared across sessions.
+ */
+@Route("shared-counter")
+public class SharedCounterView extends VerticalLayout {
+
+    public static final AtomicInteger counter = new AtomicInteger(0);
+
+    private final Paragraph display = new Paragraph(
+            "Count: " + counter.get());
+
+    public SharedCounterView() {
+        Button increment = new Button("Increment", e -> {
+            int value = counter.incrementAndGet();
+            display.setText("Count: " + value);
+        });
+
+        Button refresh = new Button("Refresh",
+                e -> display.setText("Count: " + counter.get()));
+
+        add(display, increment, refresh);
+    }
+}

--- a/junit6/src/test/java/com/example/multiuser/SimpleView.java
+++ b/junit6/src/test/java/com/example/multiuser/SimpleView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.example.multiuser;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("simple")
+public class SimpleView extends VerticalLayout {
+    public SimpleView() {
+        add(new Span("Simple view"));
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessBaseClassTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessBaseClassTest.java
@@ -80,6 +80,9 @@ class BrowserlessBaseClassTest {
             allViews.add(TemplatedParam.class);
             allViews.add(AutoLayoutView.class);
             allViews.add(GeolocationFacadeIntegrationTest.SampleView.class);
+            allViews.add(com.example.multiuser.SharedCounterView.class);
+            allViews.add(com.example.multiuser.ExternalNavigationView.class);
+            allViews.add(com.example.multiuser.SimpleView.class);
             Assertions.assertEquals(allViews.size(), routes.size());
             Assertions.assertTrue(routes.containsAll(allViews));
         }

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
@@ -105,13 +105,23 @@ class BrowserlessClosePathCleanupTest {
             var user = app.newUser();
             var window1 = user.newWindow();
             var window2 = user.newWindow();
+            var window2UI = window2.getUI();
             Assertions.assertSame(window2, BrowserlessUIContext.getActive(),
                     "Sanity check: window2 is the active context");
+            Assertions.assertSame(window2UI, UI.getCurrent(),
+                    "Sanity check: UI.getCurrent() points at window2");
 
-            // Close the *non*-active window. activeContext must not be touched.
+            // Close the *non*-active window. activeContext must not be touched
+            // and the active sibling's thread-locals must remain coherent.
             window1.close();
             Assertions.assertSame(window2, BrowserlessUIContext.getActive(),
                     "Closing a non-active window must not affect activeContext");
+            Assertions.assertSame(window2UI, UI.getCurrent(),
+                    "UI.getCurrent() must still point at the active sibling"
+                            + " after a same-user non-active close");
+            Assertions.assertSame(user.getSession(), VaadinSession.getCurrent(),
+                    "VaadinSession.getCurrent() must still point at the user's"
+                            + " session after a same-user non-active close");
 
             // Closing the active window clears the ThreadLocal.
             window2.close();

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
@@ -137,7 +137,7 @@ class BrowserlessClosePathCleanupTest {
 
     @Test
     void uiClose_restoresUserSecurityContextForDetachListeners() {
-        var handler = new CapturingHandler();
+        var handler = new CapturingSecurityHandler();
         try (var app = BrowserlessApplicationContext.<String> builder(routes)
                 .withSecurityContextHandler(handler).build()) {
 
@@ -195,7 +195,7 @@ class BrowserlessClosePathCleanupTest {
 
     @Test
     void uiClose_nonActiveCrossUserCloseLeavesThreadCoherentWithActiveContext() {
-        var handler = new CapturingHandler();
+        var handler = new CapturingSecurityHandler();
         try (var app = BrowserlessApplicationContext.<String> builder(routes)
                 .withSecurityContextHandler(handler).build()) {
 
@@ -243,7 +243,7 @@ class BrowserlessClosePathCleanupTest {
 
     @Test
     void userClose_clearsSecurityContext() {
-        var handler = new CapturingHandler();
+        var handler = new CapturingSecurityHandler();
         try (var app = BrowserlessApplicationContext.<String> builder(routes)
                 .withSecurityContextHandler(handler).build()) {
             var user = app.newUser("alice");
@@ -263,7 +263,7 @@ class BrowserlessClosePathCleanupTest {
 
     @Test
     void userClose_destroyListenerSeesClosingUserSecurity() {
-        var handler = new CapturingHandler();
+        var handler = new CapturingSecurityHandler();
         try (var app = BrowserlessApplicationContext.<String> builder(routes)
                 .withSecurityContextHandler(handler).build()) {
             var alice = app.newUser("alice");
@@ -291,7 +291,7 @@ class BrowserlessClosePathCleanupTest {
 
     @Test
     void userClose_leavesActiveUserCoherentOnTheThread() {
-        var handler = new CapturingHandler();
+        var handler = new CapturingSecurityHandler();
         try (var app = BrowserlessApplicationContext.<String> builder(routes)
                 .withSecurityContextHandler(handler).build()) {
             var alice = app.newUser("alice");
@@ -326,41 +326,4 @@ class BrowserlessClosePathCleanupTest {
         }
     }
 
-    /**
-     * Minimal {@link SecurityContextHandler} that stores a string snapshot in a
-     * thread-local, so tests can observe save/restore behaviour without pulling
-     * in Spring or Quarkus dependencies.
-     */
-    private static class CapturingHandler
-            implements SecurityContextHandler<String> {
-        private final ThreadLocal<String> live = new ThreadLocal<>();
-
-        @Override
-        public void setupAuthentication(String credentials) {
-            live.set(credentials != null ? credentials : "<anon>");
-        }
-
-        @Override
-        public Object saveContext() {
-            return live.get();
-        }
-
-        @Override
-        public void restoreContext(Object snapshot) {
-            if (snapshot == null) {
-                live.remove();
-            } else if (snapshot instanceof String s) {
-                live.set(s);
-            } else {
-                throw new IllegalArgumentException(
-                        "Expected a String snapshot, got "
-                                + snapshot.getClass().getName());
-            }
-        }
-
-        @Override
-        public void clearContext() {
-            live.remove();
-        }
-    }
 }

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
@@ -204,6 +204,8 @@ class BrowserlessClosePathCleanupTest {
 
             var bob = app.newUser("bob");
             var bobWindow = bob.newWindow();
+            var bobRequest = VaadinRequest.getCurrent();
+            var bobResponse = VaadinResponse.getCurrent();
 
             // Sanity: bob is the live state on the thread
             Assertions.assertSame(bobWindow.getUI(), UI.getCurrent());
@@ -222,6 +224,14 @@ class BrowserlessClosePathCleanupTest {
                             + " after a non-active cross-user close");
             Assertions.assertSame(bob.getSession(), VaadinSession.getCurrent(),
                     "VaadinSession.getCurrent() must remain coherent with"
+                            + " activeContext after a non-active cross-user"
+                            + " close");
+            Assertions.assertSame(bobRequest, VaadinRequest.getCurrent(),
+                    "VaadinRequest.getCurrent() must remain coherent with"
+                            + " activeContext after a non-active cross-user"
+                            + " close");
+            Assertions.assertSame(bobResponse, VaadinResponse.getCurrent(),
+                    "VaadinResponse.getCurrent() must remain coherent with"
                             + " activeContext after a non-active cross-user"
                             + " close");
             Assertions.assertEquals("bob", handler.live.get(),
@@ -248,6 +258,71 @@ class BrowserlessClosePathCleanupTest {
                     "user.close() must clear the security context so the"
                             + " closing user's snapshot does not leak onto"
                             + " the thread");
+        }
+    }
+
+    @Test
+    void userClose_destroyListenerSeesClosingUserSecurity() {
+        var handler = new CapturingHandler();
+        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+                .withSecurityContextHandler(handler).build()) {
+            var alice = app.newUser("alice");
+            alice.newWindow();
+
+            var bob = app.newUser("bob");
+            bob.newWindow(); // activates bob; thread now carries "bob"
+
+            var observed = new AtomicReference<String>();
+            app.getService().addSessionDestroyListener(event -> {
+                if (event.getSession() == alice.getSession()) {
+                    observed.set(handler.live.get());
+                }
+            });
+
+            alice.close();
+
+            Assertions.assertEquals("alice", observed.get(),
+                    "session-destroy listener should see the closing"
+                            + " user's security snapshot, not whatever"
+                            + " the thread happened to carry from another"
+                            + " active user");
+        }
+    }
+
+    @Test
+    void userClose_leavesActiveUserCoherentOnTheThread() {
+        var handler = new CapturingHandler();
+        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+                .withSecurityContextHandler(handler).build()) {
+            var alice = app.newUser("alice");
+            alice.newWindow();
+
+            var bob = app.newUser("bob");
+            var bobWindow = bob.newWindow();
+            var bobUI = UI.getCurrent();
+            var bobSession = VaadinSession.getCurrent();
+            var bobRequest = VaadinRequest.getCurrent();
+            var bobResponse = VaadinResponse.getCurrent();
+
+            alice.close();
+
+            // After closing a non-active user, the thread must remain
+            // coherent with bob (the active user) — alice.close() must not
+            // leave the thread cleared while activeContext still points to
+            // bob's window.
+            Assertions.assertSame(bobWindow, BrowserlessUIContext.getActive(),
+                    "bob's window should still be the active context");
+            Assertions.assertSame(bobUI, UI.getCurrent(),
+                    "UI thread-local should still be bob's");
+            Assertions.assertSame(bobSession, VaadinSession.getCurrent(),
+                    "VaadinSession thread-local should still be bob's");
+            Assertions.assertSame(bobRequest, VaadinRequest.getCurrent(),
+                    "VaadinRequest thread-local should still be bob's");
+            Assertions.assertSame(bobResponse, VaadinResponse.getCurrent(),
+                    "VaadinResponse thread-local should still be bob's");
+            Assertions.assertEquals("bob", handler.live.get(),
+                    "Security context should still be bob's, not cleared"
+                            + " by alice.close()");
         }
     }
 

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.example.multiuser.SimpleView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+
+/**
+ * Tests that closing user/UI contexts properly tears down thread-local state,
+ * matches MockVaadin's session-destroy semantics, and preserves the user's
+ * security context for detach listeners.
+ */
+class BrowserlessClosePathCleanupTest {
+
+    private Routes routes;
+
+    @BeforeEach
+    void setUp() {
+        routes = new Routes()
+                .autoDiscoverViews(SimpleView.class.getPackageName());
+    }
+
+    @Test
+    void userClose_clearsVaadinRequestAndResponseThreadLocals() {
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            var user = app.newUser();
+            user.newWindow();
+
+            // Sanity: thread-locals are set after a window has been activated
+            Assertions.assertNotNull(VaadinRequest.getCurrent(),
+                    "Sanity check: VaadinRequest should be set");
+            Assertions.assertNotNull(VaadinResponse.getCurrent(),
+                    "Sanity check: VaadinResponse should be set");
+
+            user.close();
+
+            Assertions.assertNull(VaadinRequest.getCurrent(),
+                    "user.close() must clear VaadinRequest thread-local");
+            Assertions.assertNull(VaadinResponse.getCurrent(),
+                    "user.close() must clear VaadinResponse thread-local");
+        }
+    }
+
+    @Test
+    void userClose_drainsSessionAccessTasksScheduledByDestroyListeners() {
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            var user = app.newUser();
+            user.newWindow();
+
+            var ran = new AtomicBoolean();
+            app.getService().addSessionDestroyListener(
+                    event -> event.getSession().access(() -> ran.set(true)));
+
+            user.close();
+
+            Assertions.assertTrue(ran.get(),
+                    "session.access tasks scheduled by session-destroy"
+                            + " listeners must be drained before close()"
+                            + " returns");
+        }
+    }
+
+    @Test
+    void uiClose_restoresUserSecurityContextForDetachListeners() {
+        var handler = new CapturingHandler();
+        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+                .withSecurityContextHandler(handler).build()) {
+
+            var alice = app.newUser("alice");
+            var aliceWindow = alice.newWindow();
+
+            var bob = app.newUser("bob");
+            bob.newWindow(); // activates bob; thread now carries "bob"
+
+            // Sanity: bob is the live snapshot
+            Assertions.assertEquals("bob", handler.live.get(),
+                    "Sanity check: bob is the live snapshot");
+
+            var observed = new AtomicReference<String>();
+            aliceWindow.getUI()
+                    .addDetachListener(e -> observed.set(handler.live.get()));
+
+            // Close aliceWindow without re-activating it. The detach listener
+            // must observe alice's snapshot, not bob's.
+            aliceWindow.close();
+
+            Assertions.assertEquals("alice", observed.get(),
+                    "Detach listener should see this user's security"
+                            + " snapshot, not whatever the thread happened"
+                            + " to carry");
+        }
+    }
+
+    /**
+     * Minimal {@link SecurityContextHandler} that stores a string snapshot in a
+     * thread-local, so tests can observe save/restore behaviour without pulling
+     * in Spring or Quarkus dependencies.
+     */
+    private static class CapturingHandler
+            implements SecurityContextHandler<String> {
+        private final ThreadLocal<String> live = new ThreadLocal<>();
+
+        @Override
+        public void setupAuthentication(String credentials) {
+            live.set(credentials != null ? credentials : "<anon>");
+        }
+
+        @Override
+        public Object saveContext() {
+            return live.get();
+        }
+
+        @Override
+        public void restoreContext(Object snapshot) {
+            if (snapshot == null) {
+                live.remove();
+            } else if (snapshot instanceof String s) {
+                live.set(s);
+            } else {
+                throw new IllegalArgumentException(
+                        "Expected a String snapshot, got "
+                                + snapshot.getClass().getName());
+            }
+        }
+
+        @Override
+        public void clearContext() {
+            live.remove();
+        }
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
@@ -83,6 +83,57 @@ class BrowserlessClosePathCleanupTest {
     }
 
     @Test
+    void uiClose_clearsActiveContextWhenClosingTheActiveWindow() {
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            var window = app.newUser().newWindow();
+            Assertions.assertSame(window, BrowserlessUIContext.getActive(),
+                    "Sanity check: newWindow activates the new window");
+
+            window.close();
+
+            Assertions.assertNull(BrowserlessUIContext.getActive(),
+                    "Closing the active window must clear the activeContext"
+                            + " ThreadLocal");
+        }
+    }
+
+    @Test
+    void uiClose_leavesActiveContextAloneWhenClosingANonActiveWindow() {
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            var user = app.newUser();
+            var window1 = user.newWindow();
+            var window2 = user.newWindow();
+            Assertions.assertSame(window2, BrowserlessUIContext.getActive(),
+                    "Sanity check: window2 is the active context");
+
+            // Close the *non*-active window. activeContext must not be touched.
+            window1.close();
+            Assertions.assertSame(window2, BrowserlessUIContext.getActive(),
+                    "Closing a non-active window must not affect activeContext");
+
+            // Closing the active window clears the ThreadLocal.
+            window2.close();
+            Assertions.assertNull(BrowserlessUIContext.getActive(),
+                    "Closing the last active window must clear activeContext");
+        }
+    }
+
+    @Test
+    void appClose_doesNotLeakActiveContextAcrossInvocations() {
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            app.newUser().newWindow();
+            // Sanity: window is active during the try block
+            Assertions.assertNotNull(BrowserlessUIContext.getActive());
+        }
+
+        // After app.close() (try-with-resources), the activeContext must not
+        // retain a reference to a closed window — otherwise reuse of this
+        // thread by a subsequent test method observes stale state.
+        Assertions.assertNull(BrowserlessUIContext.getActive(),
+                "app.close() must leave activeContext clear");
+    }
+
+    @Test
     void uiClose_restoresUserSecurityContextForDetachListeners() {
         var handler = new CapturingHandler();
         try (var app = BrowserlessApplicationContext.<String> builder(routes)

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
 
 /**
  * Tests that closing user/UI contexts properly tears down thread-local state,
@@ -143,7 +145,8 @@ class BrowserlessClosePathCleanupTest {
             var aliceWindow = alice.newWindow();
 
             var bob = app.newUser("bob");
-            bob.newWindow(); // activates bob; thread now carries "bob"
+            var bobWindow = bob.newWindow(); // activates bob; thread now
+                                             // carries "bob"
 
             // Sanity: bob is the live snapshot
             Assertions.assertEquals("bob", handler.live.get(),
@@ -161,6 +164,90 @@ class BrowserlessClosePathCleanupTest {
                     "Detach listener should see this user's security"
                             + " snapshot, not whatever the thread happened"
                             + " to carry");
+            Assertions.assertSame(bobWindow, BrowserlessUIContext.getActive(),
+                    "Closing a non-active window owned by a different user"
+                            + " must not displace the active context");
+        }
+    }
+
+    @Test
+    void uiClose_detachListenerSeesClosingUserRequest() {
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            var alice = app.newUser();
+            var aliceWindow = alice.newWindow();
+            var aliceRequest = VaadinRequest.getCurrent();
+
+            var bob = app.newUser();
+            bob.newWindow(); // activates bob; thread now carries bob's request
+
+            var observed = new AtomicReference<VaadinRequest>();
+            aliceWindow.getUI().addDetachListener(
+                    e -> observed.set(VaadinRequest.getCurrent()));
+
+            aliceWindow.close();
+
+            Assertions.assertSame(aliceRequest, observed.get(),
+                    "Detach listener should see the closing user's"
+                            + " VaadinRequest, not whatever the thread"
+                            + " happened to carry from the active user");
+        }
+    }
+
+    @Test
+    void uiClose_nonActiveCrossUserCloseLeavesThreadCoherentWithActiveContext() {
+        var handler = new CapturingHandler();
+        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+                .withSecurityContextHandler(handler).build()) {
+
+            var alice = app.newUser("alice");
+            var aliceWindow = alice.newWindow();
+
+            var bob = app.newUser("bob");
+            var bobWindow = bob.newWindow();
+
+            // Sanity: bob is the live state on the thread
+            Assertions.assertSame(bobWindow.getUI(), UI.getCurrent());
+            Assertions.assertSame(bob.getSession(), VaadinSession.getCurrent());
+            Assertions.assertEquals("bob", handler.live.get());
+
+            aliceWindow.close();
+
+            // After closing alice's non-active window, the thread must still
+            // reflect bob (the active context) — the close() path must repair
+            // any coherence it temporarily breaks.
+            Assertions.assertSame(bobWindow, BrowserlessUIContext.getActive(),
+                    "Sanity: bob remains the active context");
+            Assertions.assertSame(bobWindow.getUI(), UI.getCurrent(),
+                    "UI.getCurrent() must remain coherent with activeContext"
+                            + " after a non-active cross-user close");
+            Assertions.assertSame(bob.getSession(), VaadinSession.getCurrent(),
+                    "VaadinSession.getCurrent() must remain coherent with"
+                            + " activeContext after a non-active cross-user"
+                            + " close");
+            Assertions.assertEquals("bob", handler.live.get(),
+                    "Security context must remain bob's after a non-active"
+                            + " cross-user close, not the closed user's"
+                            + " snapshot");
+        }
+    }
+
+    @Test
+    void userClose_clearsSecurityContext() {
+        var handler = new CapturingHandler();
+        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+                .withSecurityContextHandler(handler).build()) {
+            var user = app.newUser("alice");
+            user.newWindow();
+
+            // Sanity: alice's snapshot is live on the thread
+            Assertions.assertEquals("alice", handler.live.get());
+
+            user.close();
+
+            Assertions.assertNull(handler.live.get(),
+                    "user.close() must clear the security context so the"
+                            + " closing user's snapshot does not leak onto"
+                            + " the thread");
         }
     }
 

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
@@ -100,6 +100,99 @@ class BrowserlessClosePathCleanupTest {
     }
 
     @Test
+    void uiClose_clearsThreadLocalsWhenClosingTheActiveWindow() {
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            var window = app.newUser().newWindow();
+            // Sanity: thread-locals reflect the active window before close
+            Assertions.assertNotNull(UI.getCurrent(),
+                    "Sanity check: UI.getCurrent() should be set");
+            Assertions.assertNotNull(VaadinSession.getCurrent(),
+                    "Sanity check: VaadinSession.getCurrent() should be set");
+            Assertions.assertNotNull(VaadinRequest.getCurrent(),
+                    "Sanity check: VaadinRequest.getCurrent() should be set");
+            Assertions.assertNotNull(VaadinResponse.getCurrent(),
+                    "Sanity check: VaadinResponse.getCurrent() should be set");
+
+            window.close();
+
+            Assertions.assertNull(BrowserlessUIContext.getActive(),
+                    "Closing the active window must clear activeContext");
+            Assertions.assertNull(UI.getCurrent(),
+                    "Closing the active window with no surviving sibling"
+                            + " must clear UI thread-local so user code"
+                            + " reading UI.getCurrent() between close() and"
+                            + " the next activate() does not see stale state");
+            Assertions.assertNull(VaadinSession.getCurrent(),
+                    "Closing the active window with no surviving sibling"
+                            + " must clear VaadinSession thread-local");
+            Assertions.assertNull(VaadinRequest.getCurrent(),
+                    "Closing the active window with no surviving sibling"
+                            + " must clear VaadinRequest thread-local");
+            Assertions.assertNull(VaadinResponse.getCurrent(),
+                    "Closing the active window with no surviving sibling"
+                            + " must clear VaadinResponse thread-local");
+        }
+    }
+
+    @Test
+    void uiClose_clearsSecurityContextWhenClosingTheActiveWindow() {
+        var handler = new CapturingSecurityHandler();
+        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+                .withSecurityContextHandler(handler).build()) {
+            var alice = app.newUser("alice");
+            var aliceWindow = alice.newWindow();
+            // Sanity: alice's snapshot is live on the thread
+            Assertions.assertEquals("alice", handler.live.get(),
+                    "Sanity check: alice's security snapshot is live");
+
+            aliceWindow.close();
+
+            Assertions.assertNull(handler.live.get(),
+                    "Closing the active window with no surviving sibling"
+                            + " must clear the security context so the"
+                            + " closed user's snapshot does not leak onto"
+                            + " the thread");
+        }
+    }
+
+    @Test
+    void uiClose_clearsThreadLocalsWhenNoSurvivingActiveContext() {
+        try (var app = BrowserlessApplicationContext.create(routes)) {
+            var user = app.newUser();
+            var window1 = user.newWindow();
+            var window2 = user.newWindow(); // activates window2
+
+            // Close the active window first — activeContext becomes null but
+            // window1 remains open as a non-active window.
+            window2.close();
+            Assertions.assertNull(BrowserlessUIContext.getActive(),
+                    "Sanity: activeContext is null after closing the active"
+                            + " window");
+
+            // Close the remaining (non-active) window. activeContext stays
+            // null and no sibling is reactivated, so thread-locals installed
+            // for window1's detach listeners must be cleared on the way out.
+            window1.close();
+
+            Assertions.assertNull(BrowserlessUIContext.getActive(),
+                    "activeContext must still be null after closing the"
+                            + " last remaining window");
+            Assertions.assertNull(UI.getCurrent(),
+                    "Closing a non-active window with no surviving active"
+                            + " context must clear UI thread-local");
+            Assertions.assertNull(VaadinSession.getCurrent(),
+                    "Closing a non-active window with no surviving active"
+                            + " context must clear VaadinSession thread-local");
+            Assertions.assertNull(VaadinRequest.getCurrent(),
+                    "Closing a non-active window with no surviving active"
+                            + " context must clear VaadinRequest thread-local");
+            Assertions.assertNull(VaadinResponse.getCurrent(),
+                    "Closing a non-active window with no surviving active"
+                            + " context must clear VaadinResponse thread-local");
+        }
+    }
+
+    @Test
     void uiClose_leavesActiveContextAloneWhenClosingANonActiveWindow() {
         try (var app = BrowserlessApplicationContext.create(routes)) {
             var user = app.newUser();

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessClosePathCleanupTest.java
@@ -137,7 +137,7 @@ class BrowserlessClosePathCleanupTest {
     @Test
     void uiClose_clearsSecurityContextWhenClosingTheActiveWindow() {
         var handler = new CapturingSecurityHandler();
-        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+        try (var app = BrowserlessApplicationContext.builder(routes)
                 .withSecurityContextHandler(handler).build()) {
             var alice = app.newUser("alice");
             var aliceWindow = alice.newWindow();
@@ -241,7 +241,7 @@ class BrowserlessClosePathCleanupTest {
     @Test
     void uiClose_restoresUserSecurityContextForDetachListeners() {
         var handler = new CapturingSecurityHandler();
-        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+        try (var app = BrowserlessApplicationContext.builder(routes)
                 .withSecurityContextHandler(handler).build()) {
 
             var alice = app.newUser("alice");
@@ -299,7 +299,7 @@ class BrowserlessClosePathCleanupTest {
     @Test
     void uiClose_nonActiveCrossUserCloseLeavesThreadCoherentWithActiveContext() {
         var handler = new CapturingSecurityHandler();
-        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+        try (var app = BrowserlessApplicationContext.builder(routes)
                 .withSecurityContextHandler(handler).build()) {
 
             var alice = app.newUser("alice");
@@ -347,7 +347,7 @@ class BrowserlessClosePathCleanupTest {
     @Test
     void userClose_clearsSecurityContext() {
         var handler = new CapturingSecurityHandler();
-        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+        try (var app = BrowserlessApplicationContext.builder(routes)
                 .withSecurityContextHandler(handler).build()) {
             var user = app.newUser("alice");
             user.newWindow();
@@ -367,7 +367,7 @@ class BrowserlessClosePathCleanupTest {
     @Test
     void userClose_destroyListenerSeesClosingUserSecurity() {
         var handler = new CapturingSecurityHandler();
-        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+        try (var app = BrowserlessApplicationContext.builder(routes)
                 .withSecurityContextHandler(handler).build()) {
             var alice = app.newUser("alice");
             alice.newWindow();
@@ -395,7 +395,7 @@ class BrowserlessClosePathCleanupTest {
     @Test
     void userClose_leavesActiveUserCoherentOnTheThread() {
         var handler = new CapturingSecurityHandler();
-        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+        try (var app = BrowserlessApplicationContext.builder(routes)
                 .withSecurityContextHandler(handler).build()) {
             var alice = app.newUser("alice");
             alice.newWindow();

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessNewUserTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessNewUserTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.example.multiuser.SimpleView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests construction-time semantics of {@link BrowserlessUserContext}: order of
+ * security setup vs. session-init listener firing.
+ */
+class BrowserlessNewUserTest {
+
+    private Routes routes;
+
+    @BeforeEach
+    void setUp() {
+        routes = new Routes()
+                .autoDiscoverViews(SimpleView.class.getPackageName());
+    }
+
+    @Test
+    void newUser_sessionInitListenerSeesThisUsersSecurity() {
+        var handler = new CapturingSecurityHandler();
+        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+                .withSecurityContextHandler(handler).build()) {
+
+            var observed = new AtomicReference<String>();
+            app.getService().addSessionInitListener(
+                    event -> observed.set(handler.live.get()));
+
+            app.newUser("alice");
+
+            Assertions.assertEquals("alice", observed.get(),
+                    "session-init listener should observe the new user's"
+                            + " identity, mirroring the Vaadin+Spring flow"
+                            + " where the security filter chain runs"
+                            + " before the servlet — not whatever auth"
+                            + " the calling thread happened to carry"
+                            + " before newUser()");
+        }
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessNewUserTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessNewUserTest.java
@@ -41,7 +41,7 @@ class BrowserlessNewUserTest {
     @Test
     void newUser_sessionInitListenerSeesThisUsersSecurity() {
         var handler = new CapturingSecurityHandler();
-        try (var app = BrowserlessApplicationContext.<String> builder(routes)
+        try (var app = BrowserlessApplicationContext.builder(routes)
                 .withSecurityContextHandler(handler).build()) {
 
             var observed = new AtomicReference<String>();

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.multiuser.SimpleView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.html.Div;
+
+/**
+ * Tests that calling methods on a closed {@link BrowserlessUIContext}
+ * throws {@link IllegalStateException}.
+ */
+class BrowserlessUIContextClosedTest {
+
+    private BrowserlessApplicationContext<Void> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews(
+                SimpleView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void activate_afterClose_throws() {
+        var window = app.newUser().newWindow();
+        window.close();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                window::activate,
+                "activate() on a closed context should throw");
+    }
+
+    @Test
+    void navigate_afterClose_throws() {
+        var window = app.newUser().newWindow();
+        window.close();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> window.navigate(SimpleView.class),
+                "navigate() on a closed context should throw");
+    }
+
+    @Test
+    void query_afterClose_throws() {
+        var window = app.newUser().newWindow();
+        window.close();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> window.$(Div.class),
+                "$() on a closed context should throw");
+    }
+
+    @Test
+    void close_isIdempotent() {
+        var window = app.newUser().newWindow();
+        window.close();
+        // Second close should not throw
+        Assertions.assertDoesNotThrow(window::close);
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
@@ -25,8 +25,8 @@ import com.vaadin.browserless.internal.Routes;
 import com.vaadin.flow.component.html.Div;
 
 /**
- * Tests that calling methods on a closed {@link BrowserlessUIContext}
- * throws {@link IllegalStateException}.
+ * Tests that calling methods on a closed {@link BrowserlessUIContext} throws
+ * {@link IllegalStateException}.
  */
 class BrowserlessUIContextClosedTest {
 
@@ -34,8 +34,8 @@ class BrowserlessUIContextClosedTest {
 
     @BeforeEach
     void setUp() {
-        Routes routes = new Routes().autoDiscoverViews(
-                SimpleView.class.getPackageName());
+        Routes routes = new Routes()
+                .autoDiscoverViews(SimpleView.class.getPackageName());
         app = BrowserlessApplicationContext.create(routes);
     }
 
@@ -49,8 +49,7 @@ class BrowserlessUIContextClosedTest {
         var window = app.newUser().newWindow();
         window.close();
 
-        Assertions.assertThrows(IllegalStateException.class,
-                window::activate,
+        Assertions.assertThrows(IllegalStateException.class, window::activate,
                 "activate() on a closed context should throw");
     }
 

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.UIFactory;
 import com.vaadin.flow.component.html.Div;
 
 /**
@@ -79,5 +80,32 @@ class BrowserlessUIContextClosedTest {
         window.close();
         // Second close should not throw
         Assertions.assertDoesNotThrow(window::close);
+    }
+
+    @Test
+    void newWindow_uiFactoryThrows_doesNotLeakActiveContext() {
+        UIFactory throwingFactory = () -> {
+            throw new IllegalStateException("simulated UI factory failure");
+        };
+        BrowserlessApplicationContext<Void> failingApp = BrowserlessApplicationContext
+                .<Void> builder(new Routes()
+                        .autoDiscoverViews(SimpleView.class.getPackageName()))
+                .withUIFactory(throwingFactory).build();
+        BrowserlessUIContext leakedActive;
+        try {
+            var failingUser = failingApp.newUser();
+            Assertions.assertThrows(RuntimeException.class,
+                    failingUser::newWindow,
+                    "newWindow() should propagate the UI factory failure");
+            leakedActive = BrowserlessUIContext.getActive();
+        } finally {
+            // Defensively clear so a failing assertion does not poison other
+            // tests sharing this thread.
+            BrowserlessUIContext.clearActiveContext();
+            failingApp.close();
+        }
+        Assertions.assertNull(leakedActive,
+                "A failed UI construction must not leave a half-built"
+                        + " BrowserlessUIContext as the active context");
     }
 }

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
@@ -15,11 +15,20 @@
  */
 package com.vaadin.browserless;
 
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import com.example.SingleParam;
 import com.example.multiuser.SimpleView;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.vaadin.browserless.internal.Routes;
 import com.vaadin.browserless.internal.UIFactory;
@@ -36,7 +45,8 @@ class BrowserlessUIContextClosedTest {
     @BeforeEach
     void setUp() {
         Routes routes = new Routes()
-                .autoDiscoverViews(SimpleView.class.getPackageName());
+                .autoDiscoverViews(SimpleView.class.getPackageName())
+                .autoDiscoverViews(SingleParam.class.getPackageName());
         app = BrowserlessApplicationContext.create(routes);
     }
 
@@ -45,33 +55,49 @@ class BrowserlessUIContextClosedTest {
         app.close();
     }
 
-    @Test
-    void activate_afterClose_throws() {
-        var window = app.newUser().newWindow();
-        window.close();
-
-        Assertions.assertThrows(IllegalStateException.class, window::activate,
-                "activate() on a closed context should throw");
-    }
-
-    @Test
-    void navigate_afterClose_throws() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("dslMethodsThatRequireOpenContext")
+    void dslMethod_afterClose_throws(String name,
+            Consumer<BrowserlessUIContext> invocation) {
         var window = app.newUser().newWindow();
         window.close();
 
         Assertions.assertThrows(IllegalStateException.class,
-                () -> window.navigate(SimpleView.class),
-                "navigate() on a closed context should throw");
+                () -> invocation.accept(window),
+                name + " on a closed context should throw");
     }
 
-    @Test
-    void query_afterClose_throws() {
-        var window = app.newUser().newWindow();
-        window.close();
+    static Stream<Arguments> dslMethodsThatRequireOpenContext() {
+        return Stream.of(row("activate()", BrowserlessUIContext::activate),
+                row("navigate(Class)", w -> w.navigate(SimpleView.class)),
+                row("navigate(Class, parameter)",
+                        w -> w.navigate(SingleParam.class, "x")),
+                row("navigate(Class, parameters)",
+                        w -> w.navigate(SimpleView.class, Map.of())),
+                row("navigate(String, Class)",
+                        w -> w.navigate("simple", SimpleView.class)),
+                row("$(Class)", w -> w.$(Div.class)),
+                row("$(Class, Component)", w -> w.$(Div.class, new Div())),
+                row("$view(Class)", w -> w.$view(SimpleView.class)),
+                row("get(Class)", w -> w.get(Div.class)),
+                row("get(Class, Component)", w -> w.get(Div.class, new Div())),
+                row("getView(Class)", w -> w.getView(SimpleView.class)),
+                // SimpleView (VerticalLayout) has no TesterWrappers overload,
+                // so it routes to the generic test(Y) which calls activate().
+                row("test(Component)", w -> w.test(new SimpleView())),
+                row("getCurrentView()", BrowserlessUIContext::getCurrentView),
+                row("roundTrip()", BrowserlessUIContext::roundTrip),
+                row("getExternalNavigationURL()",
+                        BrowserlessUIContext::getExternalNavigationURL),
+                row("getExternalNavigationURL(String)",
+                        w -> w.getExternalNavigationURL("popup")),
+                row("getOpenedWindows()",
+                        BrowserlessUIContext::getOpenedWindows));
+    }
 
-        Assertions.assertThrows(IllegalStateException.class,
-                () -> window.$(Div.class),
-                "$() on a closed context should throw");
+    private static Arguments row(String name,
+            Consumer<BrowserlessUIContext> invocation) {
+        return Arguments.of(Named.of(name, name), invocation);
     }
 
     @Test

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextClosedTest.java
@@ -40,7 +40,7 @@ import com.vaadin.flow.component.html.Div;
  */
 class BrowserlessUIContextClosedTest {
 
-    private BrowserlessApplicationContext<Void> app;
+    private BrowserlessApplicationContext app;
 
     @BeforeEach
     void setUp() {
@@ -113,8 +113,8 @@ class BrowserlessUIContextClosedTest {
         UIFactory throwingFactory = () -> {
             throw new IllegalStateException("simulated UI factory failure");
         };
-        BrowserlessApplicationContext<Void> failingApp = BrowserlessApplicationContext
-                .<Void> builder(new Routes()
+        BrowserlessApplicationContext failingApp = BrowserlessApplicationContext
+                .builder(new Routes()
                         .autoDiscoverViews(SimpleView.class.getPackageName()))
                 .withUIFactory(throwingFactory).build();
         BrowserlessUIContext leakedActive;

--- a/junit6/src/test/java/com/vaadin/browserless/CapturingSecurityHandler.java
+++ b/junit6/src/test/java/com/vaadin/browserless/CapturingSecurityHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+/**
+ * Minimal {@link SecurityContextHandler} that stores a string snapshot in a
+ * thread-local, so tests can observe save/restore behaviour without pulling in
+ * Spring or Quarkus dependencies.
+ */
+class CapturingSecurityHandler implements SecurityContextHandler<String> {
+
+    final ThreadLocal<String> live = new ThreadLocal<>();
+
+    @Override
+    public void setupAuthentication(String credentials) {
+        live.set(credentials != null ? credentials : "<anon>");
+    }
+
+    @Override
+    public Object saveContext() {
+        return live.get();
+    }
+
+    @Override
+    public void restoreContext(Object snapshot) {
+        if (snapshot == null) {
+            live.remove();
+        } else if (snapshot instanceof String s) {
+            live.set(s);
+        } else {
+            throw new IllegalArgumentException(
+                    "Expected a String snapshot, got "
+                            + snapshot.getClass().getName());
+        }
+    }
+
+    @Override
+    public void clearContext() {
+        live.remove();
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
@@ -56,8 +56,7 @@ class ExternalNavigationTest {
         Assertions.assertNull(ui.getExternalNavigationURL());
 
         // Click Page.setLocation button
-        ui.test(ui.$(Button.class).withText("Go to Vaadin").single())
-                .click();
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
 
         Assertions.assertEquals("https://vaadin.com/",
                 ui.getExternalNavigationURL());
@@ -73,8 +72,7 @@ class ExternalNavigationTest {
         ui.test(ui.$(Button.class).withText("Pay").single()).click();
 
         Assertions.assertNull(ui.getExternalNavigationURL());
-        Assertions.assertEquals(
-                "https://payment.example.com/checkout?id=123",
+        Assertions.assertEquals("https://payment.example.com/checkout?id=123",
                 ui.getExternalNavigationURL("_blank"));
     }
 
@@ -149,10 +147,8 @@ class ExternalNavigationTest {
         ui.test(ui.$(Button.class).withText("Open Tab 2").single()).click();
 
         Map<String, List<String>> opened = ui.getOpenedWindows();
-        Assertions.assertEquals(
-                List.of("https://tab1.example.com/",
-                        "https://tab2.example.com/"),
-                opened.get("_blank"));
+        Assertions.assertEquals(List.of("https://tab1.example.com/",
+                "https://tab2.example.com/"), opened.get("_blank"));
     }
 
     @Test
@@ -180,8 +176,7 @@ class ExternalNavigationTest {
                 "helpWindow");
 
         Map<String, List<String>> opened = ui.getOpenedWindows();
-        Assertions.assertEquals(
-                List.of("https://help.example.com/updated"),
+        Assertions.assertEquals(List.of("https://help.example.com/updated"),
                 opened.get("helpWindow"));
     }
 
@@ -202,12 +197,9 @@ class ExternalNavigationTest {
         // openedWindows contains only non-self entries
         Map<String, List<String>> opened = ui.getOpenedWindows();
         Assertions.assertEquals(2, opened.size());
-        Assertions.assertEquals(
-                List.of("https://help.example.com/"),
+        Assertions.assertEquals(List.of("https://help.example.com/"),
                 opened.get("helpWindow"));
-        Assertions.assertEquals(
-                List.of("https://tab1.example.com/",
-                        "https://tab2.example.com/"),
-                opened.get("_blank"));
+        Assertions.assertEquals(List.of("https://tab1.example.com/",
+                "https://tab2.example.com/"), opened.get("_blank"));
     }
 }

--- a/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.List;
+import java.util.Map;
+
+import com.example.multiuser.ExternalNavigationView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.button.Button;
+
+/**
+ * Tests capturing external navigation URLs triggered by
+ * {@code Page.setLocation()} and {@code Page.open()}.
+ */
+class ExternalNavigationTest {
+
+    private BrowserlessApplicationContext<Void> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews(
+                ExternalNavigationView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void getExternalNavigationURL_capturesSetLocation() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        // No navigation yet
+        Assertions.assertNull(ui.getExternalNavigationURL());
+
+        // Click Page.setLocation button
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single())
+                .click();
+
+        Assertions.assertEquals("https://vaadin.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_capturesPageOpen() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        // Page.open() uses _blank, so getExternalNavigationURL() (which
+        // returns _self navigations) should remain null
+        ui.test(ui.$(Button.class).withText("Pay").single()).click();
+
+        Assertions.assertNull(ui.getExternalNavigationURL());
+        Assertions.assertEquals(
+                "https://payment.example.com/checkout?id=123",
+                ui.getExternalNavigationURL("_blank"));
+    }
+
+    @Test
+    void getExternalNavigationURL_namedWindow() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
+
+        Assertions.assertEquals("https://help.example.com/",
+                ui.getExternalNavigationURL("helpWindow"));
+        // Should not appear as a _self navigation
+        Assertions.assertNull(ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_parentNormalizesToSelf() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
+
+        Assertions.assertEquals("https://parent.example.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_topNormalizesToSelf() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Open Top").single()).click();
+
+        Assertions.assertEquals("https://top.example.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_setLocationOverwritesPrevious() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
+
+        // _parent is normalized to _self, so it overwrites the setLocation
+        Assertions.assertEquals("https://parent.example.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getExternalNavigationURL_isNonDestructive() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+
+        // Calling multiple times returns the same value
+        Assertions.assertEquals("https://vaadin.com/",
+                ui.getExternalNavigationURL());
+        Assertions.assertEquals("https://vaadin.com/",
+                ui.getExternalNavigationURL());
+    }
+
+    @Test
+    void getOpenedWindows_blankAccumulatesAllCalls() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Open Tab 1").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Tab 2").single()).click();
+
+        Map<String, List<String>> opened = ui.getOpenedWindows();
+        Assertions.assertEquals(
+                List.of("https://tab1.example.com/",
+                        "https://tab2.example.com/"),
+                opened.get("_blank"));
+    }
+
+    @Test
+    void getOpenedWindows_excludesSelfNavigations() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Parent").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Top").single()).click();
+
+        // All three are _self navigations, so openedWindows should be empty
+        Assertions.assertTrue(ui.getOpenedWindows().isEmpty());
+    }
+
+    @Test
+    void getOpenedWindows_namedWindowLastUrlWins() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        // Open two different URLs in the same named window
+        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
+        // Navigate the same named window to a different URL via setLocation
+        ui.getUI().getPage().open("https://help.example.com/updated",
+                "helpWindow");
+
+        Map<String, List<String>> opened = ui.getOpenedWindows();
+        Assertions.assertEquals(
+                List.of("https://help.example.com/updated"),
+                opened.get("helpWindow"));
+    }
+
+    @Test
+    void getOpenedWindows_mixedWindowTypes() {
+        var ui = app.newUser().newWindow();
+        ui.navigate(ExternalNavigationView.class);
+
+        ui.test(ui.$(Button.class).withText("Go to Vaadin").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Help").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Tab 1").single()).click();
+        ui.test(ui.$(Button.class).withText("Open Tab 2").single()).click();
+
+        // _self navigation captured separately
+        Assertions.assertEquals("https://vaadin.com/",
+                ui.getExternalNavigationURL());
+
+        // openedWindows contains only non-self entries
+        Map<String, List<String>> opened = ui.getOpenedWindows();
+        Assertions.assertEquals(2, opened.size());
+        Assertions.assertEquals(
+                List.of("https://help.example.com/"),
+                opened.get("helpWindow"));
+        Assertions.assertEquals(
+                List.of("https://tab1.example.com/",
+                        "https://tab2.example.com/"),
+                opened.get("_blank"));
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ExternalNavigationTest.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.component.button.Button;
  */
 class ExternalNavigationTest {
 
-    private BrowserlessApplicationContext<Void> app;
+    private BrowserlessApplicationContext app;
 
     @BeforeEach
     void setUp() {

--- a/junit6/src/test/java/com/vaadin/browserless/MultiTabTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiTabTest.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test;
 import com.vaadin.browserless.internal.Routes;
 
 /**
- * Tests multi-tab scenarios: one user with multiple windows
- * sharing a session but with independent UI state.
+ * Tests multi-tab scenarios: one user with multiple windows sharing a session
+ * but with independent UI state.
  */
 class MultiTabTest {
 
@@ -35,8 +35,8 @@ class MultiTabTest {
     @BeforeEach
     void setUp() {
         SharedCounterView.counter.set(0);
-        Routes routes = new Routes().autoDiscoverViews(
-                SharedCounterView.class.getPackageName());
+        Routes routes = new Routes()
+                .autoDiscoverViews(SharedCounterView.class.getPackageName());
         app = BrowserlessApplicationContext.create(routes);
     }
 
@@ -52,10 +52,8 @@ class MultiTabTest {
         var window2 = user.newWindow();
 
         // Same session
-        Assertions.assertSame(user.getSession(),
-                window1.getUI().getSession());
-        Assertions.assertSame(user.getSession(),
-                window2.getUI().getSession());
+        Assertions.assertSame(user.getSession(), window1.getUI().getSession());
+        Assertions.assertSame(user.getSession(), window2.getUI().getSession());
 
         // But different UI instances
         Assertions.assertNotSame(window1.getUI(), window2.getUI());
@@ -74,7 +72,6 @@ class MultiTabTest {
         // Each window shows its own view
         Assertions.assertInstanceOf(SharedCounterView.class,
                 window1.getCurrentView());
-        Assertions.assertInstanceOf(SimpleView.class,
-                window2.getCurrentView());
+        Assertions.assertInstanceOf(SimpleView.class, window2.getCurrentView());
     }
 }

--- a/junit6/src/test/java/com/vaadin/browserless/MultiTabTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiTabTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.multiuser.SharedCounterView;
+import com.example.multiuser.SimpleView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests multi-tab scenarios: one user with multiple windows
+ * sharing a session but with independent UI state.
+ */
+class MultiTabTest {
+
+    private BrowserlessApplicationContext<Void> app;
+
+    @BeforeEach
+    void setUp() {
+        SharedCounterView.counter.set(0);
+        Routes routes = new Routes().autoDiscoverViews(
+                SharedCounterView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void sameUser_multipleWindows_shareSession() {
+        var user = app.newUser();
+        var window1 = user.newWindow();
+        var window2 = user.newWindow();
+
+        // Same session
+        Assertions.assertSame(user.getSession(),
+                window1.getUI().getSession());
+        Assertions.assertSame(user.getSession(),
+                window2.getUI().getSession());
+
+        // But different UI instances
+        Assertions.assertNotSame(window1.getUI(), window2.getUI());
+    }
+
+    @Test
+    void sameUser_multipleWindows_independentViews() {
+        var user = app.newUser();
+        var window1 = user.newWindow();
+        var window2 = user.newWindow();
+
+        // Navigate to different views
+        window1.navigate(SharedCounterView.class);
+        window2.navigate(SimpleView.class);
+
+        // Each window shows its own view
+        Assertions.assertInstanceOf(SharedCounterView.class,
+                window1.getCurrentView());
+        Assertions.assertInstanceOf(SimpleView.class,
+                window2.getCurrentView());
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.multiuser.SharedCounterView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Paragraph;
+
+/**
+ * Tests multi-user scenarios: two independent users sharing
+ * application-level state via a static counter.
+ */
+class MultiUserTest {
+
+    private BrowserlessApplicationContext<Void> app;
+
+    @BeforeEach
+    void setUp() {
+        SharedCounterView.counter.set(0);
+        Routes routes = new Routes().autoDiscoverViews(
+                SharedCounterView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void twoUsers_shareApplicationState() {
+        var user1 = app.newUser();
+        var w1 = user1.newWindow();
+        w1.navigate(SharedCounterView.class);
+
+        var user2 = app.newUser();
+        var w2 = user2.newWindow();
+        w2.navigate(SharedCounterView.class);
+
+        // User1 increments counter
+        w1.test(w1.$(Button.class).withText("Increment").single()).click();
+        Assertions.assertEquals("Count: 1",
+                w1.$(Paragraph.class).single().getText());
+
+        // User2 doesn't see the change yet (own UI state)
+        Assertions.assertEquals("Count: 0",
+                w2.$(Paragraph.class).single().getText());
+
+        // User2 refreshes to see updated shared state
+        w2.test(w2.$(Button.class).withText("Refresh").single()).click();
+        Assertions.assertEquals("Count: 1",
+                w2.$(Paragraph.class).single().getText());
+    }
+
+    @Test
+    void users_haveIndependentSessions() {
+        var user1 = app.newUser();
+        var w1 = user1.newWindow();
+
+        var user2 = app.newUser();
+        var w2 = user2.newWindow();
+
+        Assertions.assertNotSame(user1.getSession(), user2.getSession(),
+                "Users should have independent sessions");
+        Assertions.assertNotSame(w1.getUI(), w2.getUI(),
+                "Windows should have independent UIs");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
@@ -26,8 +26,8 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Paragraph;
 
 /**
- * Tests multi-user scenarios: two independent users sharing
- * application-level state via a static counter.
+ * Tests multi-user scenarios: two independent users sharing application-level
+ * state via a static counter.
  */
 class MultiUserTest {
 
@@ -36,8 +36,8 @@ class MultiUserTest {
     @BeforeEach
     void setUp() {
         SharedCounterView.counter.set(0);
-        Routes routes = new Routes().autoDiscoverViews(
-                SharedCounterView.class.getPackageName());
+        Routes routes = new Routes()
+                .autoDiscoverViews(SharedCounterView.class.getPackageName());
         app = BrowserlessApplicationContext.create(routes);
     }
 

--- a/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiUserTest.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.component.html.Paragraph;
  */
 class MultiUserTest {
 
-    private BrowserlessApplicationContext<Void> app;
+    private BrowserlessApplicationContext app;
 
     @BeforeEach
     void setUp() {

--- a/junit6/src/test/java/com/vaadin/browserless/MultiWindowTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiWindowTest.java
@@ -23,12 +23,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Paragraph;
 
 /**
- * Tests multi-tab scenarios: one user with multiple windows sharing a session
- * but with independent UI state.
+ * Tests multi-window scenarios: one user with multiple windows sharing a
+ * session but with independent UI state.
  */
-class MultiTabTest {
+class MultiWindowTest {
 
     private BrowserlessApplicationContext<Void> app;
 
@@ -57,6 +59,39 @@ class MultiTabTest {
 
         // But different UI instances
         Assertions.assertNotSame(window1.getUI(), window2.getUI());
+    }
+
+    @Test
+    void sameUser_interleavingOperations_preservePerWindowViewState() {
+        var user = app.newUser();
+        var w1 = user.newWindow();
+        var w2 = user.newWindow();
+
+        w1.navigate(SharedCounterView.class);
+        w2.navigate(SharedCounterView.class);
+
+        // w1 increments — its display reflects the new shared counter
+        w1.test(w1.$(Button.class).withText("Increment").single()).click();
+        Assertions.assertEquals("Count: 1",
+                w1.$(Paragraph.class).single().getText());
+
+        // w2 increments — its display reflects the (now larger) counter
+        w2.test(w2.$(Button.class).withText("Increment").single()).click();
+        Assertions.assertEquals("Count: 2",
+                w2.$(Paragraph.class).single().getText());
+
+        // Switching back to w1 must not corrupt its independent UI state —
+        // the display still shows the value from w1's own last increment,
+        // not whatever w2 most recently set.
+        Assertions.assertEquals("Count: 1",
+                w1.$(Paragraph.class).single().getText(),
+                "w1's display should retain its own state across"
+                        + " activations from w2");
+
+        // And w1 can still observe the shared counter via Refresh.
+        w1.test(w1.$(Button.class).withText("Refresh").single()).click();
+        Assertions.assertEquals("Count: 2",
+                w1.$(Paragraph.class).single().getText());
     }
 
     @Test

--- a/junit6/src/test/java/com/vaadin/browserless/MultiWindowTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/MultiWindowTest.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.component.html.Paragraph;
  */
 class MultiWindowTest {
 
-    private BrowserlessApplicationContext<Void> app;
+    private BrowserlessApplicationContext app;
 
     @BeforeEach
     void setUp() {

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
@@ -73,8 +73,8 @@ public final class QuarkusBrowserlessApplicationContext {
             Routes routes, UIFactory uiFactory) {
         BrowserlessApplicationContext.Builder<SecurityIdentity> builder = BrowserlessApplicationContext
                 .<SecurityIdentity> builder(routes)
-                .withServletFactory(r -> new MockQuarkusServlet(r,
-                        CDI.current().getBeanManager(), uiFactory))
+                .withServletFactory((r, uif) -> new MockQuarkusServlet(r,
+                        CDI.current().getBeanManager(), uif))
                 .withUIFactory(uiFactory)
                 .withLookupServices(QuarkusTestLookupInitializer.class);
         if (QuarkusSecuritySupport.isPresent()) {

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
@@ -71,12 +71,16 @@ public final class QuarkusBrowserlessApplicationContext {
      */
     public static BrowserlessApplicationContext<SecurityIdentity> create(
             Routes routes, UIFactory uiFactory) {
-        return BrowserlessApplicationContext.<SecurityIdentity> builder(routes)
+        BrowserlessApplicationContext.Builder<SecurityIdentity> builder = BrowserlessApplicationContext
+                .<SecurityIdentity> builder(routes)
                 .withServletFactory(r -> new MockQuarkusServlet(r,
                         CDI.current().getBeanManager(), uiFactory))
                 .withUIFactory(uiFactory)
-                .withLookupServices(QuarkusTestLookupInitializer.class)
-                .withSecurityContextHandler(new QuarkusSecurityContextHandler())
-                .build();
+                .withLookupServices(QuarkusTestLookupInitializer.class);
+        if (QuarkusSecuritySupport.isPresent()) {
+            builder.withSecurityContextHandler(
+                    new QuarkusSecurityContextHandler());
+        }
+        return builder.build();
     }
 }

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import java.util.Set;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.UIFactory;
+import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
+
+/**
+ * Factory for creating a Quarkus-integrated
+ * {@link BrowserlessApplicationContext}.
+ * <p>
+ * Configures the context with a Quarkus-aware servlet, security context
+ * handling, and lookup services.
+ *
+ * <pre>
+ * var app = QuarkusBrowserlessApplicationContext.create(routes);
+ * var admin = app.newUser(securityIdentity);
+ * var window = admin.newWindow();
+ * window.navigate(ProtectedView.class);
+ * </pre>
+ *
+ * @see BrowserlessApplicationContext
+ * @see QuarkusSecurityContextHandler
+ */
+public final class QuarkusBrowserlessApplicationContext {
+
+    private QuarkusBrowserlessApplicationContext() {
+    }
+
+    /**
+     * Creates a Quarkus-integrated application context.
+     *
+     * @param routes the discovered routes
+     * @return a new application context configured for Quarkus
+     */
+    public static BrowserlessApplicationContext<SecurityIdentity> create(
+            Routes routes) {
+        return create(routes, () -> new MockedUI());
+    }
+
+    /**
+     * Creates a Quarkus-integrated application context with a custom UI
+     * factory.
+     *
+     * @param routes    the discovered routes
+     * @param uiFactory the UI factory
+     * @return a new application context configured for Quarkus
+     */
+    public static BrowserlessApplicationContext<SecurityIdentity> create(
+            Routes routes, UIFactory uiFactory) {
+        return BrowserlessApplicationContext
+                .<SecurityIdentity>builder(routes)
+                .withServletFactory(r -> new MockQuarkusServlet(r,
+                        CDI.current().getBeanManager(), uiFactory))
+                .withUIFactory(uiFactory)
+                .withLookupServices(
+                        Set.of(QuarkusTestLookupInitializer.class))
+                .withSecurityContextHandler(
+                        new QuarkusSecurityContextHandler())
+                .build();
+    }
+}

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
@@ -17,8 +17,6 @@ package com.vaadin.browserless.quarkus;
 
 import jakarta.enterprise.inject.spi.CDI;
 
-import java.util.Set;
-
 import io.quarkus.security.identity.SecurityIdentity;
 
 import com.vaadin.browserless.BrowserlessApplicationContext;
@@ -77,7 +75,7 @@ public final class QuarkusBrowserlessApplicationContext {
                 .withServletFactory(r -> new MockQuarkusServlet(r,
                         CDI.current().getBeanManager(), uiFactory))
                 .withUIFactory(uiFactory)
-                .withLookupServices(Set.of(QuarkusTestLookupInitializer.class))
+                .withLookupServices(QuarkusTestLookupInitializer.class)
                 .withSecurityContextHandler(new QuarkusSecurityContextHandler())
                 .build();
     }

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
@@ -52,7 +52,8 @@ public final class QuarkusBrowserlessApplicationContext {
     /**
      * Creates a Quarkus-integrated application context.
      *
-     * @param routes the discovered routes
+     * @param routes
+     *            the discovered routes
      * @return a new application context configured for Quarkus
      */
     public static BrowserlessApplicationContext<SecurityIdentity> create(
@@ -64,21 +65,20 @@ public final class QuarkusBrowserlessApplicationContext {
      * Creates a Quarkus-integrated application context with a custom UI
      * factory.
      *
-     * @param routes    the discovered routes
-     * @param uiFactory the UI factory
+     * @param routes
+     *            the discovered routes
+     * @param uiFactory
+     *            the UI factory
      * @return a new application context configured for Quarkus
      */
     public static BrowserlessApplicationContext<SecurityIdentity> create(
             Routes routes, UIFactory uiFactory) {
-        return BrowserlessApplicationContext
-                .<SecurityIdentity>builder(routes)
+        return BrowserlessApplicationContext.<SecurityIdentity> builder(routes)
                 .withServletFactory(r -> new MockQuarkusServlet(r,
                         CDI.current().getBeanManager(), uiFactory))
                 .withUIFactory(uiFactory)
-                .withLookupServices(
-                        Set.of(QuarkusTestLookupInitializer.class))
-                .withSecurityContextHandler(
-                        new QuarkusSecurityContextHandler())
+                .withLookupServices(Set.of(QuarkusTestLookupInitializer.class))
+                .withSecurityContextHandler(new QuarkusSecurityContextHandler())
                 .build();
     }
 }

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessApplicationContext.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.inject.spi.CDI;
 import io.quarkus.security.identity.SecurityIdentity;
 
 import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.SecuredBrowserlessApplicationContext;
 import com.vaadin.browserless.internal.Routes;
 import com.vaadin.browserless.internal.UIFactory;
 import com.vaadin.browserless.mocks.MockedUI;
@@ -29,17 +30,28 @@ import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
  * Factory for creating a Quarkus-integrated
  * {@link BrowserlessApplicationContext}.
  * <p>
- * Configures the context with a Quarkus-aware servlet, security context
- * handling, and lookup services.
+ * Wires a Quarkus-aware servlet and the {@link QuarkusTestLookupInitializer}.
+ * Three entry points are provided:
+ * <ul>
+ * <li>{@link #create(Routes)} — returns the unsecured
+ * {@link BrowserlessApplicationContext}.</li>
+ * <li>{@link #createSecured(Routes)} — returns the credential-typed
+ * {@link SecuredBrowserlessApplicationContext}; requires Quarkus Security on
+ * the classpath.</li>
+ * <li>{@link #builder(Routes)} — returns a pre-wired
+ * {@link BrowserlessApplicationContext.Builder} for full customization (e.g.
+ * plugging in a different security handler).</li>
+ * </ul>
  *
  * <pre>
- * var app = QuarkusBrowserlessApplicationContext.create(routes);
+ * var app = QuarkusBrowserlessApplicationContext.createSecured(routes);
  * var admin = app.newUser(securityIdentity);
  * var window = admin.newWindow();
  * window.navigate(ProtectedView.class);
  * </pre>
  *
  * @see BrowserlessApplicationContext
+ * @see SecuredBrowserlessApplicationContext
  * @see QuarkusSecurityContextHandler
  */
 public final class QuarkusBrowserlessApplicationContext {
@@ -48,39 +60,100 @@ public final class QuarkusBrowserlessApplicationContext {
     }
 
     /**
-     * Creates a Quarkus-integrated application context.
+     * Creates a Quarkus-pre-wired builder. The builder has the Quarkus servlet
+     * and the lookup initializer configured; callers can chain additional
+     * customizations before calling
+     * {@link BrowserlessApplicationContext.Builder#build()}.
      *
      * @param routes
      *            the discovered routes
-     * @return a new application context configured for Quarkus
+     * @return a pre-wired builder
      */
-    public static BrowserlessApplicationContext<SecurityIdentity> create(
-            Routes routes) {
-        return create(routes, () -> new MockedUI());
+    public static BrowserlessApplicationContext.Builder builder(Routes routes) {
+        return builder(routes, () -> new MockedUI());
     }
 
     /**
-     * Creates a Quarkus-integrated application context with a custom UI
-     * factory.
+     * Creates a Quarkus-pre-wired builder with a custom UI factory.
      *
      * @param routes
      *            the discovered routes
      * @param uiFactory
      *            the UI factory
-     * @return a new application context configured for Quarkus
+     * @return a pre-wired builder
      */
-    public static BrowserlessApplicationContext<SecurityIdentity> create(
-            Routes routes, UIFactory uiFactory) {
-        BrowserlessApplicationContext.Builder<SecurityIdentity> builder = BrowserlessApplicationContext
-                .<SecurityIdentity> builder(routes)
+    public static BrowserlessApplicationContext.Builder builder(Routes routes,
+            UIFactory uiFactory) {
+        return BrowserlessApplicationContext.builder(routes)
                 .withServletFactory((r, uif) -> new MockQuarkusServlet(r,
                         CDI.current().getBeanManager(), uif))
                 .withUIFactory(uiFactory)
                 .withLookupServices(QuarkusTestLookupInitializer.class);
-        if (QuarkusSecuritySupport.isPresent()) {
-            builder.withSecurityContextHandler(
-                    new QuarkusSecurityContextHandler());
+    }
+
+    /**
+     * Creates an unsecured Quarkus-integrated application context.
+     *
+     * @param routes
+     *            the discovered routes
+     * @return a new unsecured application context configured for Quarkus
+     */
+    public static BrowserlessApplicationContext create(Routes routes) {
+        return builder(routes).build();
+    }
+
+    /**
+     * Creates an unsecured Quarkus-integrated application context with a custom
+     * UI factory.
+     *
+     * @param routes
+     *            the discovered routes
+     * @param uiFactory
+     *            the UI factory
+     * @return a new unsecured application context configured for Quarkus
+     */
+    public static BrowserlessApplicationContext create(Routes routes,
+            UIFactory uiFactory) {
+        return builder(routes, uiFactory).build();
+    }
+
+    /**
+     * Creates a Quarkus-integrated application context with Quarkus Security
+     * wiring. Requires Quarkus Security on the classpath; throws otherwise.
+     *
+     * @param routes
+     *            the discovered routes
+     * @return a new secured application context configured for Quarkus Security
+     * @throws IllegalStateException
+     *             if Quarkus Security is not on the classpath
+     */
+    public static SecuredBrowserlessApplicationContext<SecurityIdentity> createSecured(
+            Routes routes) {
+        return createSecured(routes, () -> new MockedUI());
+    }
+
+    /**
+     * Creates a secured Quarkus-integrated application context with a custom UI
+     * factory. Requires Quarkus Security on the classpath; throws otherwise.
+     *
+     * @param routes
+     *            the discovered routes
+     * @param uiFactory
+     *            the UI factory
+     * @return a new secured application context configured for Quarkus Security
+     * @throws IllegalStateException
+     *             if Quarkus Security is not on the classpath
+     */
+    public static SecuredBrowserlessApplicationContext<SecurityIdentity> createSecured(
+            Routes routes, UIFactory uiFactory) {
+        if (!QuarkusSecuritySupport.isPresent()) {
+            throw new IllegalStateException(
+                    "QuarkusBrowserlessApplicationContext.createSecured(...)"
+                            + " requires Quarkus Security on the classpath."
+                            + " Use create(...) for unsecured contexts.");
         }
-        return builder.build();
+        return builder(routes, uiFactory)
+                .withSecurityContextHandler(new QuarkusSecurityContextHandler())
+                .build();
     }
 }

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -17,8 +17,7 @@ package com.vaadin.browserless.quarkus;
 
 import jakarta.enterprise.inject.spi.CDI;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Set;
 
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -86,7 +85,6 @@ public class QuarkusSecurityContextHandler
             String... roles) {
         return QuarkusSecurityIdentity.builder()
                 .setPrincipal(new QuarkusPrincipal(username))
-                .addRoles(new HashSet<>(Arrays.asList(roles)))
-                .setAnonymous(false).build();
+                .addRoles(Set.of(roles)).setAnonymous(false).build();
     }
 }

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -29,7 +29,7 @@ import com.vaadin.browserless.SecurityContextHandler;
  * Manages the {@link SecurityIdentity} via {@link CurrentIdentityAssociation}
  * for multi-user test isolation.
  * <p>
- * The {@link #setupAuthentication(Object)} method expects a
+ * The {@link #setupAuthentication(SecurityIdentity)} method expects a
  * {@link SecurityIdentity} instance as the credentials parameter.
  *
  * @see SecurityContextHandler

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+
+import com.vaadin.browserless.SecurityContextHandler;
+
+/**
+ * Quarkus Security implementation of {@link SecurityContextHandler}.
+ * <p>
+ * Manages the {@link SecurityIdentity} via
+ * {@link CurrentIdentityAssociation} for multi-user test isolation.
+ * <p>
+ * The {@link #setupAuthentication(Object)} method expects a
+ * {@link SecurityIdentity} instance as the credentials parameter.
+ *
+ * @see SecurityContextHandler
+ * @see QuarkusBrowserlessApplicationContext
+ */
+public class QuarkusSecurityContextHandler
+        implements SecurityContextHandler<SecurityIdentity> {
+
+    @Override
+    public void setupAuthentication(SecurityIdentity credentials) {
+        if (credentials != null) {
+            getIdentityAssociation().setIdentity(credentials);
+        }
+    }
+
+    @Override
+    public Object saveContext() {
+        try {
+            return CurrentIdentityAssociation.current();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void restoreContext(Object snapshot) {
+        if (snapshot instanceof SecurityIdentity identity) {
+            getIdentityAssociation().setIdentity(identity);
+        } else {
+            clearContext();
+        }
+    }
+
+    @Override
+    public void clearContext() {
+        getIdentityAssociation().setIdentity(
+                QuarkusSecurityIdentity.builder()
+                        .setAnonymous(true).build());
+    }
+
+    private CurrentIdentityAssociation getIdentityAssociation() {
+        return CDI.current().select(CurrentIdentityAssociation.class).get();
+    }
+}

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -26,8 +26,8 @@ import com.vaadin.browserless.SecurityContextHandler;
 /**
  * Quarkus Security implementation of {@link SecurityContextHandler}.
  * <p>
- * Manages the {@link SecurityIdentity} via
- * {@link CurrentIdentityAssociation} for multi-user test isolation.
+ * Manages the {@link SecurityIdentity} via {@link CurrentIdentityAssociation}
+ * for multi-user test isolation.
  * <p>
  * The {@link #setupAuthentication(Object)} method expects a
  * {@link SecurityIdentity} instance as the credentials parameter.
@@ -66,8 +66,7 @@ public class QuarkusSecurityContextHandler
     @Override
     public void clearContext() {
         getIdentityAssociation().setIdentity(
-                QuarkusSecurityIdentity.builder()
-                        .setAnonymous(true).build());
+                QuarkusSecurityIdentity.builder().setAnonymous(true).build());
     }
 
     private CurrentIdentityAssociation getIdentityAssociation() {

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -17,8 +17,12 @@ package com.vaadin.browserless.quarkus;
 
 import jakarta.enterprise.inject.spi.CDI;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 
 import com.vaadin.browserless.SecurityContextHandler;
@@ -46,7 +50,7 @@ public class QuarkusSecurityContextHandler
     }
 
     @Override
-    public Object saveContext() {
+    public SecurityIdentity saveContext() {
         try {
             return CurrentIdentityAssociation.current();
         } catch (Exception e) {
@@ -56,10 +60,14 @@ public class QuarkusSecurityContextHandler
 
     @Override
     public void restoreContext(Object snapshot) {
-        if (snapshot instanceof SecurityIdentity identity) {
+        if (snapshot == null) {
+            clearContext();
+        } else if (snapshot instanceof SecurityIdentity identity) {
             getIdentityAssociation().setIdentity(identity);
         } else {
-            clearContext();
+            throw new IllegalArgumentException(
+                    "Expected a SecurityIdentity snapshot, got "
+                            + snapshot.getClass().getName());
         }
     }
 
@@ -71,5 +79,18 @@ public class QuarkusSecurityContextHandler
 
     private CurrentIdentityAssociation getIdentityAssociation() {
         return CDI.current().select(CurrentIdentityAssociation.class).get();
+    }
+
+    /**
+     * Builds a non-anonymous {@link SecurityIdentity} for the given username
+     * and roles.
+     */
+    @Override
+    public SecurityIdentity createCredentials(String username,
+            String... roles) {
+        return QuarkusSecurityIdentity.builder()
+                .setPrincipal(new QuarkusPrincipal(username))
+                .addRoles(new HashSet<>(Arrays.asList(roles)))
+                .setAnonymous(false).build();
     }
 }

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -44,9 +44,9 @@ public class QuarkusSecurityContextHandler
 
     @Override
     public void setupAuthentication(SecurityIdentity credentials) {
-        if (credentials != null) {
-            getIdentityAssociation().setIdentity(credentials);
-        }
+        SecurityIdentity identity = credentials != null ? credentials
+                : QuarkusSecurityIdentity.builder().setAnonymous(true).build();
+        getIdentityAssociation().setIdentity(identity);
     }
 
     @Override

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityContextHandler.java
@@ -51,11 +51,7 @@ public class QuarkusSecurityContextHandler
 
     @Override
     public SecurityIdentity saveContext() {
-        try {
-            return CurrentIdentityAssociation.current();
-        } catch (Exception e) {
-            return null;
-        }
+        return CurrentIdentityAssociation.current();
     }
 
     @Override

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
@@ -30,11 +30,11 @@ public class QuarkusSecurityCustomizer implements MockRequestCustomizer {
 
     @Override
     public void apply(MockRequest request) {
-        request.setUserPrincipalProvider(() -> {
+        request.principalProvider(() -> {
             SecurityIdentity current = CurrentIdentityAssociation.current();
             return current.isAnonymous() ? null : current.getPrincipal();
         });
-        request.setUserInRole((principal, role) -> {
+        request.roleChecker((principal, role) -> {
             SecurityIdentity current = CurrentIdentityAssociation.current();
             return !current.isAnonymous()
                     && current.getPrincipal().equals(principal)

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecuritySupport.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecuritySupport.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import java.util.function.BooleanSupplier;
+
+import com.vaadin.browserless.internal.UtilsKt;
+
+/**
+ * Detects whether Quarkus Security is active in the running application.
+ *
+ * <p>
+ * Used to gate optional Quarkus Security wiring (security context handler, mock
+ * request customizer) so that test applications without an active
+ * {@code quarkus-security} extension can still bootstrap the browserless
+ * context.
+ *
+ * <p>
+ * The classpath probe alone is not enough: extensions like
+ * {@code quarkus-undertow} bring {@code quarkus-security} in transitively, so
+ * the {@code CurrentIdentityAssociation} class can be present even when no bean
+ * is registered with Arc. We therefore also ask CDI whether the bean is
+ * resolvable.
+ *
+ * <p>
+ * For internal use only.
+ */
+final class QuarkusSecuritySupport {
+
+    private static final String CURRENT_IDENTITY_ASSOCIATION_CLASS = "io.quarkus.security.identity.CurrentIdentityAssociation";
+
+    private static final BooleanSupplier DEFAULT_DETECTOR = () -> {
+        Class<?> beanClass = UtilsKt
+                .findClass(CURRENT_IDENTITY_ASSOCIATION_CLASS);
+        if (beanClass == null) {
+            return false;
+        }
+        try {
+            return CDI.current().select(beanClass).isResolvable();
+        } catch (RuntimeException ex) {
+            // No active CDI container, or CDI failed during resolution
+            return false;
+        }
+    };
+
+    private static volatile BooleanSupplier detector = DEFAULT_DETECTOR;
+
+    private QuarkusSecuritySupport() {
+    }
+
+    static boolean isPresent() {
+        return detector.getAsBoolean();
+    }
+
+    /**
+     * Test seam: override the detector. Pass {@code null} to reset to the
+     * default probe.
+     */
+    static void overrideDetector(BooleanSupplier override) {
+        detector = override == null ? DEFAULT_DETECTOR : override;
+    }
+}

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusTestLookupInitializer.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusTestLookupInitializer.java
@@ -40,20 +40,11 @@ public class QuarkusTestLookupInitializer extends LookupInitializer {
             Map<Class<?>, Collection<Class<?>>> services,
             VaadinApplicationInitializationBootstrap bootstrap)
             throws ServletException {
-        if (securityPresent()) {
+        if (QuarkusSecuritySupport.isPresent()) {
             ensureService(services, MockRequestCustomizer.class,
                     QuarkusSecurityCustomizer.class);
         }
         super.initialize(context, services, bootstrap);
-    }
-
-    private boolean securityPresent() {
-        try {
-            return Thread.currentThread().getContextClassLoader().loadClass(
-                    "io.quarkus.security.identity.SecurityIdentity") != null;
-        } catch (ClassNotFoundException ex) {
-            return false;
-        }
     }
 
 }

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/MultiUserSecurityTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/MultiUserSecurityTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import java.util.Set;
+
+import com.testapp.security.LoginView;
+import com.testapp.security.ProtectedView;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests multi-user security context isolation with Quarkus Security. Verifies
+ * that switching between users' windows correctly saves and restores the
+ * Quarkus {@link SecurityIdentity}.
+ */
+@QuarkusTest
+@TestProfile(SecurityTestConfig.NavigationAccessControlConfig.class)
+class MultiUserSecurityTest {
+
+    private BrowserlessApplicationContext<SecurityIdentity> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
+        app = QuarkusBrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void authenticatedUser_seesProtectedView() {
+        var adminIdentity = QuarkusSecurityIdentity.builder()
+                .setPrincipal(new QuarkusPrincipal("john"))
+                .addRoles(Set.of("USER")).setAnonymous(false).build();
+
+        var admin = app.newUser(adminIdentity);
+        var adminWindow = admin.newWindow();
+
+        // Authenticated user sees the protected view
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+    }
+
+    @Test
+    void anonymousUser_redirectedToLogin() {
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Anonymous user is redirected to login
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> anonWindow.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                anonWindow.getCurrentView());
+    }
+
+    @Test
+    void multipleUsers_securityContextIsolated() {
+        var adminIdentity = QuarkusSecurityIdentity.builder()
+                .setPrincipal(new QuarkusPrincipal("john"))
+                .addRoles(Set.of("USER")).setAnonymous(false).build();
+
+        var admin = app.newUser(adminIdentity);
+        var adminWindow = admin.newWindow();
+
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Admin sees protected view
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+
+        // Anonymous user is redirected to login
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> anonWindow.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                anonWindow.getCurrentView());
+
+        // Switch back to admin — security context should be restored
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView(),
+                "Admin's security context should be restored after switching back");
+    }
+}

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/MultiUserSecurityTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/MultiUserSecurityTest.java
@@ -82,6 +82,16 @@ class MultiUserSecurityTest {
     }
 
     @Test
+    void newUser_byUsernameAndRoles_authenticatesUser() {
+        var window = app.newUser("john", "USER").newWindow();
+
+        // Helper-built identity grants access to a @PermitAll view
+        window.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                window.getCurrentView());
+    }
+
+    @Test
     void multipleUsers_securityContextIsolated() {
         var adminIdentity = QuarkusSecurityIdentity.builder()
                 .setPrincipal(new QuarkusPrincipal("john"))

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/MultiUserSecurityTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/MultiUserSecurityTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.SecuredBrowserlessApplicationContext;
 import com.vaadin.browserless.internal.Routes;
 
 /**
@@ -41,12 +41,12 @@ import com.vaadin.browserless.internal.Routes;
 @TestProfile(SecurityTestConfig.NavigationAccessControlConfig.class)
 class MultiUserSecurityTest {
 
-    private BrowserlessApplicationContext<SecurityIdentity> app;
+    private SecuredBrowserlessApplicationContext<SecurityIdentity> app;
 
     @BeforeEach
     void setUp() {
         Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
-        app = QuarkusBrowserlessApplicationContext.create(routes);
+        app = QuarkusBrowserlessApplicationContext.createSecured(routes);
     }
 
     @AfterEach

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusNewUserHelperTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusNewUserHelperTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import java.util.Set;
+
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests the {@code newUser(username, roles...)} helper in
+ * {@link QuarkusBrowserlessApplicationContext} and the
+ * {@link SecurityContextHandler}-level contract that {@code null} credentials
+ * must produce an anonymous-equivalent identity.
+ */
+@QuarkusTest
+@TestProfile(SecurityTestConfig.NavigationAccessControlConfig.class)
+class QuarkusNewUserHelperTest {
+
+    private BrowserlessApplicationContext<SecurityIdentity> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
+        app = QuarkusBrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void newUser_withUsernameAndRoles_installsIdentityWithPrincipalAndRoles() {
+        app.newUser("john", "USER", "ADMIN").newWindow();
+
+        SecurityIdentity identity = CurrentIdentityAssociation.current();
+        Assertions.assertEquals("john", identity.getPrincipal().getName());
+        Assertions.assertTrue(identity.getRoles().contains("USER"));
+        Assertions.assertTrue(identity.getRoles().contains("ADMIN"));
+        Assertions.assertFalse(identity.isAnonymous());
+    }
+
+    @Test
+    void anonymousUser_setsAnonymousIdentity() {
+        app.newUser().newWindow();
+
+        SecurityIdentity identity = CurrentIdentityAssociation.current();
+        Assertions.assertTrue(identity.isAnonymous(),
+                "Null credentials must install an anonymous-equivalent"
+                        + " SecurityIdentity per SecurityContextHandler"
+                        + " contract");
+    }
+
+    @Test
+    void setupAuthenticationNull_installsAnonymousIdentity_withoutPriorClear() {
+        var handler = new QuarkusSecurityContextHandler();
+
+        // Pre-load a non-anonymous identity so we can detect a no-op.
+        var admin = QuarkusSecurityIdentity.builder()
+                .setPrincipal(new QuarkusPrincipal("john"))
+                .addRoles(Set.of("USER")).setAnonymous(false).build();
+        CDI.current().select(CurrentIdentityAssociation.class).get()
+                .setIdentity(admin);
+
+        // The contract requires setupAuthentication(null) to produce an
+        // anonymous-equivalent state on its own — without relying on a prior
+        // clearContext() to have happened.
+        handler.setupAuthentication(null);
+
+        SecurityIdentity current = CurrentIdentityAssociation.current();
+        Assertions.assertTrue(current.isAnonymous(),
+                "setupAuthentication(null) must install an"
+                        + " anonymous-equivalent identity even when called"
+                        + " without a preceding clearContext()");
+    }
+}

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusNewUserHelperTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusNewUserHelperTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.SecuredBrowserlessApplicationContext;
 import com.vaadin.browserless.internal.Routes;
 
 /**
@@ -43,12 +43,12 @@ import com.vaadin.browserless.internal.Routes;
 @TestProfile(SecurityTestConfig.NavigationAccessControlConfig.class)
 class QuarkusNewUserHelperTest {
 
-    private BrowserlessApplicationContext<SecurityIdentity> app;
+    private SecuredBrowserlessApplicationContext<SecurityIdentity> app;
 
     @BeforeEach
     void setUp() {
         Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
-        app = QuarkusBrowserlessApplicationContext.create(routes);
+        app = QuarkusBrowserlessApplicationContext.createSecured(routes);
     }
 
     @AfterEach

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecurityAbsentTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecurityAbsentTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.MockRequestCustomizer;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Verifies that {@link QuarkusBrowserlessApplicationContext} bootstraps cleanly
+ * when {@code quarkus-security} is not on the test app's classpath. The
+ * detector is overridden to simulate the absent classpath without actually
+ * changing the Maven-resolved dependencies.
+ */
+@QuarkusTest
+class QuarkusSecurityAbsentTest {
+
+    @AfterEach
+    void tearDown() {
+        QuarkusSecuritySupport.overrideDetector(null);
+    }
+
+    @Test
+    void newUser_withoutQuarkusSecurity_doesNotThrow() {
+        QuarkusSecuritySupport.overrideDetector(() -> false);
+
+        Routes routes = new Routes();
+        try (var app = QuarkusBrowserlessApplicationContext.create(routes)) {
+            Assertions.assertDoesNotThrow(() -> {
+                var user = app.newUser();
+                user.newWindow();
+            });
+        }
+    }
+
+    @Test
+    void create_withoutQuarkusSecurity_doesNotInstallRequestCustomizerLookup() {
+        QuarkusSecuritySupport.overrideDetector(() -> false);
+
+        Routes routes = new Routes();
+        try (var app = QuarkusBrowserlessApplicationContext.create(routes)) {
+            // Trigger Lookup initialization via a window, then probe the
+            // current VaadinService for the registered MockRequestCustomizer.
+            app.newUser().newWindow();
+            Lookup lookup = VaadinService.getCurrent().getContext()
+                    .getAttribute(Lookup.class);
+            MockRequestCustomizer customizer = lookup
+                    .lookup(MockRequestCustomizer.class);
+            Assertions.assertFalse(
+                    customizer instanceof QuarkusSecurityCustomizer,
+                    "QuarkusSecurityCustomizer must not be registered as a"
+                            + " lookup service when Quarkus Security is"
+                            + " absent");
+        }
+    }
+
+    @Test
+    void create_withQuarkusSecurity_installsRequestCustomizerLookup() {
+        // Default detector: actual classpath probe (quarkus-security IS
+        // present in the quarkus module's test classpath).
+        Routes routes = new Routes();
+        try (var app = QuarkusBrowserlessApplicationContext.create(routes)) {
+            app.newUser().newWindow();
+            Lookup lookup = VaadinService.getCurrent().getContext()
+                    .getAttribute(Lookup.class);
+            Assertions.assertInstanceOf(QuarkusSecurityCustomizer.class,
+                    lookup.lookup(MockRequestCustomizer.class),
+                    "QuarkusSecurityCustomizer must be registered as a lookup"
+                            + " service when Quarkus Security is present");
+        }
+    }
+}

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecurityAbsentTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecurityAbsentTest.java
@@ -88,4 +88,18 @@ class QuarkusSecurityAbsentTest {
                             + " service when Quarkus Security is present");
         }
     }
+
+    @Test
+    void createSecured_withoutQuarkusSecurity_throws() {
+        QuarkusSecuritySupport.overrideDetector(() -> false);
+
+        Routes routes = new Routes();
+        var ex = Assertions.assertThrows(IllegalStateException.class,
+                () -> QuarkusBrowserlessApplicationContext
+                        .createSecured(routes),
+                "createSecured(...) must reject calls when Quarkus Security is"
+                        + " absent from the classpath");
+        Assertions.assertTrue(ex.getMessage().contains("Quarkus Security"),
+                "ISE message must mention Quarkus Security");
+    }
 }

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecuritySnapshotTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecuritySnapshotTest.java
@@ -84,5 +84,15 @@ class QuarkusSecuritySnapshotTest {
                 adminWindow.getCurrentView(),
                 "Admin snapshot should survive mutation of the live"
                         + " CurrentIdentityAssociation");
+
+        // Assert identity contents directly, so the test doesn't pass merely
+        // because of an unrelated re-authentication path
+        SecurityIdentity restored = CurrentIdentityAssociation.current();
+        Assertions.assertEquals("john", restored.getPrincipal().getName(),
+                "Restored identity should have admin's principal");
+        Assertions.assertTrue(restored.getRoles().contains("USER"),
+                "Restored identity should have admin's USER role");
+        Assertions.assertFalse(restored.isAnonymous(),
+                "Restored identity should not be anonymous");
     }
 }

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecuritySnapshotTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecuritySnapshotTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import java.util.Set;
+
+import com.testapp.security.ProtectedView;
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests that the Quarkus security identity snapshot is a defensive copy, not a
+ * mutable reference. Mutating the live {@link CurrentIdentityAssociation} on
+ * the thread after switching users must not corrupt the saved snapshot.
+ */
+@QuarkusTest
+@TestProfile(SecurityTestConfig.NavigationAccessControlConfig.class)
+class QuarkusSecuritySnapshotTest {
+
+    private BrowserlessApplicationContext<SecurityIdentity> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
+        app = QuarkusBrowserlessApplicationContext.create(routes);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void mutatingLiveContext_doesNotCorruptSavedSnapshot() {
+        var adminIdentity = QuarkusSecurityIdentity.builder()
+                .setPrincipal(new QuarkusPrincipal("john"))
+                .addRoles(Set.of("USER")).setAnonymous(false).build();
+
+        // Create admin user and verify access
+        var admin = app.newUser(adminIdentity);
+        var adminWindow = admin.newWindow();
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+
+        // Switch to anonymous user (saves admin's snapshot)
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Mutate the live identity on the thread
+        CDI.current().select(CurrentIdentityAssociation.class).get()
+                .setIdentity(QuarkusSecurityIdentity.builder()
+                        .setAnonymous(true).build());
+
+        // Switch back to admin — snapshot should NOT be corrupted
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView(),
+                "Admin snapshot should survive mutation of the live"
+                        + " CurrentIdentityAssociation");
+    }
+}

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecuritySnapshotTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSecuritySnapshotTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.vaadin.browserless.BrowserlessApplicationContext;
+import com.vaadin.browserless.SecuredBrowserlessApplicationContext;
 import com.vaadin.browserless.internal.Routes;
 
 /**
@@ -43,12 +43,12 @@ import com.vaadin.browserless.internal.Routes;
 @TestProfile(SecurityTestConfig.NavigationAccessControlConfig.class)
 class QuarkusSecuritySnapshotTest {
 
-    private BrowserlessApplicationContext<SecurityIdentity> app;
+    private SecuredBrowserlessApplicationContext<SecurityIdentity> app;
 
     @BeforeEach
     void setUp() {
         Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
-        app = QuarkusBrowserlessApplicationContext.create(routes);
+        app = QuarkusBrowserlessApplicationContext.createSecured(routes);
     }
 
     @AfterEach

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -34,14 +34,14 @@ import com.vaadin.flow.server.VaadinServletService;
 /**
  * Application-level context for multi-user browserless testing.
  * <p>
- * Manages a shared {@link VaadinServletService} and servlet that are
- * shared across all users and their windows. This models the application
- * level of the Vaadin hierarchy: one application contains multiple user
- * sessions, each with multiple UI instances (browser tabs).
+ * Manages a shared {@link VaadinServletService} and servlet that are shared
+ * across all users and their windows. This models the application level of the
+ * Vaadin hierarchy: one application contains multiple user sessions, each with
+ * multiple UI instances (browser tabs).
  * <p>
  * Create instances via {@link #create(Routes)} for plain Java or use the
- * {@link #builder(Routes)} for full customization. Framework-specific
- * modules (Spring, Quarkus) provide their own convenience factory methods.
+ * {@link #builder(Routes)} for full customization. Framework-specific modules
+ * (Spring, Quarkus) provide their own convenience factory methods.
  *
  * <pre>
  * var app = BrowserlessApplicationContext.create(routes);
@@ -76,18 +76,21 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     /**
      * Creates a plain Java application context with default settings.
      *
-     * @param routes the discovered routes
+     * @param routes
+     *            the discovered routes
      * @return a new application context
      */
     public static BrowserlessApplicationContext<Void> create(Routes routes) {
-        return BrowserlessApplicationContext.<Void>builder(routes).build();
+        return BrowserlessApplicationContext.<Void> builder(routes).build();
     }
 
     /**
      * Creates a builder for customizing the application context.
      *
-     * @param <C>    the credentials type for the security context handler
-     * @param routes the discovered routes
+     * @param <C>
+     *            the credentials type for the security context handler
+     * @param routes
+     *            the discovered routes
      * @return a new builder
      */
     public static <C> Builder<C> builder(Routes routes) {
@@ -97,10 +100,10 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     /**
      * Creates a new user context representing an independent user session.
      * <p>
-     * The returned context has its own {@link com.vaadin.flow.server.VaadinSession},
-     * HTTP request, and response. If credentials are provided and a
-     * {@link SecurityContextHandler} is configured, authentication is set up
-     * automatically.
+     * The returned context has its own
+     * {@link com.vaadin.flow.server.VaadinSession}, HTTP request, and response.
+     * If credentials are provided and a {@link SecurityContextHandler} is
+     * configured, authentication is set up automatically.
      *
      * @return the new user context
      */
@@ -113,12 +116,13 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
      * <p>
      * The credentials are passed to
      * {@link SecurityContextHandler#setupAuthentication(Object)
-     * SecurityContextHandler.setupAuthentication()} if a
-     * handler is configured. The security context is then automatically
-     * captured as the user's initial snapshot.
+     * SecurityContextHandler.setupAuthentication()} if a handler is configured.
+     * The security context is then automatically captured as the user's initial
+     * snapshot.
      *
-     * @param credentials framework-specific credentials, or {@code null}
-     *                    for an anonymous user
+     * @param credentials
+     *            framework-specific credentials, or {@code null} for an
+     *            anonymous user
      * @return the new user context
      */
     public BrowserlessUserContext newUser(C credentials) {
@@ -188,8 +192,8 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         /**
          * Sets the security context handler for multi-user auth isolation.
          *
-         * @param handler the handler, or {@code null} for no security
-         *                management
+         * @param handler
+         *            the handler, or {@code null} for no security management
          * @return this builder
          */
         public Builder<C> withSecurityContextHandler(
@@ -199,10 +203,11 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         }
 
         /**
-         * Sets a custom servlet factory. The factory receives the routes
-         * and must return a fully configured {@link VaadinServlet}.
+         * Sets a custom servlet factory. The factory receives the routes and
+         * must return a fully configured {@link VaadinServlet}.
          *
-         * @param factory the servlet factory
+         * @param factory
+         *            the servlet factory
          * @return this builder
          */
         public Builder<C> withServletFactory(
@@ -214,7 +219,8 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         /**
          * Sets the UI factory for creating new UI instances.
          *
-         * @param uiFactory the UI factory
+         * @param uiFactory
+         *            the UI factory
          * @return this builder
          */
         public Builder<C> withUIFactory(UIFactory uiFactory) {
@@ -225,7 +231,8 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         /**
          * Sets the Vaadin Lookup service classes.
          *
-         * @param services the service implementation classes
+         * @param services
+         *            the service implementation classes
          * @return this builder
          */
         public Builder<C> withLookupServices(Set<Class<?>> services) {

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -109,29 +109,30 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     /**
      * Creates a new user context representing an anonymous user session.
      * <p>
-     * The returned context has its own
-     * {@link com.vaadin.flow.server.VaadinSession}, HTTP request, and response.
-     * Equivalent to {@link #newUser(Object) newUser(null)}: no authentication
-     * is set up, even if a {@link SecurityContextHandler} is configured.
+     * Equivalent to {@link #newUser(Object) newUser(null)}: when a
+     * {@link SecurityContextHandler} is configured, the handler is asked to
+     * install its anonymous-equivalent state (e.g. Spring sets an
+     * {@code AnonymousAuthenticationToken}).
      *
      * @return the new user context
      * @throws IllegalStateException
      *             if this context has been closed
      */
     public BrowserlessUserContext newUser() {
-        return newUser(null);
+        return newUser((C) null);
     }
 
     /**
      * Creates a new user context with the given credentials.
      * <p>
      * If a {@link SecurityContextHandler} is configured, the security context
-     * for this user is first cleared, then — if {@code credentials} is
-     * non-{@code null} — the credentials are passed to
+     * for this user is first cleared, then the credentials are passed to
      * {@link SecurityContextHandler#setupAuthentication(Object)
-     * SecurityContextHandler.setupAuthentication()}. The resulting security
-     * state is captured as this user's initial snapshot and is automatically
-     * restored whenever one of this user's windows is activated.
+     * SecurityContextHandler.setupAuthentication()} — including when
+     * {@code credentials} is {@code null}, so that the handler can install its
+     * anonymous-equivalent state. The resulting security state is captured as
+     * this user's initial snapshot and is automatically restored whenever one
+     * of this user's windows is activated.
      *
      * @param credentials
      *            framework-specific credentials, or {@code null} for an
@@ -145,6 +146,43 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         var user = new BrowserlessUserContext(this, credentials);
         users.add(user);
         return user;
+    }
+
+    /**
+     * Creates a new user context for the given username and roles.
+     * <p>
+     * Delegates to
+     * {@link SecurityContextHandler#createCredentials(String, String...)} on
+     * the configured handler, then to {@link #newUser(Object)}. Spring and
+     * Quarkus handlers ship with overrides that mirror the conventions of
+     * {@code @WithMockUser} / Quarkus security identity construction; custom
+     * handlers must override {@code createCredentials} to opt into this helper.
+     *
+     * @param username
+     *            the username
+     * @param roles
+     *            the roles for the user; may be empty
+     * @return the new user context
+     * @throws IllegalStateException
+     *             if this context has been closed, or no
+     *             {@link SecurityContextHandler} is configured
+     * @throws UnsupportedOperationException
+     *             if the configured handler doesn't override
+     *             {@link SecurityContextHandler#createCredentials(String, String...)}
+     */
+    public BrowserlessUserContext newUser(String username, String... roles) {
+        checkNotClosed();
+        Objects.requireNonNull(username, "username must not be null");
+        Objects.requireNonNull(roles, "roles must not be null");
+        if (securityContextHandler == null) {
+            throw new IllegalStateException(
+                    "No SecurityContextHandler configured. Use"
+                            + " Builder.withSecurityContextHandler(...) or a"
+                            + " framework-specific application context that"
+                            + " installs one by default.");
+        }
+        return newUser(
+                securityContextHandler.createCredentials(username, roles));
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -21,7 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.internal.Routes;
@@ -244,7 +244,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
 
         private final Routes routes;
         private SecurityContextHandler<C> securityContextHandler;
-        private Function<Routes, VaadinServlet> servletFactory;
+        private BiFunction<Routes, UIFactory, VaadinServlet> servletFactory;
         private UIFactory uiFactory = () -> new MockedUI();
         private Set<Class<?>> lookupServices = Collections.emptySet();
 
@@ -267,9 +267,14 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
 
         /**
          * Sets a custom servlet factory. The factory receives the routes and
-         * must return a fully configured {@link VaadinServlet}. When unset, a
-         * default servlet that uses the configured {@link UIFactory} is created
-         * by {@link #build()}.
+         * the {@link UIFactory} configured via
+         * {@link #withUIFactory(UIFactory)} (or its default), and must return a
+         * fully configured {@link VaadinServlet}. Wiring the {@code UIFactory}
+         * through the builder ensures the servlet uses the same factory as
+         * {@link BrowserlessUIContext} window creation, so paths like the
+         * legacy {@code afterSessionClose} session-recreation hook don't end up
+         * producing UIs of a different type. When unset, a default servlet that
+         * uses the configured {@code UIFactory} is created by {@link #build()}.
          *
          * @param factory
          *            the servlet factory
@@ -278,7 +283,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
          *             if {@code factory} is {@code null}
          */
         public Builder<C> withServletFactory(
-                Function<Routes, VaadinServlet> factory) {
+                BiFunction<Routes, UIFactory, VaadinServlet> factory) {
             this.servletFactory = Objects.requireNonNull(factory);
             return this;
         }
@@ -335,7 +340,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
          */
         public BrowserlessApplicationContext<C> build() {
             VaadinServlet servlet = servletFactory != null
-                    ? servletFactory.apply(routes)
+                    ? servletFactory.apply(routes, uiFactory)
                     : new MockVaadinServlet(routes, uiFactory);
             VaadinServletService service = MockVaadin.setupServlet(servlet,
                     lookupServices);

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.server.VaadinServletService;
  * Manages a shared {@link VaadinServletService} and servlet that are shared
  * across all users and their windows. This models the application level of the
  * Vaadin hierarchy: one application contains multiple user sessions, each with
- * multiple UI instances (browser tabs).
+ * multiple UI instances (browser windows).
  * <p>
  * Create instances via {@link #create(Routes)} for plain Java or use the
  * {@link #builder(Routes)} for full customization. Framework-specific modules
@@ -119,7 +119,11 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
      *             if this context has been closed
      */
     public BrowserlessUserContext newUser() {
-        return newUser((C) null);
+        // Cast disambiguates from newUser(String, String...) when C
+        // happens to be String — null alone would match both overloads.
+        @SuppressWarnings("unchecked")
+        C nullCredentials = (C) null;
+        return newUser(nullCredentials);
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -17,6 +17,7 @@ package com.vaadin.browserless;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -52,6 +53,10 @@ import com.vaadin.flow.server.VaadinServletService;
  * app.close();
  * </pre>
  *
+ * @param <C>
+ *            the credentials type accepted by {@link #newUser(Object)}, as
+ *            defined by the configured {@link SecurityContextHandler};
+ *            {@link Void} when no security context handler is configured
  * @see BrowserlessUserContext
  * @see BrowserlessUIContext
  */
@@ -75,6 +80,10 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
 
     /**
      * Creates a plain Java application context with default settings.
+     * <p>
+     * The returned context has no {@link SecurityContextHandler} configured;
+     * use {@link #builder(Routes)} to enable framework-specific security
+     * integration.
      *
      * @param routes
      *            the discovered routes
@@ -98,14 +107,16 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     }
 
     /**
-     * Creates a new user context representing an independent user session.
+     * Creates a new user context representing an anonymous user session.
      * <p>
      * The returned context has its own
      * {@link com.vaadin.flow.server.VaadinSession}, HTTP request, and response.
-     * If credentials are provided and a {@link SecurityContextHandler} is
-     * configured, authentication is set up automatically.
+     * Equivalent to {@link #newUser(Object) newUser(null)}: no authentication
+     * is set up, even if a {@link SecurityContextHandler} is configured.
      *
      * @return the new user context
+     * @throws IllegalStateException
+     *             if this context has been closed
      */
     public BrowserlessUserContext newUser() {
         return newUser(null);
@@ -114,16 +125,20 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     /**
      * Creates a new user context with the given credentials.
      * <p>
-     * The credentials are passed to
+     * If a {@link SecurityContextHandler} is configured, the security context
+     * for this user is first cleared, then — if {@code credentials} is
+     * non-{@code null} — the credentials are passed to
      * {@link SecurityContextHandler#setupAuthentication(Object)
-     * SecurityContextHandler.setupAuthentication()} if a handler is configured.
-     * The security context is then automatically captured as the user's initial
-     * snapshot.
+     * SecurityContextHandler.setupAuthentication()}. The resulting security
+     * state is captured as this user's initial snapshot and is automatically
+     * restored whenever one of this user's windows is activated.
      *
      * @param credentials
      *            framework-specific credentials, or {@code null} for an
      *            anonymous user
      * @return the new user context
+     * @throws IllegalStateException
+     *             if this context has been closed
      */
     public BrowserlessUserContext newUser(C credentials) {
         checkNotClosed();
@@ -135,7 +150,10 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     /**
      * Closes this application context and all its user contexts.
      * <p>
-     * Fires service destroy listeners and clears thread-local state.
+     * Closes every {@link BrowserlessUserContext} created by this application
+     * (which in turn closes their windows), fires service destroy listeners,
+     * and resets the {@link VaadinService} thread-local. This method is
+     * idempotent: subsequent invocations have no effect.
      */
     @Override
     public void close() {
@@ -176,6 +194,9 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
 
     /**
      * Builder for creating a customized {@link BrowserlessApplicationContext}.
+     *
+     * @param <C>
+     *            the credentials type for the security context handler
      */
     public static class Builder<C> {
 
@@ -204,11 +225,15 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
 
         /**
          * Sets a custom servlet factory. The factory receives the routes and
-         * must return a fully configured {@link VaadinServlet}.
+         * must return a fully configured {@link VaadinServlet}. When unset, a
+         * default servlet that uses the configured {@link UIFactory} is created
+         * by {@link #build()}.
          *
          * @param factory
          *            the servlet factory
          * @return this builder
+         * @throws NullPointerException
+         *             if {@code factory} is {@code null}
          */
         public Builder<C> withServletFactory(
                 Function<Routes, VaadinServlet> factory) {
@@ -217,11 +242,15 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         }
 
         /**
-         * Sets the UI factory for creating new UI instances.
+         * Sets the UI factory used when creating UI instances for this
+         * application's windows. Defaults to a factory producing
+         * {@link MockedUI} instances.
          *
          * @param uiFactory
          *            the UI factory
          * @return this builder
+         * @throws NullPointerException
+         *             if {@code uiFactory} is {@code null}
          */
         public Builder<C> withUIFactory(UIFactory uiFactory) {
             this.uiFactory = Objects.requireNonNull(uiFactory);
@@ -229,15 +258,32 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         }
 
         /**
-         * Sets the Vaadin Lookup service classes.
+         * Adds the given Vaadin Lookup service classes to the set configured
+         * for this builder. Successive calls accumulate; the builder starts
+         * with an empty set. Calling with no arguments is a no-op.
          *
          * @param services
-         *            the service implementation classes
+         *            the service implementation classes to add
          * @return this builder
+         * @throws NullPointerException
+         *             if {@code services} or any of its elements is
+         *             {@code null}
          */
-        public Builder<C> withLookupServices(Set<Class<?>> services) {
-            this.lookupServices = Objects.requireNonNull(services);
+        public Builder<C> withLookupServices(Class<?>... services) {
+            Objects.requireNonNull(services);
+            if (services.length == 0) {
+                return this;
+            }
+            Set<Class<?>> updated = new LinkedHashSet<>(this.lookupServices);
+            for (Class<?> service : services) {
+                updated.add(Objects.requireNonNull(service));
+            }
+            this.lookupServices = updated;
             return this;
+        }
+
+        Set<Class<?>> getLookupServices() {
+            return lookupServices;
         }
 
         /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.UIFactory;
+import com.vaadin.browserless.mocks.MockVaadinServlet;
+import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletService;
+
+/**
+ * Application-level context for multi-user browserless testing.
+ * <p>
+ * Manages a shared {@link VaadinServletService} and servlet that are
+ * shared across all users and their windows. This models the application
+ * level of the Vaadin hierarchy: one application contains multiple user
+ * sessions, each with multiple UI instances (browser tabs).
+ * <p>
+ * Create instances via {@link #create(Routes)} for plain Java or use the
+ * {@link #builder(Routes)} for full customization. Framework-specific
+ * modules (Spring, Quarkus) provide their own convenience factory methods.
+ *
+ * <pre>
+ * var app = BrowserlessApplicationContext.create(routes);
+ * var user1 = app.newUser();
+ * var window1 = user1.newWindow();
+ * window1.navigate(MyView.class);
+ * // ...
+ * app.close();
+ * </pre>
+ *
+ * @see BrowserlessUserContext
+ * @see BrowserlessUIContext
+ */
+public class BrowserlessApplicationContext<C> implements AutoCloseable {
+
+    private final VaadinServletService service;
+    private final VaadinServlet servlet;
+    private final UIFactory uiFactory;
+    private final SecurityContextHandler<C> securityContextHandler;
+    private final List<BrowserlessUserContext> users = new ArrayList<>();
+    private boolean closed;
+
+    private BrowserlessApplicationContext(VaadinServletService service,
+            VaadinServlet servlet, UIFactory uiFactory,
+            SecurityContextHandler<C> securityContextHandler) {
+        this.service = service;
+        this.servlet = servlet;
+        this.uiFactory = uiFactory;
+        this.securityContextHandler = securityContextHandler;
+    }
+
+    /**
+     * Creates a plain Java application context with default settings.
+     *
+     * @param routes the discovered routes
+     * @return a new application context
+     */
+    public static BrowserlessApplicationContext<Void> create(Routes routes) {
+        return BrowserlessApplicationContext.<Void>builder(routes).build();
+    }
+
+    /**
+     * Creates a builder for customizing the application context.
+     *
+     * @param <C>    the credentials type for the security context handler
+     * @param routes the discovered routes
+     * @return a new builder
+     */
+    public static <C> Builder<C> builder(Routes routes) {
+        return new Builder<>(routes);
+    }
+
+    /**
+     * Creates a new user context representing an independent user session.
+     * <p>
+     * The returned context has its own {@link com.vaadin.flow.server.VaadinSession},
+     * HTTP request, and response. If credentials are provided and a
+     * {@link SecurityContextHandler} is configured, authentication is set up
+     * automatically.
+     *
+     * @return the new user context
+     */
+    public BrowserlessUserContext newUser() {
+        return newUser(null);
+    }
+
+    /**
+     * Creates a new user context with the given credentials.
+     * <p>
+     * The credentials are passed to
+     * {@link SecurityContextHandler#setupAuthentication(Object)
+     * SecurityContextHandler.setupAuthentication()} if a
+     * handler is configured. The security context is then automatically
+     * captured as the user's initial snapshot.
+     *
+     * @param credentials framework-specific credentials, or {@code null}
+     *                    for an anonymous user
+     * @return the new user context
+     */
+    public BrowserlessUserContext newUser(C credentials) {
+        checkNotClosed();
+        var user = new BrowserlessUserContext(this, credentials);
+        users.add(user);
+        return user;
+    }
+
+    /**
+     * Closes this application context and all its user contexts.
+     * <p>
+     * Fires service destroy listeners and clears thread-local state.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        for (var user : users) {
+            user.close();
+        }
+        users.clear();
+        MockVaadin.fireServiceDestroy(service);
+        VaadinService.setCurrent(null);
+    }
+
+    VaadinServletService getService() {
+        return service;
+    }
+
+    VaadinServlet getServlet() {
+        return servlet;
+    }
+
+    UIFactory getUIFactory() {
+        return uiFactory;
+    }
+
+    SecurityContextHandler<C> getSecurityContextHandler() {
+        return securityContextHandler;
+    }
+
+    private void checkNotClosed() {
+        if (closed) {
+            throw new IllegalStateException(
+                    "BrowserlessApplicationContext is already closed");
+        }
+    }
+
+    /**
+     * Builder for creating a customized {@link BrowserlessApplicationContext}.
+     */
+    public static class Builder<C> {
+
+        private final Routes routes;
+        private SecurityContextHandler<C> securityContextHandler;
+        private Function<Routes, VaadinServlet> servletFactory;
+        private UIFactory uiFactory = () -> new MockedUI();
+        private Set<Class<?>> lookupServices = Collections.emptySet();
+
+        Builder(Routes routes) {
+            this.routes = Objects.requireNonNull(routes);
+        }
+
+        /**
+         * Sets the security context handler for multi-user auth isolation.
+         *
+         * @param handler the handler, or {@code null} for no security
+         *                management
+         * @return this builder
+         */
+        public Builder<C> withSecurityContextHandler(
+                SecurityContextHandler<C> handler) {
+            this.securityContextHandler = handler;
+            return this;
+        }
+
+        /**
+         * Sets a custom servlet factory. The factory receives the routes
+         * and must return a fully configured {@link VaadinServlet}.
+         *
+         * @param factory the servlet factory
+         * @return this builder
+         */
+        public Builder<C> withServletFactory(
+                Function<Routes, VaadinServlet> factory) {
+            this.servletFactory = Objects.requireNonNull(factory);
+            return this;
+        }
+
+        /**
+         * Sets the UI factory for creating new UI instances.
+         *
+         * @param uiFactory the UI factory
+         * @return this builder
+         */
+        public Builder<C> withUIFactory(UIFactory uiFactory) {
+            this.uiFactory = Objects.requireNonNull(uiFactory);
+            return this;
+        }
+
+        /**
+         * Sets the Vaadin Lookup service classes.
+         *
+         * @param services the service implementation classes
+         * @return this builder
+         */
+        public Builder<C> withLookupServices(Set<Class<?>> services) {
+            this.lookupServices = Objects.requireNonNull(services);
+            return this;
+        }
+
+        /**
+         * Builds the application context.
+         *
+         * @return a new application context
+         */
+        public BrowserlessApplicationContext<C> build() {
+            VaadinServlet servlet = servletFactory != null
+                    ? servletFactory.apply(routes)
+                    : new MockVaadinServlet(routes, uiFactory);
+            VaadinServletService service = MockVaadin.setupServlet(servlet,
+                    lookupServices);
+            return new BrowserlessApplicationContext<>(service, servlet,
+                    uiFactory, securityContextHandler);
+        }
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -46,9 +46,14 @@ import com.vaadin.flow.server.VaadinServletService;
  * safe for concurrent access from multiple threads; driving the same context
  * from parallel test threads is unsupported.
  * <p>
- * Create instances via {@link #create(Routes)} for plain Java or use the
- * {@link #builder(Routes)} for full customization. Framework-specific modules
- * (Spring, Quarkus) provide their own convenience factory methods.
+ * This base class is unsecured: it has no {@link SecurityContextHandler}. For
+ * multi-user security isolation, configure a handler via
+ * {@link Builder#withSecurityContextHandler(SecurityContextHandler)} — the
+ * builder transitions to {@link SecuredBrowserlessApplicationContext.Builder}
+ * and {@link SecuredBrowserlessApplicationContext.Builder#build() build()}
+ * returns the typed {@link SecuredBrowserlessApplicationContext}, which exposes
+ * credential-aware {@code newUser(...)} overloads. Framework-specific modules
+ * (Spring, Quarkus) provide convenience factory methods for both paths.
  *
  * <pre>
  * var app = BrowserlessApplicationContext.create(routes);
@@ -59,29 +64,22 @@ import com.vaadin.flow.server.VaadinServletService;
  * app.close();
  * </pre>
  *
- * @param <C>
- *            the credentials type accepted by {@link #newUser(Object)}, as
- *            defined by the configured {@link SecurityContextHandler};
- *            {@link Void} when no security context handler is configured
  * @see BrowserlessUserContext
  * @see BrowserlessUIContext
+ * @see SecuredBrowserlessApplicationContext
  */
-public class BrowserlessApplicationContext<C> implements AutoCloseable {
+public class BrowserlessApplicationContext implements AutoCloseable {
 
     private final VaadinServletService service;
     private final UIFactory uiFactory;
-    private final SecurityContextHandler<C> securityContextHandler;
     private final List<Runnable> closeHooks;
     private final List<BrowserlessUserContext> users = new ArrayList<>();
     private boolean closed;
 
-    private BrowserlessApplicationContext(VaadinServletService service,
-            UIFactory uiFactory,
-            SecurityContextHandler<C> securityContextHandler,
-            List<Runnable> closeHooks) {
+    BrowserlessApplicationContext(VaadinServletService service,
+            UIFactory uiFactory, List<Runnable> closeHooks) {
         this.service = service;
         this.uiFactory = uiFactory;
-        this.securityContextHandler = securityContextHandler;
         this.closeHooks = closeHooks;
     }
 
@@ -89,111 +87,51 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
      * Creates a plain Java application context with default settings.
      * <p>
      * The returned context has no {@link SecurityContextHandler} configured;
-     * use {@link #builder(Routes)} to enable framework-specific security
-     * integration.
+     * use {@link #builder(Routes)} and
+     * {@link Builder#withSecurityContextHandler(SecurityContextHandler)} to
+     * enable framework-specific security integration.
      *
      * @param routes
      *            the discovered routes
      * @return a new application context
      */
-    public static BrowserlessApplicationContext<Void> create(Routes routes) {
-        return BrowserlessApplicationContext.<Void> builder(routes).build();
+    public static BrowserlessApplicationContext create(Routes routes) {
+        return builder(routes).build();
     }
 
     /**
      * Creates a builder for customizing the application context.
      *
-     * @param <C>
-     *            the credentials type for the security context handler
      * @param routes
      *            the discovered routes
      * @return a new builder
      */
-    public static <C> Builder<C> builder(Routes routes) {
-        return new Builder<>(routes);
+    public static Builder builder(Routes routes) {
+        return new Builder(routes);
     }
 
     /**
      * Creates a new user context representing an anonymous user session.
      * <p>
-     * Equivalent to {@link #newUser(Object) newUser(null)}: when a
-     * {@link SecurityContextHandler} is configured, the handler is asked to
+     * When a {@link SecurityContextHandler} is configured (on a
+     * {@link SecuredBrowserlessApplicationContext}), the handler is asked to
      * install its anonymous-equivalent state (e.g. Spring sets an
-     * {@code AnonymousAuthenticationToken}).
+     * {@code AnonymousAuthenticationToken}). On this unsecured base class no
+     * security setup is performed.
      *
      * @return the new user context
      * @throws IllegalStateException
      *             if this context has been closed
      */
     public BrowserlessUserContext newUser() {
-        // Cast disambiguates from newUser(String, String...) when C
-        // happens to be String — null alone would match both overloads.
-        @SuppressWarnings("unchecked")
-        C nullCredentials = (C) null;
-        return newUser(nullCredentials);
+        return newUserInternal(null);
     }
 
-    /**
-     * Creates a new user context with the given credentials.
-     * <p>
-     * If a {@link SecurityContextHandler} is configured, the security context
-     * for this user is first cleared, then the credentials are passed to
-     * {@link SecurityContextHandler#setupAuthentication(Object)
-     * SecurityContextHandler.setupAuthentication()} — including when
-     * {@code credentials} is {@code null}, so that the handler can install its
-     * anonymous-equivalent state. The resulting security state is captured as
-     * this user's initial snapshot and is automatically restored whenever one
-     * of this user's windows is activated.
-     *
-     * @param credentials
-     *            framework-specific credentials, or {@code null} for an
-     *            anonymous user
-     * @return the new user context
-     * @throws IllegalStateException
-     *             if this context has been closed
-     */
-    public BrowserlessUserContext newUser(C credentials) {
+    BrowserlessUserContext newUserInternal(Object credentials) {
         checkNotClosed();
         var user = new BrowserlessUserContext(this, credentials);
         users.add(user);
         return user;
-    }
-
-    /**
-     * Creates a new user context for the given username and roles.
-     * <p>
-     * Delegates to
-     * {@link SecurityContextHandler#createCredentials(String, String...)} on
-     * the configured handler, then to {@link #newUser(Object)}. Spring and
-     * Quarkus handlers ship with overrides that mirror the conventions of
-     * {@code @WithMockUser} / Quarkus security identity construction; custom
-     * handlers must override {@code createCredentials} to opt into this helper.
-     *
-     * @param username
-     *            the username
-     * @param roles
-     *            the roles for the user; may be empty
-     * @return the new user context
-     * @throws IllegalStateException
-     *             if this context has been closed, or no
-     *             {@link SecurityContextHandler} is configured
-     * @throws UnsupportedOperationException
-     *             if the configured handler doesn't override
-     *             {@link SecurityContextHandler#createCredentials(String, String...)}
-     */
-    public BrowserlessUserContext newUser(String username, String... roles) {
-        checkNotClosed();
-        Objects.requireNonNull(username, "username must not be null");
-        Objects.requireNonNull(roles, "roles must not be null");
-        if (securityContextHandler == null) {
-            throw new IllegalStateException(
-                    "No SecurityContextHandler configured. Use"
-                            + " Builder.withSecurityContextHandler(...) or a"
-                            + " framework-specific application context that"
-                            + " installs one by default.");
-        }
-        return newUser(
-                securityContextHandler.createCredentials(username, roles));
     }
 
     /**
@@ -240,11 +178,16 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         return uiFactory;
     }
 
-    SecurityContextHandler<C> getSecurityContextHandler() {
-        return securityContextHandler;
+    /**
+     * Returns the configured security context handler, or {@code null} when
+     * unsecured. Overridden by {@link SecuredBrowserlessApplicationContext} to
+     * return its typed, non-null handler.
+     */
+    SecurityContextHandler<?> getSecurityContextHandler() {
+        return null;
     }
 
-    private void checkNotClosed() {
+    void checkNotClosed() {
         if (closed) {
             throw new IllegalStateException(
                     "BrowserlessApplicationContext is already closed");
@@ -253,14 +196,16 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
 
     /**
      * Builder for creating a customized {@link BrowserlessApplicationContext}.
-     *
-     * @param <C>
-     *            the credentials type for the security context handler
+     * <p>
+     * Calling {@link #withSecurityContextHandler(SecurityContextHandler)}
+     * transitions to a {@link SecuredBrowserlessApplicationContext.Builder}
+     * whose {@link SecuredBrowserlessApplicationContext.Builder#build()
+     * build()} returns the credential-typed
+     * {@link SecuredBrowserlessApplicationContext}.
      */
-    public static class Builder<C> {
+    public static class Builder {
 
         private final Routes routes;
-        private SecurityContextHandler<C> securityContextHandler;
         private BiFunction<Routes, UIFactory, VaadinServlet> servletFactory;
         private UIFactory uiFactory = () -> new MockedUI();
         private Set<Class<?>> lookupServices = Collections.emptySet();
@@ -271,16 +216,25 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         }
 
         /**
-         * Sets the security context handler for multi-user auth isolation.
+         * Sets the security context handler for multi-user auth isolation and
+         * transitions to a credential-typed
+         * {@link SecuredBrowserlessApplicationContext.Builder}. The base
+         * builder's accumulated state (servlet factory, UI factory, lookup
+         * services, close hooks) is carried over.
          *
+         * @param <C>
+         *            the credentials type accepted by the handler
          * @param handler
-         *            the handler, or {@code null} for no security management
-         * @return this builder
+         *            the handler; must not be {@code null}
+         * @return a secured builder configured with the given handler
+         * @throws NullPointerException
+         *             if {@code handler} is {@code null}
          */
-        public Builder<C> withSecurityContextHandler(
+        public <C> SecuredBrowserlessApplicationContext.Builder<C> withSecurityContextHandler(
                 SecurityContextHandler<C> handler) {
-            this.securityContextHandler = handler;
-            return this;
+            Objects.requireNonNull(handler, "handler must not be null");
+            return new SecuredBrowserlessApplicationContext.Builder<>(this,
+                    handler);
         }
 
         /**
@@ -300,7 +254,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
          * @throws NullPointerException
          *             if {@code factory} is {@code null}
          */
-        public Builder<C> withServletFactory(
+        public Builder withServletFactory(
                 BiFunction<Routes, UIFactory, VaadinServlet> factory) {
             this.servletFactory = Objects.requireNonNull(factory);
             return this;
@@ -317,7 +271,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
          * @throws NullPointerException
          *             if {@code uiFactory} is {@code null}
          */
-        public Builder<C> withUIFactory(UIFactory uiFactory) {
+        public Builder withUIFactory(UIFactory uiFactory) {
             this.uiFactory = Objects.requireNonNull(uiFactory);
             return this;
         }
@@ -334,7 +288,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
          *             if {@code services} or any of its elements is
          *             {@code null}
          */
-        public Builder<C> withLookupServices(Class<?>... services) {
+        public Builder withLookupServices(Class<?>... services) {
             Objects.requireNonNull(services);
             if (services.length == 0) {
                 return this;
@@ -371,7 +325,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
          * @throws NullPointerException
          *             if {@code hook} is {@code null}
          */
-        public Builder<C> withCloseHook(Runnable hook) {
+        public Builder withCloseHook(Runnable hook) {
             this.closeHooks.add(Objects.requireNonNull(hook));
             return this;
         }
@@ -381,14 +335,24 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
          *
          * @return a new application context
          */
-        public BrowserlessApplicationContext<C> build() {
+        public BrowserlessApplicationContext build() {
+            return new BrowserlessApplicationContext(buildService(), uiFactory,
+                    buildCloseHooks());
+        }
+
+        VaadinServletService buildService() {
             VaadinServlet servlet = servletFactory != null
                     ? servletFactory.apply(routes, uiFactory)
                     : new MockVaadinServlet(routes, uiFactory);
-            VaadinServletService service = MockVaadin.setupServlet(servlet,
-                    lookupServices);
-            return new BrowserlessApplicationContext<>(service, uiFactory,
-                    securityContextHandler, List.copyOf(closeHooks));
+            return MockVaadin.setupServlet(servlet, lookupServices);
+        }
+
+        UIFactory uiFactory() {
+            return uiFactory;
+        }
+
+        List<Runnable> buildCloseHooks() {
+            return List.copyOf(closeHooks);
         }
     }
 }

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -40,6 +40,12 @@ import com.vaadin.flow.server.VaadinServletService;
  * Vaadin hierarchy: one application contains multiple user sessions, each with
  * multiple UI instances (browser windows).
  * <p>
+ * Instances of this class are <strong>thread-affine</strong>: they must be
+ * created, used, and closed on the same thread. The active context is held in a
+ * {@link ThreadLocal} and is not visible to other threads. This class is not
+ * safe for concurrent access from multiple threads; driving the same context
+ * from parallel test threads is unsupported.
+ * <p>
  * Create instances via {@link #create(Routes)} for plain Java or use the
  * {@link #builder(Routes)} for full customization. Framework-specific modules
  * (Spring, Quarkus) provide their own convenience factory methods.

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -66,16 +66,19 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     private final VaadinServlet servlet;
     private final UIFactory uiFactory;
     private final SecurityContextHandler<C> securityContextHandler;
+    private final List<Runnable> closeHooks;
     private final List<BrowserlessUserContext> users = new ArrayList<>();
     private boolean closed;
 
     private BrowserlessApplicationContext(VaadinServletService service,
             VaadinServlet servlet, UIFactory uiFactory,
-            SecurityContextHandler<C> securityContextHandler) {
+            SecurityContextHandler<C> securityContextHandler,
+            List<Runnable> closeHooks) {
         this.service = service;
         this.servlet = servlet;
         this.uiFactory = uiFactory;
         this.securityContextHandler = securityContextHandler;
+        this.closeHooks = closeHooks;
     }
 
     /**
@@ -209,6 +212,20 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         users.clear();
         MockVaadin.fireServiceDestroy(service);
         VaadinService.setCurrent(null);
+        List<RuntimeException> hookFailures = new ArrayList<>();
+        for (Runnable hook : closeHooks) {
+            try {
+                hook.run();
+            } catch (RuntimeException e) {
+                hookFailures.add(e);
+            }
+        }
+        if (!hookFailures.isEmpty()) {
+            RuntimeException aggregate = new RuntimeException(
+                    "One or more close hooks failed");
+            hookFailures.forEach(aggregate::addSuppressed);
+            throw aggregate;
+        }
     }
 
     VaadinServletService getService() {
@@ -247,6 +264,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         private BiFunction<Routes, UIFactory, VaadinServlet> servletFactory;
         private UIFactory uiFactory = () -> new MockedUI();
         private Set<Class<?>> lookupServices = Collections.emptySet();
+        private final List<Runnable> closeHooks = new ArrayList<>();
 
         Builder(Routes routes) {
             this.routes = Objects.requireNonNull(routes);
@@ -334,6 +352,31 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         }
 
         /**
+         * Registers a hook to be invoked when the built application context is
+         * closed.
+         * <p>
+         * Hooks run in registration order, after users and the Vaadin service
+         * have been torn down, exactly once (subsequent {@code close()} calls
+         * are no-ops). They are intended for releasing framework-specific state
+         * attached during context creation — for example, Spring's
+         * lookup-initializer ThreadLocal. A throwing hook does not prevent the
+         * remaining hooks from running; any thrown {@link RuntimeException}s
+         * are collected and surfaced from {@code close()} as a single
+         * {@link RuntimeException} with the originals attached as suppressed
+         * exceptions.
+         *
+         * @param hook
+         *            the hook to register; must not be {@code null}
+         * @return this builder
+         * @throws NullPointerException
+         *             if {@code hook} is {@code null}
+         */
+        public Builder<C> withCloseHook(Runnable hook) {
+            this.closeHooks.add(Objects.requireNonNull(hook));
+            return this;
+        }
+
+        /**
          * Builds the application context.
          *
          * @return a new application context
@@ -345,7 +388,7 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
             VaadinServletService service = MockVaadin.setupServlet(servlet,
                     lookupServices);
             return new BrowserlessApplicationContext<>(service, servlet,
-                    uiFactory, securityContextHandler);
+                    uiFactory, securityContextHandler, List.copyOf(closeHooks));
         }
     }
 }

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -69,7 +69,6 @@ import com.vaadin.flow.server.VaadinServletService;
 public class BrowserlessApplicationContext<C> implements AutoCloseable {
 
     private final VaadinServletService service;
-    private final VaadinServlet servlet;
     private final UIFactory uiFactory;
     private final SecurityContextHandler<C> securityContextHandler;
     private final List<Runnable> closeHooks;
@@ -77,11 +76,10 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
     private boolean closed;
 
     private BrowserlessApplicationContext(VaadinServletService service,
-            VaadinServlet servlet, UIFactory uiFactory,
+            UIFactory uiFactory,
             SecurityContextHandler<C> securityContextHandler,
             List<Runnable> closeHooks) {
         this.service = service;
-        this.servlet = servlet;
         this.uiFactory = uiFactory;
         this.securityContextHandler = securityContextHandler;
         this.closeHooks = closeHooks;
@@ -238,10 +236,6 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
         return service;
     }
 
-    VaadinServlet getServlet() {
-        return servlet;
-    }
-
     UIFactory getUIFactory() {
         return uiFactory;
     }
@@ -393,8 +387,8 @@ public class BrowserlessApplicationContext<C> implements AutoCloseable {
                     : new MockVaadinServlet(routes, uiFactory);
             VaadinServletService service = MockVaadin.setupServlet(servlet,
                     lookupServices);
-            return new BrowserlessApplicationContext<>(service, servlet,
-                    uiFactory, securityContextHandler, List.copyOf(closeHooks));
+            return new BrowserlessApplicationContext<>(service, uiFactory,
+                    securityContextHandler, List.copyOf(closeHooks));
         }
     }
 }

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -386,19 +386,37 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             return;
         }
         closed = true;
-        if (activeContext.get() == this) {
+        BrowserlessUIContext stillActive = activeContext.get();
+        boolean wasActive = stillActive == this;
+        if (wasActive) {
             activeContext.remove();
+        } else if (stillActive != null && stillActive.user != this.user) {
+            // Cross-user non-active close: capture the active user's live
+            // security state before the detach run displaces it, so the
+            // re-activation below restores their up-to-date snapshot.
+            stillActive.user.saveSecurityContext();
         }
         if (ui != null) {
-            // Set thread-locals to properly close the UI
+            // Set thread-locals so detach listeners see this user's identity
+            // (service/session/UI/request/response/security), not whatever
+            // the thread happens to carry from another user's window.
             VaadinService.setCurrent(user.getApp().getService());
             VaadinSession.setCurrent(user.getSession());
             UI.setCurrent(ui);
-            // Restore this user's security context so detach listeners see
-            // the right identity, not whatever the thread happens to carry
+            CurrentInstance.set(VaadinRequest.class, user.getRequest());
+            CurrentInstance.set(VaadinResponse.class, user.getResponse());
             user.restoreSecurityContext();
             MockVaadin.closeCurrentUI(true);
             ui = null;
+        }
+        // After a non-active close, re-establish thread-local coherence with
+        // activeContext by re-activating the still-active window. Clear
+        // activeContext first so activate() takes the full-restore branch
+        // (previous == null) and re-installs the active user's security
+        // snapshot we saved above.
+        if (!wasActive && stillActive != null && !stillActive.closed) {
+            activeContext.remove();
+            stillActive.activate();
         }
     }
 

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -35,11 +35,10 @@ import com.vaadin.flow.server.VaadinSession;
 /**
  * UI-level context for multi-user browserless testing.
  * <p>
- * Represents a single browser window/tab (one {@link UI} instance). All DSL
- * methods ({@link #navigate}, {@link #$}, {@link #$view}, {@link #test})
- * automatically call {@link #activate()} before executing, which transparently
- * switches the thread-local Vaadin state and security context to this window's
- * user.
+ * Represents a single browser window (one {@link UI} instance). All DSL methods
+ * ({@link #navigate}, {@link #$}, {@link #$view}, {@link #test}) automatically
+ * call {@link #activate()} before executing, which transparently switches the
+ * thread-local Vaadin state and security context to this window's user.
  * <p>
  * This means you can freely interleave calls on different windows without
  * explicit context switching:

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -15,13 +15,12 @@
  */
 package com.vaadin.browserless;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
+import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.browserless.internal.MockPage;
 import com.vaadin.browserless.internal.MockVaadin;
-import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
@@ -36,11 +35,11 @@ import com.vaadin.flow.server.VaadinSession;
 /**
  * UI-level context for multi-user browserless testing.
  * <p>
- * Represents a single browser window/tab (one {@link UI} instance).
- * All DSL methods ({@link #navigate}, {@link #$}, {@link #$view},
- * {@link #test}) automatically call {@link #activate()} before executing,
- * which transparently switches the thread-local Vaadin state and security
- * context to this window's user.
+ * Represents a single browser window/tab (one {@link UI} instance). All DSL
+ * methods ({@link #navigate}, {@link #$}, {@link #$view}, {@link #test})
+ * automatically call {@link #activate()} before executing, which transparently
+ * switches the thread-local Vaadin state and security context to this window's
+ * user.
  * <p>
  * This means you can freely interleave calls on different windows without
  * explicit context switching:
@@ -83,9 +82,9 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * context belonged to a different user, the outgoing user's security
      * context is automatically saved and this user's context is restored.
      * <p>
-     * This method is called automatically by all DSL methods. You only
-     * need to call it explicitly if you are accessing Vaadin APIs directly
-     * (e.g. {@code UI.getCurrent()}).
+     * This method is called automatically by all DSL methods. You only need to
+     * call it explicitly if you are accessing Vaadin APIs directly (e.g.
+     * {@code UI.getCurrent()}).
      */
     public void activate() {
         if (closed) {
@@ -119,8 +118,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Navigates this window to the given view class.
      *
-     * @param navigationTarget the view class to navigate to
-     * @param <T>              the view type
+     * @param navigationTarget
+     *            the view class to navigate to
+     * @param <T>
+     *            the view type
      * @return the instantiated view
      */
     public <T extends Component> T navigate(Class<T> navigationTarget) {
@@ -132,10 +133,14 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Navigates this window to the given view class with a URL parameter.
      *
-     * @param navigationTarget the view class to navigate to
-     * @param parameter        the URL parameter
-     * @param <T>              the view type
-     * @param <C>              the parameter type
+     * @param navigationTarget
+     *            the view class to navigate to
+     * @param parameter
+     *            the URL parameter
+     * @param <T>
+     *            the view type
+     * @param <C>
+     *            the parameter type
      * @return the instantiated view
      */
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
@@ -148,9 +153,12 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Navigates this window to the given view class with route parameters.
      *
-     * @param navigationTarget the view class to navigate to
-     * @param parameters       the route parameters
-     * @param <T>              the view type
+     * @param navigationTarget
+     *            the view class to navigate to
+     * @param parameters
+     *            the route parameters
+     * @param <T>
+     *            the view type
      * @return the instantiated view
      */
     public <T extends Component> T navigate(Class<T> navigationTarget,
@@ -161,12 +169,15 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Navigates this window to the given location and validates the
-     * resulting view.
+     * Navigates this window to the given location and validates the resulting
+     * view.
      *
-     * @param location       the navigation location string
-     * @param expectedTarget the expected view class
-     * @param <T>            the view type
+     * @param location
+     *            the navigation location string
+     * @param expectedTarget
+     *            the expected view class
+     * @param <T>
+     *            the view type
      * @return the instantiated view
      */
     public <T extends Component> T navigate(String location,
@@ -177,40 +188,46 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Gets a query object for finding components of the given type in
-     * this window's UI.
+     * Gets a query object for finding components of the given type in this
+     * window's UI.
      *
-     * @param componentType the type of component to search for
-     * @param <T>           the component type
+     * @param componentType
+     *            the type of component to search for
+     * @param <T>
+     *            the component type
      * @return a query object
      */
-    public <T extends Component> ComponentQuery<T> $(
-            Class<T> componentType) {
+    public <T extends Component> ComponentQuery<T> $(Class<T> componentType) {
         activate();
         return new ComponentQuery<>(componentType);
     }
 
     /**
-     * Gets a query object for finding components of the given type
-     * nested inside the specified component.
+     * Gets a query object for finding components of the given type nested
+     * inside the specified component.
      *
-     * @param componentType the type of component to search for
-     * @param fromThis      the component to search within
-     * @param <T>           the component type
+     * @param componentType
+     *            the type of component to search for
+     * @param fromThis
+     *            the component to search within
+     * @param <T>
+     *            the component type
      * @return a query object
      */
-    public <T extends Component> ComponentQuery<T> $(
-            Class<T> componentType, Component fromThis) {
+    public <T extends Component> ComponentQuery<T> $(Class<T> componentType,
+            Component fromThis) {
         activate();
         return new ComponentQuery<>(componentType).from(fromThis);
     }
 
     /**
-     * Gets a query object for finding components of the given type
-     * inside the current view.
+     * Gets a query object for finding components of the given type inside the
+     * current view.
      *
-     * @param componentType the type of component to search for
-     * @param <T>           the component type
+     * @param componentType
+     *            the type of component to search for
+     * @param <T>
+     *            the component type
      * @return a query object
      */
     public <T extends Component> ComponentQuery<T> $view(
@@ -225,16 +242,15 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Alias for {@link #$(Class)} — Java-idiomatic name.
      */
-    public <T extends Component> ComponentQuery<T> get(
-            Class<T> componentType) {
+    public <T extends Component> ComponentQuery<T> get(Class<T> componentType) {
         return $(componentType);
     }
 
     /**
      * Alias for {@link #$(Class, Component)} — Java-idiomatic name.
      */
-    public <T extends Component> ComponentQuery<T> get(
-            Class<T> componentType, Component fromThis) {
+    public <T extends Component> ComponentQuery<T> get(Class<T> componentType,
+            Component fromThis) {
         return $(componentType, fromThis);
     }
 
@@ -247,14 +263,16 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Wraps a component with the best matching
-     * {@link ComponentTester}. This generic fallback is used for
-     * component types not covered by the specific {@link TesterWrappers}
-     * defaults.
+     * Wraps a component with the best matching {@link ComponentTester}. This
+     * generic fallback is used for component types not covered by the specific
+     * {@link TesterWrappers} defaults.
      *
-     * @param component the component to wrap
-     * @param <T>       the tester type
-     * @param <Y>       the component type
+     * @param component
+     *            the component to wrap
+     * @param <T>
+     *            the tester type
+     * @param <Y>
+     *            the component type
      * @return the component wrapped in a tester
      */
     public <T extends ComponentTester<Y>, Y extends Component> T test(
@@ -286,9 +304,9 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * {@link com.vaadin.flow.component.page.Page#setLocation(String)} or
      * {@link com.vaadin.flow.component.page.Page#open(String)}.
      * <p>
-     * This captures URLs where the window name is {@code _self}, {@code _parent},
-     * {@code _top}, empty, or {@code null} (all of which navigate the current
-     * window). To query URLs opened in other windows, use
+     * This captures URLs where the window name is {@code _self},
+     * {@code _parent}, {@code _top}, empty, or {@code null} (all of which
+     * navigate the current window). To query URLs opened in other windows, use
      * {@link #getExternalNavigationURL(String)} or {@link #getOpenedWindows()}.
      *
      * @return the external navigation URL, or {@code null} if no external
@@ -305,10 +323,11 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     /**
      * Returns the last URL opened with the given window name.
      * <p>
-     * For {@code _blank}, returns the URL from the most recent call.
-     * For named windows, returns the last URL that targeted that name.
+     * For {@code _blank}, returns the URL from the most recent call. For named
+     * windows, returns the last URL that targeted that name.
      *
-     * @param windowName the window name to look up
+     * @param windowName
+     *            the window name to look up
      * @return the last URL for the given window name, or {@code null} if none
      */
     public String getExternalNavigationURL(String windowName) {
@@ -326,10 +345,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * excluding navigations that target the current window ({@code _self},
      * {@code _parent}, {@code _top}, empty, or {@code null}).
      * <p>
-     * The map keys are window names, and values are lists of URLs opened
-     * under that name. For {@code _blank}, the list contains all URLs
-     * (each call opens a new window). For named windows, the list
-     * typically contains a single entry (the last URL).
+     * The map keys are window names, and values are lists of URLs opened under
+     * that name. For {@code _blank}, the list contains all URLs (each call
+     * opens a new window). For named windows, the list typically contains a
+     * single entry (the last URL).
      *
      * @return an unmodifiable map of window names to URL lists
      */
@@ -391,15 +410,15 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             }
             throw new IllegalArgumentException(
                     "Navigation resulted in unexpected class "
-                            + currentView.getClass().getName()
-                            + " instead of " + navigationTarget.getName());
+                            + currentView.getClass().getName() + " instead of "
+                            + navigationTarget.getName());
         }
         return navigationTarget.cast(currentView);
     }
 
     /**
-     * Returns the currently active UI context for the calling thread,
-     * or {@code null} if none is active.
+     * Returns the currently active UI context for the calling thread, or
+     * {@code null} if none is active.
      *
      * @return the active context, or {@code null}
      */

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import com.vaadin.browserless.internal.MockPage;
+import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.MockInternalSeverError;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * UI-level context for multi-user browserless testing.
+ * <p>
+ * Represents a single browser window/tab (one {@link UI} instance).
+ * All DSL methods ({@link #navigate}, {@link #$}, {@link #$view},
+ * {@link #test}) automatically call {@link #activate()} before executing,
+ * which transparently switches the thread-local Vaadin state and security
+ * context to this window's user.
+ * <p>
+ * This means you can freely interleave calls on different windows without
+ * explicit context switching:
+ *
+ * <pre>
+ * window1.navigate(ViewA.class);
+ * window2.navigate(ViewB.class); // auto-switches to window2's user
+ * window1.$(Button.class).first(); // auto-switches back to window1's user
+ * </pre>
+ *
+ * @see BrowserlessUserContext#newWindow()
+ * @see BrowserlessApplicationContext
+ */
+public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
+
+    private static final ThreadLocal<BrowserlessUIContext> activeContext = new ThreadLocal<>();
+
+    private final BrowserlessUserContext user;
+    private UI ui;
+    private boolean closed;
+
+    BrowserlessUIContext(BrowserlessUserContext user) {
+        this.user = user;
+
+        // Activate this context (sets thread-locals + restores security)
+        activate();
+
+        // Create the UI
+        MockVaadin.createUI(user.getApp().getUIFactory(), user.getSession());
+        this.ui = UI.getCurrent();
+    }
+
+    /**
+     * Activates this UI context on the current thread.
+     * <p>
+     * Sets all Vaadin thread-locals ({@link VaadinService},
+     * {@link VaadinSession}, {@link UI}, {@link VaadinRequest},
+     * {@link VaadinResponse}) to this window's values. If a
+     * {@link SecurityContextHandler} is configured and the previous active
+     * context belonged to a different user, the outgoing user's security
+     * context is automatically saved and this user's context is restored.
+     * <p>
+     * This method is called automatically by all DSL methods. You only
+     * need to call it explicitly if you are accessing Vaadin APIs directly
+     * (e.g. {@code UI.getCurrent()}).
+     */
+    public void activate() {
+        if (closed) {
+            throw new IllegalStateException(
+                    "BrowserlessUIContext is already closed");
+        }
+        BrowserlessUIContext previous = activeContext.get();
+
+        // Save outgoing user's security context on user switch
+        if (previous != null && previous != this
+                && previous.user != this.user) {
+            previous.user.saveSecurityContext();
+        }
+
+        // Set Vaadin thread-locals
+        VaadinService.setCurrent(user.getApp().getService());
+        VaadinSession.setCurrent(user.getSession());
+        UI.setCurrent(ui);
+        CurrentInstance.set(VaadinRequest.class, user.getRequest());
+        CurrentInstance.set(VaadinResponse.class, user.getResponse());
+
+        // Restore security context on user switch or first activation
+        boolean switchingUser = previous == null || previous.user != this.user;
+        if (switchingUser) {
+            user.restoreSecurityContext();
+        }
+
+        activeContext.set(this);
+    }
+
+    /**
+     * Navigates this window to the given view class.
+     *
+     * @param navigationTarget the view class to navigate to
+     * @param <T>              the view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(Class<T> navigationTarget) {
+        activate();
+        ui.navigate(navigationTarget);
+        return validateNavigationTarget(navigationTarget);
+    }
+
+    /**
+     * Navigates this window to the given view class with a URL parameter.
+     *
+     * @param navigationTarget the view class to navigate to
+     * @param parameter        the URL parameter
+     * @param <T>              the view type
+     * @param <C>              the parameter type
+     * @return the instantiated view
+     */
+    public <C, T extends Component & HasUrlParameter<C>> T navigate(
+            Class<T> navigationTarget, C parameter) {
+        activate();
+        ui.navigate(navigationTarget, parameter);
+        return validateNavigationTarget(navigationTarget);
+    }
+
+    /**
+     * Navigates this window to the given view class with route parameters.
+     *
+     * @param navigationTarget the view class to navigate to
+     * @param parameters       the route parameters
+     * @param <T>              the view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(Class<T> navigationTarget,
+            Map<String, String> parameters) {
+        activate();
+        ui.navigate(navigationTarget, new RouteParameters(parameters));
+        return validateNavigationTarget(navigationTarget);
+    }
+
+    /**
+     * Navigates this window to the given location and validates the
+     * resulting view.
+     *
+     * @param location       the navigation location string
+     * @param expectedTarget the expected view class
+     * @param <T>            the view type
+     * @return the instantiated view
+     */
+    public <T extends Component> T navigate(String location,
+            Class<T> expectedTarget) {
+        activate();
+        ui.navigate(location);
+        return validateNavigationTarget(expectedTarget);
+    }
+
+    /**
+     * Gets a query object for finding components of the given type in
+     * this window's UI.
+     *
+     * @param componentType the type of component to search for
+     * @param <T>           the component type
+     * @return a query object
+     */
+    public <T extends Component> ComponentQuery<T> $(
+            Class<T> componentType) {
+        activate();
+        return new ComponentQuery<>(componentType);
+    }
+
+    /**
+     * Gets a query object for finding components of the given type
+     * nested inside the specified component.
+     *
+     * @param componentType the type of component to search for
+     * @param fromThis      the component to search within
+     * @param <T>           the component type
+     * @return a query object
+     */
+    public <T extends Component> ComponentQuery<T> $(
+            Class<T> componentType, Component fromThis) {
+        activate();
+        return new ComponentQuery<>(componentType).from(fromThis);
+    }
+
+    /**
+     * Gets a query object for finding components of the given type
+     * inside the current view.
+     *
+     * @param componentType the type of component to search for
+     * @param <T>           the component type
+     * @return a query object
+     */
+    public <T extends Component> ComponentQuery<T> $view(
+            Class<T> componentType) {
+        activate();
+        Component viewComponent = getCurrentView().getElement().getComponent()
+                .orElseThrow(() -> new AssertionError(
+                        "Cannot get Component instance for current view"));
+        return new ComponentQuery<>(componentType).from(viewComponent);
+    }
+
+    /**
+     * Alias for {@link #$(Class)} — Java-idiomatic name.
+     */
+    public <T extends Component> ComponentQuery<T> get(
+            Class<T> componentType) {
+        return $(componentType);
+    }
+
+    /**
+     * Alias for {@link #$(Class, Component)} — Java-idiomatic name.
+     */
+    public <T extends Component> ComponentQuery<T> get(
+            Class<T> componentType, Component fromThis) {
+        return $(componentType, fromThis);
+    }
+
+    /**
+     * Alias for {@link #$view(Class)} — Java-idiomatic name.
+     */
+    public <T extends Component> ComponentQuery<T> getView(
+            Class<T> componentType) {
+        return $view(componentType);
+    }
+
+    /**
+     * Wraps a component with the best matching
+     * {@link ComponentTester}. This generic fallback is used for
+     * component types not covered by the specific {@link TesterWrappers}
+     * defaults.
+     *
+     * @param component the component to wrap
+     * @param <T>       the tester type
+     * @param <Y>       the component type
+     * @return the component wrapped in a tester
+     */
+    public <T extends ComponentTester<Y>, Y extends Component> T test(
+            Y component) {
+        activate();
+        return BaseBrowserlessTest.internalWrap(component);
+    }
+
+    /**
+     * Gets the current view displayed in this window.
+     *
+     * @return the current view
+     */
+    public HasElement getCurrentView() {
+        activate();
+        return ui.getInternals().getActiveRouterTargetsChain().get(0);
+    }
+
+    /**
+     * Simulates a server round-trip, flushing pending component changes.
+     */
+    public void roundTrip() {
+        activate();
+        BaseBrowserlessTest.roundTrip();
+    }
+
+    /**
+     * Returns the URL from the last external navigation triggered by
+     * {@link com.vaadin.flow.component.page.Page#setLocation(String)} or
+     * {@link com.vaadin.flow.component.page.Page#open(String)}.
+     * <p>
+     * This captures URLs where the window name is {@code _self}, {@code _parent},
+     * {@code _top}, empty, or {@code null} (all of which navigate the current
+     * window). To query URLs opened in other windows, use
+     * {@link #getExternalNavigationURL(String)} or {@link #getOpenedWindows()}.
+     *
+     * @return the external navigation URL, or {@code null} if no external
+     *         navigation has occurred
+     */
+    public String getExternalNavigationURL() {
+        activate();
+        if (ui.getPage() instanceof MockPage mockPage) {
+            return mockPage.getLastExternalNavigationURL();
+        }
+        return null;
+    }
+
+    /**
+     * Returns the last URL opened with the given window name.
+     * <p>
+     * For {@code _blank}, returns the URL from the most recent call.
+     * For named windows, returns the last URL that targeted that name.
+     *
+     * @param windowName the window name to look up
+     * @return the last URL for the given window name, or {@code null} if none
+     */
+    public String getExternalNavigationURL(String windowName) {
+        activate();
+        if (ui.getPage() instanceof MockPage mockPage) {
+            return mockPage.getExternalNavigationURL(windowName);
+        }
+        return null;
+    }
+
+    /**
+     * Returns a map of all windows opened via
+     * {@link com.vaadin.flow.component.page.Page#open(String)} or
+     * {@link com.vaadin.flow.component.page.Page#open(String, String)},
+     * excluding navigations that target the current window ({@code _self},
+     * {@code _parent}, {@code _top}, empty, or {@code null}).
+     * <p>
+     * The map keys are window names, and values are lists of URLs opened
+     * under that name. For {@code _blank}, the list contains all URLs
+     * (each call opens a new window). For named windows, the list
+     * typically contains a single entry (the last URL).
+     *
+     * @return an unmodifiable map of window names to URL lists
+     */
+    public Map<String, List<String>> getOpenedWindows() {
+        activate();
+        if (ui.getPage() instanceof MockPage mockPage) {
+            return mockPage.getOpenedWindows();
+        }
+        return Map.of();
+    }
+
+    /**
+     * Returns the UI managed by this context.
+     *
+     * @return the UI instance
+     */
+    public UI getUI() {
+        return ui;
+    }
+
+    /**
+     * Returns the user context that owns this window.
+     *
+     * @return the parent user context
+     */
+    public BrowserlessUserContext getUser() {
+        return user;
+    }
+
+    /**
+     * Closes this UI context and detaches the UI.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (activeContext.get() == this) {
+            activeContext.remove();
+        }
+        if (ui != null) {
+            // Set thread-locals to properly close the UI
+            VaadinService.setCurrent(user.getApp().getService());
+            VaadinSession.setCurrent(user.getSession());
+            UI.setCurrent(ui);
+            MockVaadin.closeCurrentUI(true);
+            ui = null;
+        }
+    }
+
+    private <T extends Component> T validateNavigationTarget(
+            Class<T> navigationTarget) {
+        HasElement currentView = getCurrentView();
+        if (!navigationTarget.isAssignableFrom(currentView.getClass())) {
+            if (currentView instanceof MockInternalSeverError) {
+                System.err.println(
+                        currentView.getElement().getProperty("stackTrace"));
+            }
+            throw new IllegalArgumentException(
+                    "Navigation resulted in unexpected class "
+                            + currentView.getClass().getName()
+                            + " instead of " + navigationTarget.getName());
+        }
+        return navigationTarget.cast(currentView);
+    }
+
+    /**
+     * Returns the currently active UI context for the calling thread,
+     * or {@code null} if none is active.
+     *
+     * @return the active context, or {@code null}
+     */
+    static BrowserlessUIContext getActive() {
+        return activeContext.get();
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -445,4 +445,20 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     static BrowserlessUIContext getActive() {
         return activeContext.get();
     }
+
+    /**
+     * Clears the active-context ThreadLocal without otherwise touching the
+     * thread-local Vaadin state. Used by close paths that re-activate a
+     * surviving window via {@link #activate()} — clearing first ensures
+     * {@code activate()} takes the full-restore branch
+     * ({@code previous == null}) and re-installs the active user's security
+     * snapshot.
+     */
+    static void clearActiveContext() {
+        activeContext.remove();
+    }
+
+    boolean isClosed() {
+        return closed;
+    }
 }

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -395,6 +395,9 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             VaadinService.setCurrent(user.getApp().getService());
             VaadinSession.setCurrent(user.getSession());
             UI.setCurrent(ui);
+            // Restore this user's security context so detach listeners see
+            // the right identity, not whatever the thread happens to carry
+            user.restoreSecurityContext();
             MockVaadin.closeCurrentUI(true);
             ui = null;
         }

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -39,6 +39,11 @@ import com.vaadin.flow.server.VaadinSession;
  * call {@link #activate()} before executing, which transparently switches the
  * thread-local Vaadin state and security context to this window's user.
  * <p>
+ * Instances of this class are <strong>thread-affine</strong>: they must be
+ * created, used, and closed on the same thread. The active context is held in a
+ * {@link ThreadLocal} and is not visible to other threads. This class is not
+ * safe for concurrent access from multiple threads.
+ * <p>
  * This means you can freely interleave calls on different windows without
  * explicit context switching:
  *
@@ -107,6 +112,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      * {@link SecurityContextHandler} is configured and the previous active
      * context belonged to a different user, the outgoing user's security
      * context is automatically saved and this user's context is restored.
+     * <p>
+     * The security context is a per-user snapshot, not per-window: switching
+     * between windows of the same user does not save or restore security state,
+     * so mutations made by one window are observed by sibling windows.
      * <p>
      * This method is called automatically by all DSL methods. You only need to
      * call it explicitly if you are accessing Vaadin APIs directly (e.g.

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -423,10 +423,17 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             MockVaadin.closeCurrentUI(true);
             ui = null;
         }
-        // After a non-active close, re-establish thread-local coherence with
-        // activeContext by re-activating the still-active window.
+        // Re-establish thread-local coherence with activeContext. After a
+        // non-active close with a surviving active sibling, re-activate it.
+        // Otherwise (active close, or no surviving active context) clear the
+        // closing user's thread-locals so user code reading e.g.
+        // SecurityContextHolder / UI.getCurrent() between close() and the
+        // next activate() does not observe stale state from the closed
+        // window.
         if (!wasActive && stillActive != null && !stillActive.closed) {
             reactivateSurviving(stillActive);
+        } else {
+            user.clearThreadLocals();
         }
     }
 

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -63,12 +63,58 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     BrowserlessUIContext(BrowserlessUserContext user) {
         this.user = user;
 
-        // Activate this context (sets thread-locals + restores security)
-        activate();
+        BrowserlessUIContext previous = activeContext.get();
 
-        // Create the UI
-        MockVaadin.createUI(user.getApp().getUIFactory(), user.getSession());
-        this.ui = UI.getCurrent();
+        // Save outgoing user's security context on user switch — symmetric
+        // with activate().
+        if (previous != null && previous.user != this.user) {
+            previous.user.saveSecurityContext();
+        }
+
+        // Install Vaadin thread-locals required by MockVaadin.createUI (it
+        // reads VaadinRequest.getCurrent()). UI is intentionally not touched
+        // here — createUI sets UI.setCurrent itself after instantiating the
+        // UI, so leaving it alone avoids clobbering a prior UI if createUI
+        // throws before reaching its own UI.setCurrent.
+        VaadinService.setCurrent(user.getApp().getService());
+        VaadinSession.setCurrent(user.getSession());
+        CurrentInstance.set(VaadinRequest.class, user.getRequest());
+        CurrentInstance.set(VaadinResponse.class, user.getResponse());
+
+        // Restore security context on user switch (or first activation) so
+        // UIInit listeners observe this user's identity.
+        boolean switchingUser = previous == null || previous.user != this.user;
+        if (switchingUser) {
+            user.restoreSecurityContext();
+        }
+
+        try {
+            MockVaadin.createUI(user.getApp().getUIFactory(),
+                    user.getSession());
+            this.ui = UI.getCurrent();
+        } catch (RuntimeException ex) {
+            // Roll back thread-local state: do not leak this half-built
+            // context as the active context.
+            if (previous != null && !previous.closed) {
+                activeContext.remove();
+                previous.activate();
+            } else {
+                VaadinService.setCurrent(null);
+                VaadinSession.setCurrent(null);
+                UI.setCurrent(null);
+                CurrentInstance.set(VaadinRequest.class, null);
+                CurrentInstance.set(VaadinResponse.class, null);
+                SecurityContextHandler<?> handler = user.getApp()
+                        .getSecurityContextHandler();
+                if (handler != null) {
+                    handler.clearContext();
+                }
+            }
+            throw ex;
+        }
+
+        // Publish as active only after the UI was fully constructed.
+        activeContext.set(this);
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -24,7 +24,6 @@ import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.server.VaadinRequest;
@@ -71,22 +70,14 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             previous.user.saveSecurityContext();
         }
 
-        // Install Vaadin thread-locals required by MockVaadin.createUI (it
-        // reads VaadinRequest.getCurrent()). UI is intentionally not touched
-        // here — createUI sets UI.setCurrent itself after instantiating the
-        // UI, so leaving it alone avoids clobbering a prior UI if createUI
-        // throws before reaching its own UI.setCurrent.
-        VaadinService.setCurrent(user.getApp().getService());
-        VaadinSession.setCurrent(user.getSession());
-        CurrentInstance.set(VaadinRequest.class, user.getRequest());
-        CurrentInstance.set(VaadinResponse.class, user.getResponse());
-
-        // Restore security context on user switch (or first activation) so
-        // UIInit listeners observe this user's identity.
-        boolean switchingUser = previous == null || previous.user != this.user;
-        if (switchingUser) {
-            user.restoreSecurityContext();
-        }
+        // Install this user's Vaadin thread-locals (service/session/request/
+        // response/security) so MockVaadin.createUI observes this user's
+        // identity. UI is intentionally not touched here — createUI sets
+        // UI.setCurrent itself after instantiating the UI, so leaving it
+        // alone avoids clobbering a prior UI if createUI throws before
+        // reaching its own UI.setCurrent. On same-user re-entry the security
+        // restore is a no-op (snapshot matches live thread state).
+        user.applySessionThreadLocals();
 
         try {
             MockVaadin.createUI(user.getApp().getUIFactory(),
@@ -96,19 +87,9 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             // Roll back thread-local state: do not leak this half-built
             // context as the active context.
             if (previous != null && !previous.closed) {
-                activeContext.remove();
-                previous.activate();
+                reactivateSurviving(previous);
             } else {
-                VaadinService.setCurrent(null);
-                VaadinSession.setCurrent(null);
-                UI.setCurrent(null);
-                CurrentInstance.set(VaadinRequest.class, null);
-                CurrentInstance.set(VaadinResponse.class, null);
-                SecurityContextHandler<?> handler = user.getApp()
-                        .getSecurityContextHandler();
-                if (handler != null) {
-                    handler.clearContext();
-                }
+                user.clearThreadLocals();
             }
             throw ex;
         }
@@ -144,18 +125,10 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             previous.user.saveSecurityContext();
         }
 
-        // Set Vaadin thread-locals
-        VaadinService.setCurrent(user.getApp().getService());
-        VaadinSession.setCurrent(user.getSession());
-        UI.setCurrent(ui);
-        CurrentInstance.set(VaadinRequest.class, user.getRequest());
-        CurrentInstance.set(VaadinResponse.class, user.getResponse());
-
-        // Restore security context on user switch or first activation
-        boolean switchingUser = previous == null || previous.user != this.user;
-        if (switchingUser) {
-            user.restoreSecurityContext();
-        }
+        // Install this user's Vaadin thread-locals and UI, restoring the
+        // user's security snapshot. On same-user re-entry the security
+        // restore is a no-op (snapshot matches live thread state).
+        user.applyUIThreadLocals(ui);
 
         activeContext.set(this);
     }
@@ -446,23 +419,14 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
             // Set thread-locals so detach listeners see this user's identity
             // (service/session/UI/request/response/security), not whatever
             // the thread happens to carry from another user's window.
-            VaadinService.setCurrent(user.getApp().getService());
-            VaadinSession.setCurrent(user.getSession());
-            UI.setCurrent(ui);
-            CurrentInstance.set(VaadinRequest.class, user.getRequest());
-            CurrentInstance.set(VaadinResponse.class, user.getResponse());
-            user.restoreSecurityContext();
+            user.applyUIThreadLocals(ui);
             MockVaadin.closeCurrentUI(true);
             ui = null;
         }
         // After a non-active close, re-establish thread-local coherence with
-        // activeContext by re-activating the still-active window. Clear
-        // activeContext first so activate() takes the full-restore branch
-        // (previous == null) and re-installs the active user's security
-        // snapshot we saved above.
+        // activeContext by re-activating the still-active window.
         if (!wasActive && stillActive != null && !stillActive.closed) {
-            activeContext.remove();
-            stillActive.activate();
+            reactivateSurviving(stillActive);
         }
     }
 
@@ -494,14 +458,27 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
 
     /**
      * Clears the active-context ThreadLocal without otherwise touching the
-     * thread-local Vaadin state. Used by close paths that re-activate a
-     * surviving window via {@link #activate()} — clearing first ensures
-     * {@code activate()} takes the full-restore branch
-     * ({@code previous == null}) and re-installs the active user's security
-     * snapshot.
+     * thread-local Vaadin state. Reserved for defensive test cleanup; lifecycle
+     * code paths should prefer
+     * {@link #reactivateSurviving(BrowserlessUIContext)} which both clears and
+     * re-installs the surviving window's state.
      */
     static void clearActiveContext() {
         activeContext.remove();
+    }
+
+    /**
+     * Re-establishes thread-local coherence with {@link #activeContext} by
+     * re-activating the given surviving window. Clears {@code activeContext}
+     * first so {@link #activate()} takes the full-restore branch
+     * ({@code previous == null}) and re-installs the active user's security
+     * snapshot. Used by lifecycle paths (constructor rollback, non-active
+     * window close, cross-user session destroy) that temporarily displaced the
+     * active window's thread-local state.
+     */
+    static void reactivateSurviving(BrowserlessUIContext stillActive) {
+        activeContext.remove();
+        stillActive.activate();
     }
 
     boolean isClosed() {

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -157,6 +157,12 @@ public class BrowserlessUserContext implements AutoCloseable {
         VaadinService.setCurrent(null);
         CurrentInstance.set(VaadinRequest.class, null);
         CurrentInstance.set(VaadinResponse.class, null);
+        // Drop this user's security snapshot from the thread so it does not
+        // leak into subsequent activations or tests sharing the thread.
+        SecurityContextHandler<?> handler = app.getSecurityContextHandler();
+        if (handler != null) {
+            handler.clearContext();
+        }
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.SessionObjects;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * User-level context for multi-user browserless testing.
+ * <p>
+ * Represents a single logical user with their own
+ * {@link VaadinSession}, HTTP request, and response. Each user context
+ * can have multiple windows (UI instances) via {@link #newWindow()}.
+ * <p>
+ * Security context (if a {@link SecurityContextHandler} is configured on
+ * the parent {@link BrowserlessApplicationContext}) is automatically
+ * captured when this context is created and saved/restored when switching
+ * between users' windows.
+ *
+ * @see BrowserlessApplicationContext#newUser()
+ * @see BrowserlessUIContext
+ */
+public class BrowserlessUserContext implements AutoCloseable {
+
+    private final BrowserlessApplicationContext<?> app;
+    private final VaadinSession session;
+    private final VaadinRequest request;
+    private final VaadinResponse response;
+    private final List<BrowserlessUIContext> windows = new ArrayList<>();
+    private Object securitySnapshot;
+    private boolean closed;
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    BrowserlessUserContext(BrowserlessApplicationContext<?> app,
+            Object credentials) {
+        this.app = app;
+
+        // Save current thread-local state so we can restore it after setup
+        VaadinService previousService = VaadinService.getCurrent();
+        VaadinSession previousSession = VaadinSession.getCurrent();
+        VaadinRequest previousRequest = VaadinRequest.getCurrent();
+        VaadinResponse previousResponse = VaadinResponse.getCurrent();
+        SecurityContextHandler handler = (SecurityContextHandler) app.getSecurityContextHandler();
+        Object previousSecuritySnapshot = handler != null
+                ? handler.saveContext() : null;
+
+        try {
+            // Set service as current (needed for session creation)
+            VaadinService.setCurrent(app.getService());
+
+            // Create session objects without setting thread-locals
+            SessionObjects objs = MockVaadin
+                    .createSessionObjects(app.getService());
+            this.session = objs.getSession();
+            this.request = objs.getRequest();
+            this.response = objs.getResponse();
+
+            // Install thread-locals temporarily for session init listeners
+            VaadinSession.setCurrent(session);
+            CurrentInstance.set(VaadinRequest.class, request);
+            CurrentInstance.set(VaadinResponse.class, response);
+
+            // Fire session init listeners
+            MockVaadin.fireSessionInit(app.getService(), session, request);
+
+            // Set up authentication for this user
+            if (handler != null) {
+                // Start with a clean security context for this user
+                handler.clearContext();
+                if (credentials != null) {
+                    handler.setupAuthentication(credentials);
+                }
+                // Capture as this user's initial security snapshot
+                securitySnapshot = handler.saveContext();
+            }
+        } finally {
+            // Restore previous thread-local state
+            VaadinService.setCurrent(previousService);
+            VaadinSession.setCurrent(previousSession);
+            CurrentInstance.set(VaadinRequest.class, previousRequest);
+            CurrentInstance.set(VaadinResponse.class, previousResponse);
+            // Restore previous security context
+            if (handler != null) {
+                if (previousSecuritySnapshot != null) {
+                    handler.restoreContext(previousSecuritySnapshot);
+                } else {
+                    handler.clearContext();
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a new window (UI instance) for this user.
+     * <p>
+     * The window is automatically activated (thread-locals set) and a new
+     * UI is created. If a route target for {@code ""} is registered, the UI
+     * will navigate to it.
+     *
+     * @return the new UI context
+     */
+    public BrowserlessUIContext newWindow() {
+        checkNotClosed();
+        var window = new BrowserlessUIContext(this);
+        windows.add(window);
+        return window;
+    }
+
+    /**
+     * Closes this user context and all its windows.
+     * <p>
+     * Destroys the Vaadin session and clears associated state.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        for (var window : windows) {
+            window.close();
+        }
+        windows.clear();
+
+        // Destroy session
+        VaadinService.setCurrent(app.getService());
+        VaadinSession.setCurrent(session);
+        app.getService().fireSessionDestroy(session);
+        VaadinSession.setCurrent(null);
+        VaadinService.setCurrent(null);
+    }
+
+    /**
+     * Returns the Vaadin session associated with this user.
+     *
+     * @return the Vaadin session
+     */
+    public VaadinSession getSession() {
+        return session;
+    }
+
+    BrowserlessApplicationContext<?> getApp() {
+        return app;
+    }
+
+    VaadinRequest getRequest() {
+        return request;
+    }
+
+    VaadinResponse getResponse() {
+        return response;
+    }
+
+    /**
+     * Saves the current thread's security context into this user's
+     * snapshot. Called automatically by {@link BrowserlessUIContext#activate()}
+     * when switching away from this user.
+     */
+    void saveSecurityContext() {
+        SecurityContextHandler<?> handler = app.getSecurityContextHandler();
+        if (handler != null) {
+            securitySnapshot = handler.saveContext();
+        }
+    }
+
+    /**
+     * Restores this user's security context onto the current thread.
+     * Called automatically by {@link BrowserlessUIContext#activate()}
+     * when switching to this user.
+     */
+    void restoreSecurityContext() {
+        SecurityContextHandler<?> handler = app.getSecurityContextHandler();
+        if (handler != null) {
+            if (securitySnapshot != null) {
+                handler.restoreContext(securitySnapshot);
+            } else {
+                handler.clearContext();
+            }
+        }
+    }
+
+    private void checkNotClosed() {
+        if (closed) {
+            throw new IllegalStateException(
+                    "BrowserlessUserContext is already closed");
+        }
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -38,9 +38,14 @@ import com.vaadin.flow.server.VaadinSession;
  * parent {@link BrowserlessApplicationContext}) is initialised when this user
  * is created and refreshed on user-switch (when activating a different user's
  * window), capturing the outgoing user's live thread-local state at that
- * moment. Mutations to the security context while one of this user's windows is
- * active persist on the thread and are captured into this user's snapshot at
- * the next user-switch — same-user window switches don't touch the snapshot.
+ * moment. The new user's authentication is installed on the thread before
+ * {@code SessionInit} listeners fire, so listeners observe this user's identity
+ * — matching the Vaadin+Spring flow where the security filter chain runs before
+ * the servlet. The user's initial snapshot is captured after init fires, so any
+ * security mutation a listener performs persists into the snapshot. Mutations
+ * to the security context while one of this user's windows is active persist on
+ * the thread and are captured into the snapshot at the next user-switch —
+ * same-user window switches don't touch the snapshot.
  *
  * @see BrowserlessApplicationContext#newUser()
  * @see BrowserlessUIContext
@@ -90,10 +95,9 @@ public class BrowserlessUserContext implements AutoCloseable {
             CurrentInstance.set(VaadinRequest.class, request);
             CurrentInstance.set(VaadinResponse.class, response);
 
-            // Fire session init listeners
-            MockVaadin.fireSessionInit(app.getService(), session, request);
-
-            // Set up authentication for this user
+            // Set up authentication BEFORE firing session-init listeners so
+            // they observe this user's identity, mirroring the Vaadin+Spring
+            // flow where the security filter chain runs before the servlet.
             if (handler != null) {
                 // Start with a clean security context for this user
                 handler.clearContext();
@@ -101,7 +105,15 @@ public class BrowserlessUserContext implements AutoCloseable {
                 // credentials (e.g. Spring sets an
                 // AnonymousAuthenticationToken)
                 handler.setupAuthentication(credentials);
-                // Capture as this user's initial security snapshot
+            }
+
+            // Fire session init listeners
+            MockVaadin.fireSessionInit(app.getService(), session, request);
+
+            // Capture as this user's initial security snapshot, after init
+            // so any security mutation a listener performs persists into
+            // this user's snapshot rather than being silently discarded.
+            if (handler != null) {
                 securitySnapshot = handler.saveContext();
             }
         } finally {

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -34,9 +34,12 @@ import com.vaadin.flow.server.VaadinSession;
  * instances) via {@link #newWindow()}.
  * <p>
  * Security context (if a {@link SecurityContextHandler} is configured on the
- * parent {@link BrowserlessApplicationContext}) is automatically captured when
- * this context is created and saved/restored when switching between users'
- * windows.
+ * parent {@link BrowserlessApplicationContext}) is initialised when this user
+ * is created and refreshed on user-switch (when activating a different user's
+ * window), capturing the outgoing user's live thread-local state at that
+ * moment. Mutations to the security context while one of this user's windows is
+ * active persist on the thread and are captured into this user's snapshot at
+ * the next user-switch — same-user window switches don't touch the snapshot.
  *
  * @see BrowserlessApplicationContext#newUser()
  * @see BrowserlessUIContext

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -51,7 +51,6 @@ public class BrowserlessUserContext implements AutoCloseable {
     private Object securitySnapshot;
     private boolean closed;
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     BrowserlessUserContext(BrowserlessApplicationContext<?> app,
             Object credentials) {
         this.app = app;
@@ -61,6 +60,10 @@ public class BrowserlessUserContext implements AutoCloseable {
         VaadinSession previousSession = VaadinSession.getCurrent();
         VaadinRequest previousRequest = VaadinRequest.getCurrent();
         VaadinResponse previousResponse = VaadinResponse.getCurrent();
+        // Raw type so we can pass the Object credentials to setupAuthentication
+        // without forcing every caller (and the surrounding wildcard
+        // BrowserlessApplicationContext<?>) to know the concrete C.
+        @SuppressWarnings({ "unchecked", "rawtypes" })
         SecurityContextHandler handler = app.getSecurityContextHandler();
         Object previousSecuritySnapshot = handler != null
                 ? handler.saveContext()

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.internal.SessionObjects;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -63,6 +64,7 @@ public class BrowserlessUserContext implements AutoCloseable {
         VaadinSession previousSession = VaadinSession.getCurrent();
         VaadinRequest previousRequest = VaadinRequest.getCurrent();
         VaadinResponse previousResponse = VaadinResponse.getCurrent();
+        UI previousUI = UI.getCurrent();
         // Raw type so we can pass the Object credentials to setupAuthentication
         // without forcing every caller (and the surrounding wildcard
         // BrowserlessApplicationContext<?>) to know the concrete C.
@@ -108,6 +110,7 @@ public class BrowserlessUserContext implements AutoCloseable {
             VaadinSession.setCurrent(previousSession);
             CurrentInstance.set(VaadinRequest.class, previousRequest);
             CurrentInstance.set(VaadinResponse.class, previousResponse);
+            UI.setCurrent(previousUI);
             // Restore previous security context — handler contract specifies
             // null → clearContext, so the snapshot is forwarded as-is.
             if (handler != null) {
@@ -135,7 +138,10 @@ public class BrowserlessUserContext implements AutoCloseable {
     /**
      * Closes this user context and all its windows.
      * <p>
-     * Destroys the Vaadin session and clears associated state.
+     * Destroys the Vaadin session and clears associated state. If a window
+     * belonging to a different user is the active context on the calling thread
+     * when this method runs, that window is re-activated at the end so
+     * subsequent operations on it see a coherent thread-local state.
      */
     @Override
     public void close() {
@@ -148,13 +154,34 @@ public class BrowserlessUserContext implements AutoCloseable {
         }
         windows.clear();
 
+        // After window.close() iterations the thread state may belong to a
+        // window of another user (see BrowserlessUIContext.close()'s
+        // re-activation step for cross-user non-active closes). Capture the
+        // active context now so we can restore it after the destroy phase.
+        BrowserlessUIContext active = BrowserlessUIContext.getActive();
+        boolean activeIsAnotherUser = active != null
+                && active.getUser() != this;
+
+        // Set thread-locals so destroy listeners (and the security snapshot
+        // observed by them) see this user's identity, not whatever the
+        // thread happens to carry from another active user. VaadinRequest
+        // and VaadinResponse are set for parity even though Vaadin's
+        // session-destroy listeners run under session.access semantics that
+        // null them out — keeping the prep symmetric protects against
+        // future Vaadin changes.
+        VaadinService.setCurrent(app.getService());
+        VaadinSession.setCurrent(session);
+        CurrentInstance.set(VaadinRequest.class, request);
+        CurrentInstance.set(VaadinResponse.class, response);
+        restoreSecurityContext();
+
         // Destroy session: fire destroy listeners and drain the queue,
         // mirroring MockVaadin.closeCurrentSession (which gates the
         // session-recreation hook via a thread-local flag).
-        VaadinService.setCurrent(app.getService());
-        VaadinSession.setCurrent(session);
         MockVaadin.fireSessionDestroyAndDrain(session);
+
         VaadinService.setCurrent(null);
+        VaadinSession.setCurrent(null);
         CurrentInstance.set(VaadinRequest.class, null);
         CurrentInstance.set(VaadinResponse.class, null);
         // Drop this user's security snapshot from the thread so it does not
@@ -162,6 +189,15 @@ public class BrowserlessUserContext implements AutoCloseable {
         SecurityContextHandler<?> handler = app.getSecurityContextHandler();
         if (handler != null) {
             handler.clearContext();
+        }
+
+        // If a different user's window is still active, re-establish its
+        // thread-locals (UI/Session/Request/Response/security) so any
+        // subsequent operation on it observes a coherent state. Clear
+        // activeContext first so activate() takes the full-restore branch.
+        if (activeIsAnotherUser && !active.isClosed()) {
+            BrowserlessUIContext.clearActiveContext();
+            active.activate();
         }
     }
 

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -145,12 +145,15 @@ public class BrowserlessUserContext implements AutoCloseable {
         }
         windows.clear();
 
-        // Destroy session
+        // Destroy session: fire destroy listeners and drain the queue,
+        // mirroring MockVaadin.closeCurrentSession (which gates the
+        // session-recreation hook via a thread-local flag).
         VaadinService.setCurrent(app.getService());
         VaadinSession.setCurrent(session);
-        app.getService().fireSessionDestroy(session);
-        VaadinSession.setCurrent(null);
+        MockVaadin.fireSessionDestroyAndDrain(session);
         VaadinService.setCurrent(null);
+        CurrentInstance.set(VaadinRequest.class, null);
+        CurrentInstance.set(VaadinResponse.class, null);
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -61,8 +61,7 @@ public class BrowserlessUserContext implements AutoCloseable {
         VaadinSession previousSession = VaadinSession.getCurrent();
         VaadinRequest previousRequest = VaadinRequest.getCurrent();
         VaadinResponse previousResponse = VaadinResponse.getCurrent();
-        SecurityContextHandler handler = (SecurityContextHandler) app
-                .getSecurityContextHandler();
+        SecurityContextHandler handler = app.getSecurityContextHandler();
         Object previousSecuritySnapshot = handler != null
                 ? handler.saveContext()
                 : null;
@@ -90,9 +89,10 @@ public class BrowserlessUserContext implements AutoCloseable {
             if (handler != null) {
                 // Start with a clean security context for this user
                 handler.clearContext();
-                if (credentials != null) {
-                    handler.setupAuthentication(credentials);
-                }
+                // Always delegate to the handler so it can interpret null
+                // credentials (e.g. Spring sets an
+                // AnonymousAuthenticationToken)
+                handler.setupAuthentication(credentials);
                 // Capture as this user's initial security snapshot
                 securitySnapshot = handler.saveContext();
             }

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -29,14 +29,14 @@ import com.vaadin.flow.server.VaadinSession;
 /**
  * User-level context for multi-user browserless testing.
  * <p>
- * Represents a single logical user with their own
- * {@link VaadinSession}, HTTP request, and response. Each user context
- * can have multiple windows (UI instances) via {@link #newWindow()}.
+ * Represents a single logical user with their own {@link VaadinSession}, HTTP
+ * request, and response. Each user context can have multiple windows (UI
+ * instances) via {@link #newWindow()}.
  * <p>
- * Security context (if a {@link SecurityContextHandler} is configured on
- * the parent {@link BrowserlessApplicationContext}) is automatically
- * captured when this context is created and saved/restored when switching
- * between users' windows.
+ * Security context (if a {@link SecurityContextHandler} is configured on the
+ * parent {@link BrowserlessApplicationContext}) is automatically captured when
+ * this context is created and saved/restored when switching between users'
+ * windows.
  *
  * @see BrowserlessApplicationContext#newUser()
  * @see BrowserlessUIContext
@@ -61,9 +61,11 @@ public class BrowserlessUserContext implements AutoCloseable {
         VaadinSession previousSession = VaadinSession.getCurrent();
         VaadinRequest previousRequest = VaadinRequest.getCurrent();
         VaadinResponse previousResponse = VaadinResponse.getCurrent();
-        SecurityContextHandler handler = (SecurityContextHandler) app.getSecurityContextHandler();
+        SecurityContextHandler handler = (SecurityContextHandler) app
+                .getSecurityContextHandler();
         Object previousSecuritySnapshot = handler != null
-                ? handler.saveContext() : null;
+                ? handler.saveContext()
+                : null;
 
         try {
             // Set service as current (needed for session creation)
@@ -114,9 +116,9 @@ public class BrowserlessUserContext implements AutoCloseable {
     /**
      * Creates a new window (UI instance) for this user.
      * <p>
-     * The window is automatically activated (thread-locals set) and a new
-     * UI is created. If a route target for {@code ""} is registered, the UI
-     * will navigate to it.
+     * The window is automatically activated (thread-locals set) and a new UI is
+     * created. If a route target for {@code ""} is registered, the UI will
+     * navigate to it.
      *
      * @return the new UI context
      */
@@ -173,9 +175,9 @@ public class BrowserlessUserContext implements AutoCloseable {
     }
 
     /**
-     * Saves the current thread's security context into this user's
-     * snapshot. Called automatically by {@link BrowserlessUIContext#activate()}
-     * when switching away from this user.
+     * Saves the current thread's security context into this user's snapshot.
+     * Called automatically by {@link BrowserlessUIContext#activate()} when
+     * switching away from this user.
      */
     void saveSecurityContext() {
         SecurityContextHandler<?> handler = app.getSecurityContextHandler();
@@ -185,9 +187,9 @@ public class BrowserlessUserContext implements AutoCloseable {
     }
 
     /**
-     * Restores this user's security context onto the current thread.
-     * Called automatically by {@link BrowserlessUIContext#activate()}
-     * when switching to this user.
+     * Restores this user's security context onto the current thread. Called
+     * automatically by {@link BrowserlessUIContext#activate()} when switching
+     * to this user.
      */
     void restoreSecurityContext() {
         SecurityContextHandler<?> handler = app.getSecurityContextHandler();

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -102,13 +102,10 @@ public class BrowserlessUserContext implements AutoCloseable {
             VaadinSession.setCurrent(previousSession);
             CurrentInstance.set(VaadinRequest.class, previousRequest);
             CurrentInstance.set(VaadinResponse.class, previousResponse);
-            // Restore previous security context
+            // Restore previous security context — handler contract specifies
+            // null → clearContext, so the snapshot is forwarded as-is.
             if (handler != null) {
-                if (previousSecuritySnapshot != null) {
-                    handler.restoreContext(previousSecuritySnapshot);
-                } else {
-                    handler.clearContext();
-                }
+                handler.restoreContext(previousSecuritySnapshot);
             }
         }
     }
@@ -197,11 +194,8 @@ public class BrowserlessUserContext implements AutoCloseable {
     void restoreSecurityContext() {
         SecurityContextHandler<?> handler = app.getSecurityContextHandler();
         if (handler != null) {
-            if (securitySnapshot != null) {
-                handler.restoreContext(securitySnapshot);
-            } else {
-                handler.clearContext();
-            }
+            // Contract: handler.restoreContext(null) clears the context.
+            handler.restoreContext(securitySnapshot);
         }
     }
 

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -90,10 +90,11 @@ public class BrowserlessUserContext implements AutoCloseable {
             this.request = objs.getRequest();
             this.response = objs.getResponse();
 
-            // Install thread-locals temporarily for session init listeners
-            VaadinSession.setCurrent(session);
-            CurrentInstance.set(VaadinRequest.class, request);
-            CurrentInstance.set(VaadinResponse.class, response);
+            // Install thread-locals temporarily for session init listeners.
+            // restoreSecurityContext() is a no-op here (snapshot is still
+            // null), and the explicit clearContext()+setupAuthentication
+            // below replaces it before any listener observes the state.
+            applySessionThreadLocals();
 
             // Set up authentication BEFORE firing session-init listeners so
             // they observe this user's identity, mirroring the Vaadin+Spring
@@ -181,35 +182,23 @@ public class BrowserlessUserContext implements AutoCloseable {
         // session-destroy listeners run under session.access semantics that
         // null them out — keeping the prep symmetric protects against
         // future Vaadin changes.
-        VaadinService.setCurrent(app.getService());
-        VaadinSession.setCurrent(session);
-        CurrentInstance.set(VaadinRequest.class, request);
-        CurrentInstance.set(VaadinResponse.class, response);
-        restoreSecurityContext();
+        applySessionThreadLocals();
 
         // Destroy session: fire destroy listeners and drain the queue,
         // mirroring MockVaadin.closeCurrentSession (which gates the
         // session-recreation hook via a thread-local flag).
         MockVaadin.fireSessionDestroyAndDrain(session);
 
-        VaadinService.setCurrent(null);
-        VaadinSession.setCurrent(null);
-        CurrentInstance.set(VaadinRequest.class, null);
-        CurrentInstance.set(VaadinResponse.class, null);
-        // Drop this user's security snapshot from the thread so it does not
-        // leak into subsequent activations or tests sharing the thread.
-        SecurityContextHandler<?> handler = app.getSecurityContextHandler();
-        if (handler != null) {
-            handler.clearContext();
-        }
+        // Drop this user's thread-local state — including the security
+        // snapshot — so it does not leak into subsequent activations or
+        // tests sharing the thread.
+        clearThreadLocals();
 
         // If a different user's window is still active, re-establish its
         // thread-locals (UI/Session/Request/Response/security) so any
-        // subsequent operation on it observes a coherent state. Clear
-        // activeContext first so activate() takes the full-restore branch.
+        // subsequent operation on it observes a coherent state.
         if (activeIsAnotherUser && !active.isClosed()) {
-            BrowserlessUIContext.clearActiveContext();
-            active.activate();
+            BrowserlessUIContext.reactivateSurviving(active);
         }
     }
 
@@ -232,6 +221,54 @@ public class BrowserlessUserContext implements AutoCloseable {
 
     VaadinResponse getResponse() {
         return response;
+    }
+
+    /**
+     * Applies this user's session-level Vaadin thread-locals
+     * (service/session/request/response/security) on the current thread, and
+     * restores this user's security snapshot. Does not touch
+     * {@link UI#setCurrent}. Used by the {@link BrowserlessUIContext}
+     * constructor (where {@code MockVaadin.createUI} sets {@code UI.setCurrent}
+     * itself, so we intentionally leave any prior UI in place until
+     * {@code createUI} succeeds) and by this class's own constructor +
+     * {@code close()}.
+     */
+    void applySessionThreadLocals() {
+        VaadinService.setCurrent(app.getService());
+        VaadinSession.setCurrent(session);
+        CurrentInstance.set(VaadinRequest.class, request);
+        CurrentInstance.set(VaadinResponse.class, response);
+        restoreSecurityContext();
+    }
+
+    /**
+     * Applies this user's full Vaadin thread-local state on the current thread:
+     * the session-level state from {@link #applySessionThreadLocals()} plus
+     * {@code UI.setCurrent(ui)}. Used by
+     * {@link BrowserlessUIContext#activate()} and
+     * {@link BrowserlessUIContext#close()}.
+     */
+    void applyUIThreadLocals(UI ui) {
+        applySessionThreadLocals();
+        UI.setCurrent(ui);
+    }
+
+    /**
+     * Clears all Vaadin thread-locals and the security context on the current
+     * thread. Vaadin thread-locals are cleared before security so a future
+     * security handler that reads {@code VaadinSession.getCurrent()} during
+     * clear-out sees {@code null}.
+     */
+    void clearThreadLocals() {
+        VaadinService.setCurrent(null);
+        VaadinSession.setCurrent(null);
+        UI.setCurrent(null);
+        CurrentInstance.set(VaadinRequest.class, null);
+        CurrentInstance.set(VaadinResponse.class, null);
+        SecurityContextHandler<?> handler = app.getSecurityContextHandler();
+        if (handler != null) {
+            handler.clearContext();
+        }
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -60,7 +60,7 @@ import com.vaadin.flow.server.VaadinSession;
  */
 public class BrowserlessUserContext implements AutoCloseable {
 
-    private final BrowserlessApplicationContext<?> app;
+    private final BrowserlessApplicationContext app;
     private final VaadinSession session;
     private final VaadinRequest request;
     private final VaadinResponse response;
@@ -68,7 +68,7 @@ public class BrowserlessUserContext implements AutoCloseable {
     private Object securitySnapshot;
     private boolean closed;
 
-    BrowserlessUserContext(BrowserlessApplicationContext<?> app,
+    BrowserlessUserContext(BrowserlessApplicationContext app,
             Object credentials) {
         this.app = app;
 
@@ -79,8 +79,9 @@ public class BrowserlessUserContext implements AutoCloseable {
         VaadinResponse previousResponse = VaadinResponse.getCurrent();
         UI previousUI = UI.getCurrent();
         // Raw type so we can pass the Object credentials to setupAuthentication
-        // without forcing every caller (and the surrounding wildcard
-        // BrowserlessApplicationContext<?>) to know the concrete C.
+        // without knowing the concrete C; getSecurityContextHandler() returns
+        // null on the unsecured base class and a typed handler on the secured
+        // subclass.
         @SuppressWarnings({ "unchecked", "rawtypes" })
         SecurityContextHandler handler = app.getSecurityContextHandler();
         Object previousSecuritySnapshot = handler != null
@@ -219,7 +220,7 @@ public class BrowserlessUserContext implements AutoCloseable {
         return session;
     }
 
-    BrowserlessApplicationContext<?> getApp() {
+    BrowserlessApplicationContext getApp() {
         return app;
     }
 

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -34,6 +34,11 @@ import com.vaadin.flow.server.VaadinSession;
  * request, and response. Each user context can have multiple windows (UI
  * instances) via {@link #newWindow()}.
  * <p>
+ * Instances of this class are <strong>thread-affine</strong>: they must be
+ * created, used, and closed on the same thread. The active context is held in a
+ * {@link ThreadLocal} and is not visible to other threads. This class is not
+ * safe for concurrent access from multiple threads.
+ * <p>
  * Security context (if a {@link SecurityContextHandler} is configured on the
  * parent {@link BrowserlessApplicationContext}) is initialised when this user
  * is created and refreshed on user-switch (when activating a different user's
@@ -42,10 +47,13 @@ import com.vaadin.flow.server.VaadinSession;
  * {@code SessionInit} listeners fire, so listeners observe this user's identity
  * — matching the Vaadin+Spring flow where the security filter chain runs before
  * the servlet. The user's initial snapshot is captured after init fires, so any
- * security mutation a listener performs persists into the snapshot. Mutations
- * to the security context while one of this user's windows is active persist on
- * the thread and are captured into the snapshot at the next user-switch —
- * same-user window switches don't touch the snapshot.
+ * security mutation a listener performs persists into the snapshot.
+ * <p>
+ * The security snapshot is <strong>per-user, not per-window</strong>: all of a
+ * user's windows share one snapshot. Security-context mutations made while one
+ * window is active persist on the thread and remain visible to other windows of
+ * the same user; the snapshot is re-captured only on user-switch, so same-user
+ * window switches don't touch it.
  *
  * @see BrowserlessApplicationContext#newUser()
  * @see BrowserlessUIContext

--- a/shared/src/main/java/com/vaadin/browserless/SecuredBrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/SecuredBrowserlessApplicationContext.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.UIFactory;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletService;
+
+/**
+ * Credential-aware application context.
+ * <p>
+ * Extends {@link BrowserlessApplicationContext} with a configured, non-null
+ * {@link SecurityContextHandler} and credential-typed {@code newUser(...)}
+ * overloads for installing per-user security state. Build instances via
+ * {@link BrowserlessApplicationContext#builder(Routes)} followed by
+ * {@link BrowserlessApplicationContext.Builder#withSecurityContextHandler(SecurityContextHandler)},
+ * which transitions to {@link Builder} and produces this typed context.
+ * <p>
+ * All thread-affinity and lifecycle guarantees of the base
+ * {@link BrowserlessApplicationContext} apply unchanged.
+ *
+ * @param <C>
+ *            the credentials type accepted by {@link #newUser(Object)}, as
+ *            defined by the configured {@link SecurityContextHandler}
+ * @see BrowserlessApplicationContext
+ * @see SecurityContextHandler
+ */
+public class SecuredBrowserlessApplicationContext<C>
+        extends BrowserlessApplicationContext {
+
+    private final SecurityContextHandler<C> handler;
+
+    SecuredBrowserlessApplicationContext(VaadinServletService service,
+            UIFactory uiFactory, SecurityContextHandler<C> handler,
+            List<Runnable> closeHooks) {
+        super(service, uiFactory, closeHooks);
+        this.handler = handler;
+    }
+
+    /**
+     * Creates a new user context with the given credentials.
+     * <p>
+     * The security context for this user is first cleared, then the credentials
+     * are passed to {@link SecurityContextHandler#setupAuthentication(Object)
+     * SecurityContextHandler.setupAuthentication()} — including when
+     * {@code credentials} is {@code null}, so that the handler can install its
+     * anonymous-equivalent state. The resulting security state is captured as
+     * this user's initial snapshot and is automatically restored whenever one
+     * of this user's windows is activated.
+     *
+     * @param credentials
+     *            framework-specific credentials, or {@code null} for an
+     *            anonymous user
+     * @return the new user context
+     * @throws IllegalStateException
+     *             if this context has been closed
+     */
+    public BrowserlessUserContext newUser(C credentials) {
+        return newUserInternal(credentials);
+    }
+
+    /**
+     * Creates a new user context for the given username and roles.
+     * <p>
+     * Delegates to
+     * {@link SecurityContextHandler#createCredentials(String, String...)} on
+     * the configured handler, then to {@link #newUser(Object)}. Spring and
+     * Quarkus handlers ship with overrides that mirror the conventions of
+     * {@code @WithMockUser} / Quarkus security identity construction; custom
+     * handlers must override {@code createCredentials} to opt into this helper.
+     *
+     * @param username
+     *            the username
+     * @param roles
+     *            the roles for the user; may be empty
+     * @return the new user context
+     * @throws IllegalStateException
+     *             if this context has been closed
+     * @throws UnsupportedOperationException
+     *             if the configured handler doesn't override
+     *             {@link SecurityContextHandler#createCredentials(String, String...)}
+     */
+    public BrowserlessUserContext newUser(String username, String... roles) {
+        checkNotClosed();
+        Objects.requireNonNull(username, "username must not be null");
+        Objects.requireNonNull(roles, "roles must not be null");
+        return newUser(handler.createCredentials(username, roles));
+    }
+
+    @Override
+    SecurityContextHandler<C> getSecurityContextHandler() {
+        return handler;
+    }
+
+    /**
+     * Builder for {@link SecuredBrowserlessApplicationContext}. Obtained from
+     * {@link BrowserlessApplicationContext.Builder#withSecurityContextHandler(SecurityContextHandler)};
+     * delegates to the underlying base builder for shared configuration.
+     *
+     * @param <C>
+     *            the credentials type
+     */
+    public static final class Builder<C> {
+
+        private final BrowserlessApplicationContext.Builder base;
+        private final SecurityContextHandler<C> handler;
+
+        Builder(BrowserlessApplicationContext.Builder base,
+                SecurityContextHandler<C> handler) {
+            this.base = base;
+            this.handler = handler;
+        }
+
+        /**
+         * Replaces the security context handler, possibly switching its
+         * credentials type.
+         *
+         * @param <D>
+         *            the new credentials type
+         * @param handler
+         *            the handler; must not be {@code null}
+         * @return a builder configured with the given handler
+         * @throws NullPointerException
+         *             if {@code handler} is {@code null}
+         */
+        public <D> Builder<D> withSecurityContextHandler(
+                SecurityContextHandler<D> handler) {
+            Objects.requireNonNull(handler, "handler must not be null");
+            return new Builder<>(base, handler);
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withServletFactory
+         */
+        public Builder<C> withServletFactory(
+                BiFunction<Routes, UIFactory, VaadinServlet> factory) {
+            base.withServletFactory(factory);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withUIFactory
+         */
+        public Builder<C> withUIFactory(UIFactory uiFactory) {
+            base.withUIFactory(uiFactory);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withLookupServices
+         */
+        public Builder<C> withLookupServices(Class<?>... services) {
+            base.withLookupServices(services);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withCloseHook
+         */
+        public Builder<C> withCloseHook(Runnable hook) {
+            base.withCloseHook(hook);
+            return this;
+        }
+
+        /**
+         * Builds the secured application context.
+         *
+         * @return a new secured application context
+         */
+        public SecuredBrowserlessApplicationContext<C> build() {
+            return new SecuredBrowserlessApplicationContext<>(
+                    base.buildService(), base.uiFactory(), handler,
+                    base.buildCloseHooks());
+        }
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
+++ b/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
@@ -37,9 +37,16 @@ public interface SecurityContextHandler<C> {
      * implementation. For example, Spring uses
      * {@code org.springframework.security.core.Authentication} and Quarkus uses
      * {@code io.quarkus.security.identity.SecurityIdentity}.
+     * <p>
+     * Implementations must accept {@code null} credentials and produce an
+     * anonymous-equivalent state — e.g. Spring sets an
+     * {@code AnonymousAuthenticationToken}, mirroring
+     * {@code @WithAnonymousUser}. {@link #clearContext()} is invoked
+     * immediately before this method so that earlier state cannot leak through.
      *
      * @param credentials
-     *            framework-specific credentials object
+     *            framework-specific credentials object, or {@code null} for an
+     *            anonymous user
      */
     void setupAuthentication(C credentials);
 
@@ -68,4 +75,34 @@ public interface SecurityContextHandler<C> {
      * Clears the security context from the current thread.
      */
     void clearContext();
+
+    /**
+     * Builds framework-specific credentials for the given username and roles.
+     * <p>
+     * Used by {@link BrowserlessApplicationContext#newUser(String, String...)}
+     * so tests can authenticate a user without writing the framework-specific
+     * boilerplate. Spring's implementation produces a
+     * {@code UsernamePasswordAuthenticationToken} carrying a {@code User}
+     * principal (mirroring {@code @WithMockUser}); Quarkus's implementation
+     * produces a {@code QuarkusSecurityIdentity}.
+     * <p>
+     * The default implementation throws {@link UnsupportedOperationException} —
+     * handlers that don't have a natural mapping from username + roles to
+     * {@code C} can simply leave it unimplemented; callers must then use
+     * {@link BrowserlessApplicationContext#newUser(Object) newUser(C
+     * credentials)} directly.
+     *
+     * @param username
+     *            the username
+     * @param roles
+     *            the roles for the user; never {@code null}, may be empty
+     * @return the credentials, never {@code null}
+     */
+    default C createCredentials(String username, String... roles) {
+        throw new UnsupportedOperationException("This "
+                + getClass().getSimpleName()
+                + " does not support building credentials from a username and"
+                + " roles. Override createCredentials(...) or call"
+                + " newUser(C credentials) with explicit credentials.");
+    }
 }

--- a/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
+++ b/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+/**
+ * Abstracts per-user security context management for multi-user testing.
+ * <p>
+ * Framework modules (Spring, Quarkus) provide implementations that bridge
+ * their security infrastructure (e.g. Spring's {@code SecurityContextHolder},
+ * Quarkus's {@code CurrentIdentityAssociation}) with the browserless
+ * multi-user context hierarchy.
+ * <p>
+ * Implementations must be thread-safe with respect to the thread-local
+ * security state they manage.
+ *
+ * @see BrowserlessApplicationContext.Builder#withSecurityContextHandler(SecurityContextHandler)
+ */
+public interface SecurityContextHandler<C> {
+
+    /**
+     * Sets up authentication for a new user from the given credentials.
+     * <p>
+     * The type parameter {@code C} is determined by the framework
+     * implementation. For example, Spring uses
+     * {@code org.springframework.security.core.Authentication} and Quarkus
+     * uses {@code io.quarkus.security.identity.SecurityIdentity}.
+     *
+     * @param credentials framework-specific credentials object
+     */
+    void setupAuthentication(C credentials);
+
+    /**
+     * Captures the current thread's security context as an opaque snapshot.
+     * <p>
+     * Called automatically when switching away from a user context to
+     * preserve its security state.
+     *
+     * @return an opaque snapshot of the current security context, or
+     *         {@code null} if no security context is active
+     */
+    Object saveContext();
+
+    /**
+     * Restores a previously saved security context snapshot onto the
+     * current thread.
+     *
+     * @param snapshot a snapshot previously returned by {@link #saveContext()},
+     *                 or {@code null} to clear the context
+     */
+    void restoreContext(Object snapshot);
+
+    /**
+     * Clears the security context from the current thread.
+     */
+    void clearContext();
+}

--- a/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
+++ b/shared/src/main/java/com/vaadin/browserless/SecurityContextHandler.java
@@ -18,13 +18,13 @@ package com.vaadin.browserless;
 /**
  * Abstracts per-user security context management for multi-user testing.
  * <p>
- * Framework modules (Spring, Quarkus) provide implementations that bridge
- * their security infrastructure (e.g. Spring's {@code SecurityContextHolder},
- * Quarkus's {@code CurrentIdentityAssociation}) with the browserless
- * multi-user context hierarchy.
+ * Framework modules (Spring, Quarkus) provide implementations that bridge their
+ * security infrastructure (e.g. Spring's {@code SecurityContextHolder},
+ * Quarkus's {@code CurrentIdentityAssociation}) with the browserless multi-user
+ * context hierarchy.
  * <p>
- * Implementations must be thread-safe with respect to the thread-local
- * security state they manage.
+ * Implementations must be thread-safe with respect to the thread-local security
+ * state they manage.
  *
  * @see BrowserlessApplicationContext.Builder#withSecurityContextHandler(SecurityContextHandler)
  */
@@ -35,18 +35,19 @@ public interface SecurityContextHandler<C> {
      * <p>
      * The type parameter {@code C} is determined by the framework
      * implementation. For example, Spring uses
-     * {@code org.springframework.security.core.Authentication} and Quarkus
-     * uses {@code io.quarkus.security.identity.SecurityIdentity}.
+     * {@code org.springframework.security.core.Authentication} and Quarkus uses
+     * {@code io.quarkus.security.identity.SecurityIdentity}.
      *
-     * @param credentials framework-specific credentials object
+     * @param credentials
+     *            framework-specific credentials object
      */
     void setupAuthentication(C credentials);
 
     /**
      * Captures the current thread's security context as an opaque snapshot.
      * <p>
-     * Called automatically when switching away from a user context to
-     * preserve its security state.
+     * Called automatically when switching away from a user context to preserve
+     * its security state.
      *
      * @return an opaque snapshot of the current security context, or
      *         {@code null} if no security context is active
@@ -54,11 +55,12 @@ public interface SecurityContextHandler<C> {
     Object saveContext();
 
     /**
-     * Restores a previously saved security context snapshot onto the
-     * current thread.
+     * Restores a previously saved security context snapshot onto the current
+     * thread.
      *
-     * @param snapshot a snapshot previously returned by {@link #saveContext()},
-     *                 or {@code null} to clear the context
+     * @param snapshot
+     *            a snapshot previously returned by {@link #saveContext()}, or
+     *            {@code null} to clear the context
      */
     void restoreContext(Object snapshot);
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -202,15 +202,30 @@ object MockVaadin {
     private fun closeCurrentSession() {
         val session: VaadinSession? = VaadinSession.getCurrent()
         if (session != null) {
-            val service: VaadinService = VaadinService.getCurrent()
-            service.fireSessionDestroy(session)
-            VaadinSession.setCurrent(null)
-            // service destroys session via session.access(); we need to run that action now.
-            currentlyClosingSession.set(true)
-            runUIQueue(session = session)
-            currentlyClosingSession.set(false)
+            fireSessionDestroyAndDrain(session)
         }
         strongRefSession.remove()
+    }
+
+    /**
+     * Fires session-destroy listeners on [session] and drains pending
+     * [VaadinSession.access] tasks scheduled during destruction. The
+     * `currentlyClosingSession` flag is set for the duration so the
+     * `afterSessionClose` recreation hook (used by single-user `setup`) is
+     * suppressed — multi-user callers manage their own session lifecycle.
+     */
+    @JvmStatic
+    public fun fireSessionDestroyAndDrain(session: VaadinSession) {
+        val service: VaadinService = session.service
+        service.fireSessionDestroy(session)
+        VaadinSession.setCurrent(null)
+        // service destroys session via session.access(); we need to run that action now.
+        currentlyClosingSession.set(true)
+        try {
+            runUIQueue(session = session)
+        } finally {
+            currentlyClosingSession.set(false)
+        }
     }
 
     private val currentlyClosingSession: ThreadLocal<Boolean> = object : ThreadLocal<Boolean>() {

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -289,6 +289,19 @@ object MockVaadin {
         createUI(uiFactory, objs.session)
     }
 
+    /**
+     * Creates a new [UI] for the given [session] using [uiFactory] and
+     * attaches it to the Vaadin thread-locals.
+     *
+     * The caller must have already installed the thread-locals for the
+     * target user ([VaadinService], [VaadinSession], [VaadinRequest],
+     * [VaadinResponse]) before calling this function; [VaadinRequest.getCurrent]
+     * must return a non-null request. If a route target is registered for the
+     * empty path `""`, the new UI will navigate to it.
+     *
+     * @param uiFactory factory that produces a fresh, unattached [UI]
+     * @param session the session that will own the new UI
+     */
     @JvmStatic
     fun createUI(uiFactory: UIFactory, session: VaadinSession) {
         val request: VaadinRequest = checkNotNull(VaadinRequest.getCurrent())
@@ -467,15 +480,6 @@ object MockVaadin {
         service.fireServiceDestroyListeners(ServiceDestroyEvent(service))
     }
 
-    /**
-     * Clears the current UI from thread-locals without firing detach events.
-     * Useful for multi-user context where UIs are managed independently.
-     */
-    @JvmStatic
-    fun clearCurrentUI() {
-        UI.setCurrent(null)
-        strongRefUI.remove()
-    }
 }
 
 private val _VaadinService_sessionInitListeners: Field by lazy(LazyThreadSafetyMode.PUBLICATION) {

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -50,6 +50,18 @@ import com.vaadin.browserless.mocks.createVaadinServletRequest
 import com.vaadin.browserless.mocks.createVaadinServletResponse
 import com.vaadin.browserless.mocks.serviceSafe
 
+/**
+ * Holds the objects created during session initialization, before they are
+ * installed as thread-locals. Used by [MockVaadin.createSessionObjects] to
+ * allow callers (e.g. multi-user context) to manage thread-locals themselves.
+ */
+data class SessionObjects(
+    val session: VaadinSession,
+    val request: VaadinRequest,
+    val response: VaadinResponse,
+    val httpSession: MockHttpSession
+)
+
 object MockVaadin {
     // prevent GC on Vaadin Session and Vaadin UI as they are only soft-referenced from the Vaadin itself.
     // use ThreadLocals so that multiple threads may initialize fresh Vaadin instances at the same time.
@@ -113,6 +125,24 @@ object MockVaadin {
     fun setup(uiFactory: UIFactory = UIFactory { MockedUI() }, servlet: VaadinServlet,
               lookupServices: Set<Class<*>> = emptySet()
     ) {
+        val service = setupServlet(servlet, lookupServices)
+        VaadinService.setCurrent(service)
+
+        // init Vaadin Session
+        createSession(servlet.servletContext, uiFactory)
+    }
+
+    /**
+     * Initializes the given [servlet] and its service, but does NOT create a
+     * session, UI, or set any thread-locals. Call this when you need to share
+     * a single service across multiple independent sessions (multi-user testing).
+     *
+     * @return the initialized [VaadinServletService]
+     */
+    @JvmStatic
+    fun setupServlet(servlet: VaadinServlet,
+                     lookupServices: Set<Class<*>> = emptySet()
+    ): VaadinServletService {
         if (!servlet.isInitialized) {
             val ctx: ServletContext = MockVaadinHelper.createMockContext(lookupServices)
             val config = MockServletConfig(ctx)
@@ -121,16 +151,14 @@ object MockVaadin {
         }
         val service: VaadinServletService = checkNotNull(servlet.serviceSafe)
         check(service.router != null) { "$servlet failed to call VaadinServletService.init() in createServletService()" }
-        VaadinService.setCurrent(service)
-
-        // init Vaadin Session
-        createSession(servlet.servletContext, uiFactory)
+        return service
     }
 
     /**
      * Properly closes the current UI and fire the detach event on it.
      * Does nothing if there is no current UI.
      */
+    @JvmStatic
     fun closeCurrentUI(fireUIDetach: Boolean) {
         val ui: UI = UI.getCurrent() ?: return
         lastNavigation.set(ui.internals.activeViewLocation)
@@ -202,50 +230,67 @@ object MockVaadin {
      */
     var mockRequestFactory: (MockHttpSession) -> MockRequest = { MockRequest(it) }
 
-    private fun createSession(ctx: ServletContext, uiFactory: UIFactory) {
-        val service: VaadinServletService = checkNotNull(VaadinService.getCurrent()) as VaadinServletService
-        val httpSession: MockHttpSession = MockHttpSession.create(ctx)
+    /**
+     * Creates a new session, request and response for the given [service],
+     * but does NOT set any thread-locals or create a UI.
+     *
+     * Use this when you need to create multiple independent sessions for
+     * multi-user testing. The caller is responsible for setting thread-locals
+     * (via [VaadinSession.setCurrent], [CurrentInstance], etc.) and for
+     * creating the UI via [createUI].
+     *
+     * @param service the initialized Vaadin service (from [setupServlet])
+     * @return the created session objects
+     */
+    @JvmStatic
+    fun createSessionObjects(service: VaadinServletService): SessionObjects {
+        val httpSession: MockHttpSession = MockHttpSession.create(service.servlet.servletContext)
 
         // init Vaadin Request
         val mockRequest = mockRequestFactory(httpSession)
-        // so that session.browser.updateRequestDetails() also creates browserDetails
         mockRequest.headers["User-Agent"] = listOf(userAgent)
         service.context.getAttribute(Lookup::class.java)
                 .lookup(MockRequestCustomizer::class.java)?.apply(mockRequest)
         val request = createVaadinServletRequest(mockRequest, service)
-        strongRefReq.set(request)
-        CurrentInstance.set(VaadinRequest::class.java, request)
 
         // init Session.
-        // Use the underlying Service to create the Vaadin Session; however
-        // you MUST mock certain things in order for browserless testing to work.
-        // See MockSession for more details. By default the service is a MockService
-        // which creates MockSession.
-        val session: VaadinSession = service._createVaadinSession(VaadinRequest.getCurrent())
+        val session: VaadinSession = service._createVaadinSession(request)
         httpSession.setAttribute(service.serviceName + ".lock", ReentrantLock().apply { lock() })
         httpSession.setAttribute(VaadinSession::class.java.name + "." + service.serviceName, session)
         session.refreshTransients(WrappedHttpSession(httpSession), service)
         check(session.lockInstance != null) { "$session created from $service has null lock. See the MockSession class on how to mock locks properly" }
         check((session.lockInstance as ReentrantLock).isLocked) { "$session created from $service: lock must be locked!" }
 
-        VaadinSession.setCurrent(session)
-        strongRefSession.set(session)
         session.browser = WebBrowser(request)
         checkNotNull(session.browser.browserApplication) { "The WebBrowser has not been mocked properly" }
 
         // init Vaadin Response
         val response = createVaadinServletResponse(MockResponse(), service)
-        strongRefRes.set(response)
-        CurrentInstance.set(VaadinResponse::class.java, response)
 
-        // fire session init listeners
-        service.fireSessionInitListeners(SessionInitEvent(service, session, request))
-
-        // create UI
-        createUI(uiFactory, session)
+        return SessionObjects(session, request, response, httpSession)
     }
 
-    internal fun createUI(uiFactory: UIFactory, session: VaadinSession) {
+    private fun createSession(ctx: ServletContext, uiFactory: UIFactory) {
+        val service: VaadinServletService = checkNotNull(VaadinService.getCurrent()) as VaadinServletService
+        val objs = createSessionObjects(service)
+
+        // install thread-locals
+        strongRefReq.set(objs.request)
+        CurrentInstance.set(VaadinRequest::class.java, objs.request)
+        VaadinSession.setCurrent(objs.session)
+        strongRefSession.set(objs.session)
+        strongRefRes.set(objs.response)
+        CurrentInstance.set(VaadinResponse::class.java, objs.response)
+
+        // fire session init listeners
+        service.fireSessionInitListeners(SessionInitEvent(service, objs.session, objs.request))
+
+        // create UI
+        createUI(uiFactory, objs.session)
+    }
+
+    @JvmStatic
+    fun createUI(uiFactory: UIFactory, session: VaadinSession) {
         val request: VaadinRequest = checkNotNull(VaadinRequest.getCurrent())
         val ui: UI = uiFactory()
         require(ui.session == null) {
@@ -403,6 +448,34 @@ object MockVaadin {
             createSession(mockSession.servletContext, uiFactory)
         }
     }
+
+    /**
+     * Fires session init listeners on the given service.
+     * Java-friendly static wrapper for the internal extension function.
+     */
+    @JvmStatic
+    fun fireSessionInit(service: VaadinService, session: VaadinSession, request: VaadinRequest) {
+        service.fireSessionInitListeners(SessionInitEvent(service, session, request))
+    }
+
+    /**
+     * Fires service destroy listeners on the given service.
+     * Java-friendly static wrapper for the internal extension function.
+     */
+    @JvmStatic
+    fun fireServiceDestroy(service: VaadinService) {
+        service.fireServiceDestroyListeners(ServiceDestroyEvent(service))
+    }
+
+    /**
+     * Clears the current UI from thread-locals without firing detach events.
+     * Useful for multi-user context where UIs are managed independently.
+     */
+    @JvmStatic
+    fun clearCurrentUI() {
+        UI.setCurrent(null)
+        strongRefUI.remove()
+    }
 }
 
 private val _VaadinService_sessionInitListeners: Field by lazy(LazyThreadSafetyMode.PUBLICATION) {
@@ -411,7 +484,7 @@ private val _VaadinService_sessionInitListeners: Field by lazy(LazyThreadSafetyM
     field
 }
 
-private fun VaadinService.fireSessionInitListeners(event: SessionInitEvent) {
+internal fun VaadinService.fireSessionInitListeners(event: SessionInitEvent) {
     @Suppress("UNCHECKED_CAST")
     val sessionInitListeners: Collection<SessionInitListener> =
             _VaadinService_sessionInitListeners.get(this) as Collection<SessionInitListener>
@@ -426,7 +499,7 @@ private val _VaadinService_sessionDestroyListeners: Field by lazy(LazyThreadSafe
     field
 }
 
-private fun VaadinService.fireServiceDestroyListeners(event: ServiceDestroyEvent) {
+internal fun VaadinService.fireServiceDestroyListeners(event: ServiceDestroyEvent) {
     @Suppress("UNCHECKED_CAST")
     val listeners: Collection<ServiceDestroyListener> =
             _VaadinService_sessionDestroyListeners.get(this) as Collection<ServiceDestroyListener>
@@ -435,13 +508,43 @@ private fun VaadinService.fireServiceDestroyListeners(event: ServiceDestroyEvent
     }
 }
 
-private class MockPage(ui: UI, private val uiFactory: UIFactory, private val session: VaadinSession) : Page(ui) {
+internal class MockPage(ui: UI, private val uiFactory: UIFactory, private val session: VaadinSession) : Page(ui) {
+
+    private companion object {
+        private val SELF_NAMES = setOf("_self", "_parent", "_top", "")
+    }
+
+    private val navigations: MutableMap<String, MutableList<String>> = mutableMapOf()
+
+    val lastExternalNavigationURL: String?
+        get() = navigations["_self"]?.lastOrNull()
+
+    fun getExternalNavigationURL(windowName: String): String? =
+        navigations[normalizeWindowName(windowName)]?.lastOrNull()
+
+    val openedWindows: Map<String, List<String>>
+        get() = navigations.filterKeys { it != "_self" }
+            .mapValues { (_, urls) -> urls.toList() }
+
+    override fun open(url: String, windowName: String) {
+        val normalized = normalizeWindowName(windowName)
+        if (normalized == "_blank") {
+            navigations.getOrPut(normalized) { mutableListOf() }.add(url)
+        } else {
+            navigations[normalized] = mutableListOf(url)
+        }
+        super.open(url, windowName)
+    }
+
     override fun reload() {
         // recreate the UI on reload(), to simulate browser's F5
         super.reload()
         MockVaadin.closeCurrentUI(true)
         MockVaadin.createUI(uiFactory, session)
     }
+
+    private fun normalizeWindowName(windowName: String?): String =
+        if (windowName == null || windowName in SELF_NAMES) "_self" else windowName
 }
 
 fun interface MockRequestCustomizer {

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -304,19 +304,6 @@ object MockVaadin {
         createUI(uiFactory, objs.session)
     }
 
-    /**
-     * Creates a new [UI] for the given [session] using [uiFactory] and
-     * attaches it to the Vaadin thread-locals.
-     *
-     * The caller must have already installed the thread-locals for the
-     * target user ([VaadinService], [VaadinSession], [VaadinRequest],
-     * [VaadinResponse]) before calling this function; [VaadinRequest.getCurrent]
-     * must return a non-null request. If a route target is registered for the
-     * empty path `""`, the new UI will navigate to it.
-     *
-     * @param uiFactory factory that produces a fresh, unattached [UI]
-     * @param session the session that will own the new UI
-     */
     @JvmStatic
     fun createUI(uiFactory: UIFactory, session: VaadinSession) {
         val request: VaadinRequest = checkNotNull(VaadinRequest.getCurrent())
@@ -495,6 +482,15 @@ object MockVaadin {
         service.fireServiceDestroyListeners(ServiceDestroyEvent(service))
     }
 
+    /**
+     * Clears the current UI from thread-locals without firing detach events.
+     * Useful for multi-user context where UIs are managed independently.
+     */
+    @JvmStatic
+    fun clearCurrentUI() {
+        UI.setCurrent(null)
+        strongRefUI.remove()
+    }
 }
 
 private val _VaadinService_sessionInitListeners: Field by lazy(LazyThreadSafetyMode.PUBLICATION) {

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
@@ -175,6 +175,14 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
     var isUserInRole: (Principal, role: String) -> Boolean = { _, _ -> false }
 
     /**
+     * Sets the user-in-role checker using a [java.util.function.BiPredicate].
+     * Java-friendly alternative to setting [isUserInRole] directly.
+     */
+    fun roleChecker(checker: java.util.function.BiPredicate<Principal, String>) {
+        isUserInRole = { principal, role -> checker.test(principal, role) }
+    }
+
+    /**
      * Set [isUserInRole] to modify the outcome of this function.
      */
     override fun isUserInRole(role: String): Boolean {
@@ -222,6 +230,14 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
      * call time (e.g. from a security context that is populated after setup).
      */
     var userPrincipalProvider: (() -> Principal?)? = null
+
+    /**
+     * Sets the user principal provider using a [java.util.function.Supplier].
+     * Java-friendly alternative to setting [userPrincipalProvider] directly.
+     */
+    fun principalProvider(supplier: java.util.function.Supplier<Principal?>) {
+        userPrincipalProvider = { supplier.get() }
+    }
 
     /**
      * Returns the principal from [userPrincipalProvider] if set, otherwise

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
@@ -228,12 +228,15 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
      * Optional provider for [getUserPrincipal]. When set, takes precedence over
      * [userPrincipalInt], allowing the principal to be resolved lazily at
      * call time (e.g. from a security context that is populated after setup).
+     * Set via [principalProvider].
      */
     var userPrincipalProvider: (() -> Principal?)? = null
+        private set
 
     /**
-     * Sets the user principal provider using a [java.util.function.Supplier].
-     * Java-friendly alternative to setting [userPrincipalProvider] directly.
+     * Sets the user principal provider. Accepts a [java.util.function.Supplier]
+     * so Java callers can pass a lambda directly; Kotlin callers can do the
+     * same via SAM conversion.
      */
     fun principalProvider(supplier: java.util.function.Supplier<Principal?>) {
         userPrincipalProvider = { supplier.get() }

--- a/shared/src/test/java/com/vaadin/browserless/BuilderCloseHookTest.java
+++ b/shared/src/test/java/com/vaadin/browserless/BuilderCloseHookTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Contract tests for
+ * {@link BrowserlessApplicationContext.Builder#withCloseHook} and the
+ * hook-invocation behaviour of {@link BrowserlessApplicationContext#close()}.
+ */
+class BuilderCloseHookTest {
+
+    private static Routes emptyRoutes() {
+        return new Routes(new HashSet<>(), new HashSet<>(), new HashSet<>(),
+                true);
+    }
+
+    @Test
+    void hooksRunInRegistrationOrderOnClose() {
+        List<String> log = new ArrayList<>();
+        var app = BrowserlessApplicationContext.<Void> builder(emptyRoutes())
+                .withCloseHook(() -> log.add("a"))
+                .withCloseHook(() -> log.add("b"))
+                .withCloseHook(() -> log.add("c")).build();
+
+        app.close();
+
+        Assertions.assertEquals(List.of("a", "b", "c"), log,
+                "hooks must run in registration order");
+    }
+
+    @Test
+    void hooksFireExactlyOnceAcrossRedundantCloseCalls() {
+        AtomicInteger calls = new AtomicInteger();
+        var app = BrowserlessApplicationContext.<Void> builder(emptyRoutes())
+                .withCloseHook(calls::incrementAndGet).build();
+
+        app.close();
+        app.close();
+        app.close();
+
+        Assertions.assertEquals(1, calls.get(),
+                "redundant close() calls must not re-run hooks");
+    }
+
+    @Test
+    void allHooksRunEvenIfSomeThrow() {
+        List<String> log = new ArrayList<>();
+        var app = BrowserlessApplicationContext.<Void> builder(emptyRoutes())
+                .withCloseHook(() -> log.add("a")).withCloseHook(() -> {
+                    log.add("b-throws");
+                    throw new IllegalStateException("boom-b");
+                }).withCloseHook(() -> log.add("c")).withCloseHook(() -> {
+                    log.add("d-throws");
+                    throw new IllegalArgumentException("boom-d");
+                }).build();
+
+        var ex = Assertions.assertThrows(RuntimeException.class, app::close);
+
+        Assertions.assertEquals(List.of("a", "b-throws", "c", "d-throws"), log,
+                "a throwing hook must not prevent subsequent hooks from"
+                        + " running");
+        Throwable[] suppressed = ex.getSuppressed();
+        Assertions.assertEquals(2, suppressed.length,
+                "aggregate exception must collect all hook failures as"
+                        + " suppressed");
+        Assertions.assertInstanceOf(IllegalStateException.class, suppressed[0]);
+        Assertions.assertEquals("boom-b", suppressed[0].getMessage());
+        Assertions.assertInstanceOf(IllegalArgumentException.class,
+                suppressed[1]);
+        Assertions.assertEquals("boom-d", suppressed[1].getMessage());
+    }
+
+    @Test
+    void singleThrowingHookSurfacesAsAggregateWithOneSuppressed() {
+        var cause = new IllegalStateException("solo-boom");
+        var app = BrowserlessApplicationContext.<Void> builder(emptyRoutes())
+                .withCloseHook(() -> {
+                    throw cause;
+                }).build();
+
+        var ex = Assertions.assertThrows(RuntimeException.class, app::close);
+
+        Assertions.assertArrayEquals(new Throwable[] { cause },
+                ex.getSuppressed(),
+                "single hook failure must still surface via suppressed");
+    }
+
+    @Test
+    void closeWithoutHooksDoesNotThrow() {
+        try (var app = BrowserlessApplicationContext
+                .<Void> builder(emptyRoutes()).build()) {
+            // try-with-resources triggers close(); just asserting no throw
+        }
+    }
+
+    @Test
+    void withCloseHook_nullThrows() {
+        var builder = BrowserlessApplicationContext
+                .<Void> builder(emptyRoutes());
+        Assertions.assertThrows(NullPointerException.class,
+                () -> builder.withCloseHook(null));
+    }
+}

--- a/shared/src/test/java/com/vaadin/browserless/BuilderLookupServicesTest.java
+++ b/shared/src/test/java/com/vaadin/browserless/BuilderLookupServicesTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BuilderLookupServicesTest {
+
+    private static class ServiceA {
+    }
+
+    private static class ServiceB {
+    }
+
+    private static class ServiceC {
+    }
+
+    private BrowserlessApplicationContext.Builder<Void> newBuilder() {
+        Routes routes = new Routes(new HashSet<>(), new HashSet<>(),
+                new HashSet<>(), true);
+        return BrowserlessApplicationContext.builder(routes);
+    }
+
+    @Test
+    void successiveCallsAccumulate() {
+        var builder = newBuilder().withLookupServices(ServiceA.class)
+                .withLookupServices(ServiceB.class, ServiceC.class);
+        assertEquals(List.of(ServiceA.class, ServiceB.class, ServiceC.class),
+                List.copyOf(builder.getLookupServices()));
+    }
+
+    @Test
+    void noArgsIsNoOp() {
+        var builder = newBuilder().withLookupServices(ServiceA.class)
+                .withLookupServices();
+        assertEquals(Set.of(ServiceA.class), builder.getLookupServices());
+    }
+
+    @Test
+    void duplicatesAreDeduplicated() {
+        var builder = newBuilder().withLookupServices(ServiceA.class)
+                .withLookupServices(ServiceA.class, ServiceB.class);
+        assertEquals(Set.of(ServiceA.class, ServiceB.class),
+                builder.getLookupServices());
+    }
+
+    @Test
+    void nullArrayThrows() {
+        var builder = newBuilder();
+        assertThrows(NullPointerException.class,
+                () -> builder.withLookupServices((Class<?>[]) null));
+    }
+
+    @Test
+    void nullElementThrows() {
+        var builder = newBuilder();
+        assertThrows(NullPointerException.class, () -> builder
+                .withLookupServices(ServiceA.class, null, ServiceB.class));
+    }
+}

--- a/shared/src/test/java/com/vaadin/browserless/BuilderLookupServicesTest.java
+++ b/shared/src/test/java/com/vaadin/browserless/BuilderLookupServicesTest.java
@@ -37,7 +37,7 @@ class BuilderLookupServicesTest {
     private static class ServiceC {
     }
 
-    private BrowserlessApplicationContext.Builder<Void> newBuilder() {
+    private BrowserlessApplicationContext.Builder newBuilder() {
         Routes routes = new Routes(new HashSet<>(), new HashSet<>(),
                 new HashSet<>(), true);
         return BrowserlessApplicationContext.builder(routes);

--- a/shared/src/test/java/com/vaadin/browserless/BuilderSecurityContextHandlerTest.java
+++ b/shared/src/test/java/com/vaadin/browserless/BuilderSecurityContextHandlerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Contract tests for the security-handler-related entry points on
+ * {@link BrowserlessApplicationContext} and its
+ * {@link BrowserlessApplicationContext.Builder}: the {@code newUser(username,
+ * roles...)} helper's failure modes and the builder's null-reset behaviour.
+ */
+class BuilderSecurityContextHandlerTest {
+
+    private static Routes emptyRoutes() {
+        return new Routes(new HashSet<>(), new HashSet<>(), new HashSet<>(),
+                true);
+    }
+
+    @Test
+    void withSecurityContextHandler_acceptsNullToReset() {
+        try (var app = BrowserlessApplicationContext
+                .<String> builder(emptyRoutes())
+                .withSecurityContextHandler(new MinimalHandler())
+                .withSecurityContextHandler(null).build()) {
+            Assertions.assertNull(app.getSecurityContextHandler(),
+                    "withSecurityContextHandler(null) must reset the"
+                            + " previously configured handler");
+        }
+    }
+
+    @Test
+    void newUserByUsernameAndRoles_throwsISE_whenNoHandlerConfigured() {
+        try (var app = BrowserlessApplicationContext
+                .<Void> builder(emptyRoutes()).build()) {
+            var ex = Assertions.assertThrows(IllegalStateException.class,
+                    () -> app.newUser("foo", "BAR"));
+            Assertions.assertTrue(
+                    ex.getMessage().contains("SecurityContextHandler"),
+                    "ISE message should mention SecurityContextHandler");
+        }
+    }
+
+    @Test
+    void newUserByUsernameAndRoles_throwsUOE_whenHandlerDoesNotOverrideCreateCredentials() {
+        try (var app = BrowserlessApplicationContext
+                .<String> builder(emptyRoutes())
+                .withSecurityContextHandler(new MinimalHandler()).build()) {
+            var ex = Assertions.assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> app.newUser("foo", "BAR"));
+            Assertions.assertTrue(ex.getMessage().contains("createCredentials"),
+                    "UOE message should reference createCredentials");
+        }
+    }
+
+    /**
+     * Bare-bones handler that does not override
+     * {@link SecurityContextHandler#createCredentials(String, String...)}, so
+     * the default UOE-throwing implementation kicks in.
+     */
+    private static class MinimalHandler
+            implements SecurityContextHandler<String> {
+        @Override
+        public void setupAuthentication(String credentials) {
+        }
+
+        @Override
+        public Object saveContext() {
+            return null;
+        }
+
+        @Override
+        public void restoreContext(Object snapshot) {
+        }
+
+        @Override
+        public void clearContext() {
+        }
+    }
+}

--- a/shared/src/test/java/com/vaadin/browserless/BuilderSecurityContextHandlerTest.java
+++ b/shared/src/test/java/com/vaadin/browserless/BuilderSecurityContextHandlerTest.java
@@ -24,9 +24,11 @@ import com.vaadin.browserless.internal.Routes;
 
 /**
  * Contract tests for the security-handler-related entry points on
- * {@link BrowserlessApplicationContext} and its
- * {@link BrowserlessApplicationContext.Builder}: the {@code newUser(username,
- * roles...)} helper's failure modes and the builder's null-reset behaviour.
+ * {@link BrowserlessApplicationContext.Builder} and
+ * {@link SecuredBrowserlessApplicationContext}: the
+ * {@code withSecurityContextHandler} null contract and the
+ * {@code newUser(username, roles...)} helper's failure mode for handlers that
+ * do not override {@code createCredentials}.
  */
 class BuilderSecurityContextHandlerTest {
 
@@ -36,33 +38,23 @@ class BuilderSecurityContextHandlerTest {
     }
 
     @Test
-    void withSecurityContextHandler_acceptsNullToReset() {
-        try (var app = BrowserlessApplicationContext
-                .<String> builder(emptyRoutes())
-                .withSecurityContextHandler(new MinimalHandler())
-                .withSecurityContextHandler(null).build()) {
-            Assertions.assertNull(app.getSecurityContextHandler(),
-                    "withSecurityContextHandler(null) must reset the"
-                            + " previously configured handler");
-        }
+    void withSecurityContextHandler_rejectsNull() {
+        var builder = BrowserlessApplicationContext.builder(emptyRoutes());
+        Assertions.assertThrows(NullPointerException.class,
+                () -> builder.withSecurityContextHandler(null));
     }
 
     @Test
-    void newUserByUsernameAndRoles_throwsISE_whenNoHandlerConfigured() {
-        try (var app = BrowserlessApplicationContext
-                .<Void> builder(emptyRoutes()).build()) {
-            var ex = Assertions.assertThrows(IllegalStateException.class,
-                    () -> app.newUser("foo", "BAR"));
-            Assertions.assertTrue(
-                    ex.getMessage().contains("SecurityContextHandler"),
-                    "ISE message should mention SecurityContextHandler");
-        }
+    void securedBuilder_withSecurityContextHandler_rejectsNull() {
+        var secured = BrowserlessApplicationContext.builder(emptyRoutes())
+                .withSecurityContextHandler(new MinimalHandler());
+        Assertions.assertThrows(NullPointerException.class,
+                () -> secured.withSecurityContextHandler(null));
     }
 
     @Test
     void newUserByUsernameAndRoles_throwsUOE_whenHandlerDoesNotOverrideCreateCredentials() {
-        try (var app = BrowserlessApplicationContext
-                .<String> builder(emptyRoutes())
+        try (var app = BrowserlessApplicationContext.builder(emptyRoutes())
                 .withSecurityContextHandler(new MinimalHandler()).build()) {
             var ex = Assertions.assertThrows(
                     UnsupportedOperationException.class,

--- a/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -89,11 +89,12 @@ public class BrowserlessTestSpringLookupInitializer
     /**
      * Sets the application context to be used by the lookup initializer.
      * <p>
-     * This is used by {@code SpringBrowserlessApplicationContext} to
-     * configure the Spring context for multi-user testing without relying
-     * on the {@link TestExecutionListener} lifecycle.
+     * This is used by {@code SpringBrowserlessApplicationContext} to configure
+     * the Spring context for multi-user testing without relying on the
+     * {@link TestExecutionListener} lifecycle.
      *
-     * @param appCtx the Spring application context
+     * @param appCtx
+     *            the Spring application context
      */
     public static void setApplicationContext(ApplicationContext appCtx) {
         applicationContext.set(appCtx);

--- a/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -71,19 +71,9 @@ public class BrowserlessTestSpringLookupInitializer
     }
 
     private void setApplicationContext(TestContext testContext) {
-        BrowserlessTestSpringLookupInitializer.applicationContext
-                .set(testContext.getApplicationContext());
         ApplicationContext appCtx = testContext.getApplicationContext();
-        // Register a MockRequestCustomizer bean so that request will have
-        // access to authentication details from Spring Security
-        if (appCtx instanceof ConfigurableApplicationContext
-                && !appCtx.containsBean(
-                        SpringSecurityRequestCustomizer.class.getName())) {
-            ((ConfigurableApplicationContext) appCtx).getBeanFactory()
-                    .registerSingleton(
-                            SpringSecurityRequestCustomizer.class.getName(),
-                            new SpringSecurityRequestCustomizer());
-        }
+        BrowserlessTestSpringLookupInitializer.applicationContext.set(appCtx);
+        registerSpringSecurityRequestCustomizerIfNeeded(appCtx);
     }
 
     /**
@@ -98,7 +88,17 @@ public class BrowserlessTestSpringLookupInitializer
      */
     public static void setApplicationContext(ApplicationContext appCtx) {
         applicationContext.set(appCtx);
-        if (appCtx instanceof ConfigurableApplicationContext
+        registerSpringSecurityRequestCustomizerIfNeeded(appCtx);
+    }
+
+    private static void registerSpringSecurityRequestCustomizerIfNeeded(
+            ApplicationContext appCtx) {
+        // Register a MockRequestCustomizer bean so that the request has access
+        // to authentication details from Spring Security. Skip when Spring
+        // Security is not on the classpath: the customizer would be a no-op,
+        // and advertising it as a bean is misleading.
+        if (SpringSecuritySupport.isPresent()
+                && appCtx instanceof ConfigurableApplicationContext
                 && !appCtx.containsBean(
                         SpringSecurityRequestCustomizer.class.getName())) {
             ((ConfigurableApplicationContext) appCtx).getBeanFactory()

--- a/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -86,6 +86,27 @@ public class BrowserlessTestSpringLookupInitializer
         }
     }
 
+    /**
+     * Sets the application context to be used by the lookup initializer.
+     * <p>
+     * This is used by {@code SpringBrowserlessApplicationContext} to
+     * configure the Spring context for multi-user testing without relying
+     * on the {@link TestExecutionListener} lifecycle.
+     *
+     * @param appCtx the Spring application context
+     */
+    public static void setApplicationContext(ApplicationContext appCtx) {
+        applicationContext.set(appCtx);
+        if (appCtx instanceof ConfigurableApplicationContext
+                && !appCtx.containsBean(
+                        SpringSecurityRequestCustomizer.class.getName())) {
+            ((ConfigurableApplicationContext) appCtx).getBeanFactory()
+                    .registerSingleton(
+                            SpringSecurityRequestCustomizer.class.getName(),
+                            new SpringSecurityRequestCustomizer());
+        }
+    }
+
     @Override
     public void initialize(VaadinContext context,
             Map<Class<?>, Collection<Class<?>>> services,

--- a/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -67,7 +67,7 @@ public class BrowserlessTestSpringLookupInitializer
 
     @Override
     public void afterTestMethod(TestContext testContext) throws Exception {
-        BrowserlessTestSpringLookupInitializer.applicationContext.remove();
+        clearApplicationContext();
     }
 
     private void setApplicationContext(TestContext testContext) {
@@ -89,6 +89,28 @@ public class BrowserlessTestSpringLookupInitializer
     public static void setApplicationContext(ApplicationContext appCtx) {
         applicationContext.set(appCtx);
         registerSpringSecurityRequestCustomizerIfNeeded(appCtx);
+    }
+
+    /**
+     * Clears the application context for the current thread.
+     * <p>
+     * Companion to {@link #setApplicationContext(ApplicationContext)} used by
+     * {@code SpringBrowserlessApplicationContext} to release the ThreadLocal
+     * when an application context is closed outside the
+     * {@link TestExecutionListener} lifecycle.
+     */
+    public static void clearApplicationContext() {
+        applicationContext.remove();
+    }
+
+    /**
+     * Returns the application context currently registered for this thread, or
+     * {@code null} if none is set.
+     *
+     * @return the registered application context, or {@code null}
+     */
+    public static ApplicationContext getApplicationContext() {
+        return applicationContext.get();
     }
 
     private static void registerSpringSecurityRequestCustomizerIfNeeded(

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -30,8 +30,8 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  * Factory for creating a Spring-integrated
  * {@link BrowserlessApplicationContext}.
  * <p>
- * Configures the context with Spring-aware servlet, security context
- * handling, and lookup services.
+ * Configures the context with Spring-aware servlet, security context handling,
+ * and lookup services.
  *
  * <pre>
  * var app = SpringBrowserlessApplicationContext.create(routes, springCtx);
@@ -51,8 +51,10 @@ public final class SpringBrowserlessApplicationContext {
     /**
      * Creates a Spring-integrated application context.
      *
-     * @param routes the discovered routes
-     * @param applicationContext the Spring application context
+     * @param routes
+     *            the discovered routes
+     * @param applicationContext
+     *            the Spring application context
      * @return a new application context configured for Spring
      */
     public static BrowserlessApplicationContext<Authentication> create(
@@ -61,12 +63,14 @@ public final class SpringBrowserlessApplicationContext {
     }
 
     /**
-     * Creates a Spring-integrated application context with a custom UI
-     * factory.
+     * Creates a Spring-integrated application context with a custom UI factory.
      *
-     * @param routes the discovered routes
-     * @param applicationContext the Spring application context
-     * @param uiFactory the UI factory
+     * @param routes
+     *            the discovered routes
+     * @param applicationContext
+     *            the Spring application context
+     * @param uiFactory
+     *            the UI factory
      * @return a new application context configured for Spring
      */
     public static BrowserlessApplicationContext<Authentication> create(
@@ -76,16 +80,14 @@ public final class SpringBrowserlessApplicationContext {
         BrowserlessTestSpringLookupInitializer
                 .setApplicationContext(applicationContext);
 
-        return BrowserlessApplicationContext
-                .<Authentication>builder(routes)
+        return BrowserlessApplicationContext.<Authentication> builder(routes)
                 .withServletFactory(r -> new MockSpringServlet(r,
                         applicationContext, uiFactory))
                 .withUIFactory(uiFactory)
-                .withLookupServices(Set.of(
-                        BrowserlessTestSpringLookupInitializer.class,
-                        SpringSecurityRequestCustomizer.class))
-                .withSecurityContextHandler(
-                        new SpringSecurityContextHandler())
+                .withLookupServices(
+                        Set.of(BrowserlessTestSpringLookupInitializer.class,
+                                SpringSecurityRequestCustomizer.class))
+                .withSecurityContextHandler(new SpringSecurityContextHandler())
                 .build();
     }
 }

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -78,14 +78,17 @@ public final class SpringBrowserlessApplicationContext {
         BrowserlessTestSpringLookupInitializer
                 .setApplicationContext(applicationContext);
 
-        return BrowserlessApplicationContext.<Authentication> builder(routes)
+        BrowserlessApplicationContext.Builder<Authentication> builder = BrowserlessApplicationContext
+                .<Authentication> builder(routes)
                 .withServletFactory(r -> new MockSpringServlet(r,
                         applicationContext, uiFactory))
-                .withUIFactory(uiFactory)
-                .withLookupServices(
-                        BrowserlessTestSpringLookupInitializer.class,
-                        SpringSecurityRequestCustomizer.class)
-                .withSecurityContextHandler(new SpringSecurityContextHandler())
-                .build();
+                .withUIFactory(uiFactory).withLookupServices(
+                        BrowserlessTestSpringLookupInitializer.class);
+        if (SpringSecuritySupport.isPresent()) {
+            builder.withLookupServices(SpringSecurityRequestCustomizer.class)
+                    .withSecurityContextHandler(
+                            new SpringSecurityContextHandler());
+        }
+        return builder.build();
     }
 }

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.browserless;
 
-import java.util.Set;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.core.Authentication;
 
@@ -85,8 +83,8 @@ public final class SpringBrowserlessApplicationContext {
                         applicationContext, uiFactory))
                 .withUIFactory(uiFactory)
                 .withLookupServices(
-                        Set.of(BrowserlessTestSpringLookupInitializer.class,
-                                SpringSecurityRequestCustomizer.class))
+                        BrowserlessTestSpringLookupInitializer.class,
+                        SpringSecurityRequestCustomizer.class)
                 .withSecurityContextHandler(new SpringSecurityContextHandler())
                 .build();
     }

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Set;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.core.Authentication;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.internal.UIFactory;
+import com.vaadin.browserless.mocks.MockSpringServlet;
+import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
+
+/**
+ * Factory for creating a Spring-integrated
+ * {@link BrowserlessApplicationContext}.
+ * <p>
+ * Configures the context with Spring-aware servlet, security context
+ * handling, and lookup services.
+ *
+ * <pre>
+ * var app = SpringBrowserlessApplicationContext.create(routes, springCtx);
+ * var admin = app.newUser(adminAuth);
+ * var window = admin.newWindow();
+ * window.navigate(ProtectedView.class);
+ * </pre>
+ *
+ * @see BrowserlessApplicationContext
+ * @see SpringSecurityContextHandler
+ */
+public final class SpringBrowserlessApplicationContext {
+
+    private SpringBrowserlessApplicationContext() {
+    }
+
+    /**
+     * Creates a Spring-integrated application context.
+     *
+     * @param routes the discovered routes
+     * @param applicationContext the Spring application context
+     * @return a new application context configured for Spring
+     */
+    public static BrowserlessApplicationContext<Authentication> create(
+            Routes routes, ApplicationContext applicationContext) {
+        return create(routes, applicationContext, () -> new MockedUI());
+    }
+
+    /**
+     * Creates a Spring-integrated application context with a custom UI
+     * factory.
+     *
+     * @param routes the discovered routes
+     * @param applicationContext the Spring application context
+     * @param uiFactory the UI factory
+     * @return a new application context configured for Spring
+     */
+    public static BrowserlessApplicationContext<Authentication> create(
+            Routes routes, ApplicationContext applicationContext,
+            UIFactory uiFactory) {
+        // Set the Spring application context for the lookup initializer
+        BrowserlessTestSpringLookupInitializer
+                .setApplicationContext(applicationContext);
+
+        return BrowserlessApplicationContext
+                .<Authentication>builder(routes)
+                .withServletFactory(r -> new MockSpringServlet(r,
+                        applicationContext, uiFactory))
+                .withUIFactory(uiFactory)
+                .withLookupServices(Set.of(
+                        BrowserlessTestSpringLookupInitializer.class,
+                        SpringSecurityRequestCustomizer.class))
+                .withSecurityContextHandler(
+                        new SpringSecurityContextHandler())
+                .build();
+    }
+}

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -80,8 +80,8 @@ public final class SpringBrowserlessApplicationContext {
 
         BrowserlessApplicationContext.Builder<Authentication> builder = BrowserlessApplicationContext
                 .<Authentication> builder(routes)
-                .withServletFactory(r -> new MockSpringServlet(r,
-                        applicationContext, uiFactory))
+                .withServletFactory((r, uif) -> new MockSpringServlet(r,
+                        applicationContext, uif))
                 .withUIFactory(uiFactory).withLookupServices(
                         BrowserlessTestSpringLookupInitializer.class);
         if (SpringSecuritySupport.isPresent()) {

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -33,7 +33,7 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  *
  * <pre>
  * var app = SpringBrowserlessApplicationContext.create(routes, springCtx);
- * var admin = app.newUser(adminAuth);
+ * var admin = app.newUser("admin", "ADMIN");
  * var window = admin.newWindow();
  * window.navigate(ProtectedView.class);
  * </pre>

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -82,8 +82,11 @@ public final class SpringBrowserlessApplicationContext {
                 .<Authentication> builder(routes)
                 .withServletFactory((r, uif) -> new MockSpringServlet(r,
                         applicationContext, uif))
-                .withUIFactory(uiFactory).withLookupServices(
-                        BrowserlessTestSpringLookupInitializer.class);
+                .withUIFactory(uiFactory)
+                .withLookupServices(
+                        BrowserlessTestSpringLookupInitializer.class)
+                .withCloseHook(
+                        BrowserlessTestSpringLookupInitializer::clearApplicationContext);
         if (SpringSecuritySupport.isPresent()) {
             builder.withLookupServices(SpringSecurityRequestCustomizer.class)
                     .withSecurityContextHandler(

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessApplicationContext.java
@@ -28,17 +28,30 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  * Factory for creating a Spring-integrated
  * {@link BrowserlessApplicationContext}.
  * <p>
- * Configures the context with Spring-aware servlet, security context handling,
- * and lookup services.
+ * Wires a Spring-aware servlet and the
+ * {@link BrowserlessTestSpringLookupInitializer} so the test context can reach
+ * Spring beans and lifecycle. Three entry points are provided:
+ * <ul>
+ * <li>{@link #create(Routes, ApplicationContext)} — returns the unsecured
+ * {@link BrowserlessApplicationContext}.</li>
+ * <li>{@link #createSecured(Routes, ApplicationContext)} — returns the
+ * credential-typed {@link SecuredBrowserlessApplicationContext}; requires
+ * Spring Security on the classpath.</li>
+ * <li>{@link #builder(Routes, ApplicationContext)} — returns a pre-wired
+ * {@link BrowserlessApplicationContext.Builder} for full customization (e.g.
+ * plugging in a different security handler).</li>
+ * </ul>
  *
  * <pre>
- * var app = SpringBrowserlessApplicationContext.create(routes, springCtx);
+ * var app = SpringBrowserlessApplicationContext.createSecured(routes,
+ *         springCtx);
  * var admin = app.newUser("admin", "ADMIN");
  * var window = admin.newWindow();
  * window.navigate(ProtectedView.class);
  * </pre>
  *
  * @see BrowserlessApplicationContext
+ * @see SecuredBrowserlessApplicationContext
  * @see SpringSecurityContextHandler
  */
 public final class SpringBrowserlessApplicationContext {
@@ -47,21 +60,24 @@ public final class SpringBrowserlessApplicationContext {
     }
 
     /**
-     * Creates a Spring-integrated application context.
+     * Creates a Spring-pre-wired builder. The builder has the Spring servlet,
+     * the lookup initializer and the lookup-initializer close hook configured;
+     * callers can chain additional customizations before calling
+     * {@link BrowserlessApplicationContext.Builder#build()}.
      *
      * @param routes
      *            the discovered routes
      * @param applicationContext
      *            the Spring application context
-     * @return a new application context configured for Spring
+     * @return a pre-wired builder
      */
-    public static BrowserlessApplicationContext<Authentication> create(
-            Routes routes, ApplicationContext applicationContext) {
-        return create(routes, applicationContext, () -> new MockedUI());
+    public static BrowserlessApplicationContext.Builder builder(Routes routes,
+            ApplicationContext applicationContext) {
+        return builder(routes, applicationContext, () -> new MockedUI());
     }
 
     /**
-     * Creates a Spring-integrated application context with a custom UI factory.
+     * Creates a Spring-pre-wired builder with a custom UI factory.
      *
      * @param routes
      *            the discovered routes
@@ -69,17 +85,14 @@ public final class SpringBrowserlessApplicationContext {
      *            the Spring application context
      * @param uiFactory
      *            the UI factory
-     * @return a new application context configured for Spring
+     * @return a pre-wired builder
      */
-    public static BrowserlessApplicationContext<Authentication> create(
-            Routes routes, ApplicationContext applicationContext,
-            UIFactory uiFactory) {
-        // Set the Spring application context for the lookup initializer
+    public static BrowserlessApplicationContext.Builder builder(Routes routes,
+            ApplicationContext applicationContext, UIFactory uiFactory) {
         BrowserlessTestSpringLookupInitializer
                 .setApplicationContext(applicationContext);
-
-        BrowserlessApplicationContext.Builder<Authentication> builder = BrowserlessApplicationContext
-                .<Authentication> builder(routes)
+        BrowserlessApplicationContext.Builder builder = BrowserlessApplicationContext
+                .builder(routes)
                 .withServletFactory((r, uif) -> new MockSpringServlet(r,
                         applicationContext, uif))
                 .withUIFactory(uiFactory)
@@ -88,10 +101,88 @@ public final class SpringBrowserlessApplicationContext {
                 .withCloseHook(
                         BrowserlessTestSpringLookupInitializer::clearApplicationContext);
         if (SpringSecuritySupport.isPresent()) {
-            builder.withLookupServices(SpringSecurityRequestCustomizer.class)
-                    .withSecurityContextHandler(
-                            new SpringSecurityContextHandler());
+            // Register the security-aware request customizer when Spring
+            // Security is on the classpath. It is a no-op when no
+            // authentication is set, so it is safe (and consistent with the
+            // pre-split factory) to wire it on the unsecured path too.
+            builder.withLookupServices(SpringSecurityRequestCustomizer.class);
         }
-        return builder.build();
+        return builder;
+    }
+
+    /**
+     * Creates an unsecured Spring-integrated application context.
+     *
+     * @param routes
+     *            the discovered routes
+     * @param applicationContext
+     *            the Spring application context
+     * @return a new unsecured application context configured for Spring
+     */
+    public static BrowserlessApplicationContext create(Routes routes,
+            ApplicationContext applicationContext) {
+        return builder(routes, applicationContext).build();
+    }
+
+    /**
+     * Creates an unsecured Spring-integrated application context with a custom
+     * UI factory.
+     *
+     * @param routes
+     *            the discovered routes
+     * @param applicationContext
+     *            the Spring application context
+     * @param uiFactory
+     *            the UI factory
+     * @return a new unsecured application context configured for Spring
+     */
+    public static BrowserlessApplicationContext create(Routes routes,
+            ApplicationContext applicationContext, UIFactory uiFactory) {
+        return builder(routes, applicationContext, uiFactory).build();
+    }
+
+    /**
+     * Creates a Spring-integrated application context with Spring Security
+     * wiring. Requires Spring Security on the classpath; throws otherwise.
+     *
+     * @param routes
+     *            the discovered routes
+     * @param applicationContext
+     *            the Spring application context
+     * @return a new secured application context configured for Spring Security
+     * @throws IllegalStateException
+     *             if Spring Security is not on the classpath
+     */
+    public static SecuredBrowserlessApplicationContext<Authentication> createSecured(
+            Routes routes, ApplicationContext applicationContext) {
+        return createSecured(routes, applicationContext, () -> new MockedUI());
+    }
+
+    /**
+     * Creates a secured Spring-integrated application context with a custom UI
+     * factory. Requires Spring Security on the classpath; throws otherwise.
+     *
+     * @param routes
+     *            the discovered routes
+     * @param applicationContext
+     *            the Spring application context
+     * @param uiFactory
+     *            the UI factory
+     * @return a new secured application context configured for Spring Security
+     * @throws IllegalStateException
+     *             if Spring Security is not on the classpath
+     */
+    public static SecuredBrowserlessApplicationContext<Authentication> createSecured(
+            Routes routes, ApplicationContext applicationContext,
+            UIFactory uiFactory) {
+        if (!SpringSecuritySupport.isPresent()) {
+            throw new IllegalStateException(
+                    "SpringBrowserlessApplicationContext.createSecured(...)"
+                            + " requires Spring Security on the classpath."
+                            + " Use create(...) for unsecured contexts.");
+        }
+        return builder(routes, applicationContext, uiFactory)
+                .withSecurityContextHandler(new SpringSecurityContextHandler())
+                .build();
     }
 }

--- a/spring/src/main/java/com/vaadin/browserless/SpringSecurityContextHandler.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringSecurityContextHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Spring Security implementation of {@link SecurityContextHandler}.
+ * <p>
+ * Manages the thread-local {@link SecurityContext} via
+ * {@link SecurityContextHolder} for multi-user test isolation.
+ * <p>
+ * The {@link #setupAuthentication(Object)} method expects an
+ * {@link Authentication} instance as the credentials parameter.
+ *
+ * @see SecurityContextHandler
+ * @see SpringBrowserlessApplicationContext
+ */
+public class SpringSecurityContextHandler
+        implements SecurityContextHandler<Authentication> {
+
+    @Override
+    public void setupAuthentication(Authentication credentials) {
+        if (credentials != null) {
+            SecurityContext ctx = SecurityContextHolder.getContext();
+            if (ctx == null) {
+                ctx = SecurityContextHolder.createEmptyContext();
+                SecurityContextHolder.setContext(ctx);
+            }
+            ctx.setAuthentication(credentials);
+        }
+    }
+
+    @Override
+    public Object saveContext() {
+        SecurityContext current = SecurityContextHolder.getContext();
+        SecurityContext copy = SecurityContextHolder.createEmptyContext();
+        copy.setAuthentication(current.getAuthentication());
+        return copy;
+    }
+
+    @Override
+    public void restoreContext(Object snapshot) {
+        if (snapshot instanceof SecurityContext ctx) {
+            SecurityContextHolder.setContext(ctx);
+        } else {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Override
+    public void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/spring/src/main/java/com/vaadin/browserless/SpringSecurityContextHandler.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringSecurityContextHandler.java
@@ -15,9 +15,18 @@
  */
 package com.vaadin.browserless;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
 
 /**
  * Spring Security implementation of {@link SecurityContextHandler}.
@@ -26,7 +35,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * {@link SecurityContextHolder} for multi-user test isolation.
  * <p>
  * The {@link #setupAuthentication(Object)} method expects an
- * {@link Authentication} instance as the credentials parameter.
+ * {@link Authentication} instance as the credentials parameter, or {@code null}
+ * for an anonymous user — in which case an {@link AnonymousAuthenticationToken}
+ * is installed (mirroring the behaviour of {@code @WithAnonymousUser}).
  *
  * @see SecurityContextHandler
  * @see SpringBrowserlessApplicationContext
@@ -36,18 +47,23 @@ public class SpringSecurityContextHandler
 
     @Override
     public void setupAuthentication(Authentication credentials) {
-        if (credentials != null) {
-            SecurityContext ctx = SecurityContextHolder.getContext();
-            if (ctx == null) {
-                ctx = SecurityContextHolder.createEmptyContext();
-                SecurityContextHolder.setContext(ctx);
-            }
-            ctx.setAuthentication(credentials);
+        SecurityContext ctx = SecurityContextHolder.getContext();
+        if (ctx == null) {
+            ctx = SecurityContextHolder.createEmptyContext();
+            SecurityContextHolder.setContext(ctx);
         }
+        ctx.setAuthentication(
+                credentials != null ? credentials : anonymousAuthentication());
+    }
+
+    private static AnonymousAuthenticationToken anonymousAuthentication() {
+        return new AnonymousAuthenticationToken("browserless-anonymous-key",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
     }
 
     @Override
-    public Object saveContext() {
+    public SecurityContext saveContext() {
         SecurityContext current = SecurityContextHolder.getContext();
         SecurityContext copy = SecurityContextHolder.createEmptyContext();
         copy.setAuthentication(current.getAuthentication());
@@ -56,15 +72,38 @@ public class SpringSecurityContextHandler
 
     @Override
     public void restoreContext(Object snapshot) {
-        if (snapshot instanceof SecurityContext ctx) {
+        if (snapshot == null) {
+            SecurityContextHolder.clearContext();
+        } else if (snapshot instanceof SecurityContext ctx) {
             SecurityContextHolder.setContext(ctx);
         } else {
-            SecurityContextHolder.clearContext();
+            throw new IllegalArgumentException(
+                    "Expected a SecurityContext snapshot, got "
+                            + snapshot.getClass().getName());
         }
     }
 
     @Override
     public void clearContext() {
         SecurityContextHolder.clearContext();
+    }
+
+    /**
+     * Builds an {@link Authentication} for the given username and roles, in the
+     * same shape produced by Spring Security's {@code @WithMockUser}: a
+     * {@link UsernamePasswordAuthenticationToken} carrying a {@link User}
+     * principal whose authorities are the given roles, prefixed with
+     * {@code ROLE_} when not already prefixed.
+     */
+    @Override
+    public Authentication createCredentials(String username, String... roles) {
+        List<GrantedAuthority> authorities = new ArrayList<>(roles.length);
+        for (String role : roles) {
+            authorities.add(new SimpleGrantedAuthority(
+                    role.startsWith("ROLE_") ? role : "ROLE_" + role));
+        }
+        User principal = new User(username, "", authorities);
+        return UsernamePasswordAuthenticationToken.authenticated(principal,
+                principal.getPassword(), principal.getAuthorities());
     }
 }

--- a/spring/src/main/java/com/vaadin/browserless/SpringSecurityContextHandler.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringSecurityContextHandler.java
@@ -47,12 +47,9 @@ public class SpringSecurityContextHandler
 
     @Override
     public void setupAuthentication(Authentication credentials) {
-        SecurityContext ctx = SecurityContextHolder.getContext();
-        if (ctx == null) {
-            ctx = SecurityContextHolder.createEmptyContext();
-            SecurityContextHolder.setContext(ctx);
-        }
-        ctx.setAuthentication(
+        // SecurityContextHolder.getContext() never returns null — the strategy
+        // lazily installs an empty context if the slot is unset.
+        SecurityContextHolder.getContext().setAuthentication(
                 credentials != null ? credentials : anonymousAuthentication());
     }
 

--- a/spring/src/main/java/com/vaadin/browserless/SpringSecuritySupport.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringSecuritySupport.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.function.BooleanSupplier;
+
+import com.vaadin.browserless.internal.UtilsKt;
+
+/**
+ * Detects whether Spring Security is present on the classpath.
+ *
+ * <p>
+ * Used to gate optional Spring Security wiring (security context handler, mock
+ * request customizer) so that test applications without Spring Security can
+ * still bootstrap the browserless context.
+ *
+ * <p>
+ * For internal use only.
+ */
+final class SpringSecuritySupport {
+
+    private static final String SECURITY_CONTEXT_HOLDER_CLASS = "org.springframework.security.core.context.SecurityContextHolder";
+
+    private static final BooleanSupplier DEFAULT_DETECTOR = () -> UtilsKt
+            .findClass(SECURITY_CONTEXT_HOLDER_CLASS) != null;
+
+    private static volatile BooleanSupplier detector = DEFAULT_DETECTOR;
+
+    private SpringSecuritySupport() {
+    }
+
+    static boolean isPresent() {
+        return detector.getAsBoolean();
+    }
+
+    /**
+     * Test seam: override the detector. Pass {@code null} to reset to the
+     * default classpath probe.
+     */
+    static void overrideDetector(BooleanSupplier override) {
+        detector = override == null ? DEFAULT_DETECTOR : override;
+    }
+}

--- a/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
+++ b/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
@@ -26,6 +26,8 @@ import kotlin.jvm.functions.Function0;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -152,11 +154,15 @@ public class MockSpringServlet extends SpringServlet {
         private static final String ROLE_PREFIX = "ROLE_";
         private static final boolean SPRING_SECURITY_PRESENT = hasSpringSecurity();
         private static final UnaryOperator<HttpServletRequest> springSecurityRequestWrapper = springSecurityRequestWrapper();
+        private static final AuthenticationTrustResolver TRUST_RESOLVER = new AuthenticationTrustResolverImpl();
 
         private static Principal currentPrincipal() {
             Authentication auth = SecurityContextHolder.getContext()
                     .getAuthentication();
-            return (auth != null && auth.getPrincipal() != null) ? auth : null;
+            if (!TRUST_RESOLVER.isAuthenticated(auth)) {
+                return null;
+            }
+            return auth.getPrincipal() != null ? auth : null;
         }
 
         private static boolean hasSpringSecurity() {

--- a/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
+++ b/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
@@ -133,7 +133,7 @@ public class MockSpringServlet extends SpringServlet {
             if (wrappedRequest instanceof MockRequest) {
                 // Spring Security Web not on classpath: read
                 // SecurityContextHolder lazily
-                request.setUserPrincipalProvider(
+                request.principalProvider(
                         SpringSecuritySupport::currentPrincipal);
                 request.setUserInRole(SpringSecuritySupport::isGranted);
             } else {
@@ -141,8 +141,7 @@ public class MockSpringServlet extends SpringServlet {
                 // SecurityContextHolderAwareRequestWrapper lazily so that
                 // security context populated after setup (e.g. @WithMockUser)
                 // is picked up at test execution time
-                request.setUserPrincipalProvider(
-                        wrappedRequest::getUserPrincipal);
+                request.principalProvider(wrappedRequest::getUserPrincipal);
                 request.setUserInRole(
                         (principal, role) -> wrappedRequest.isUserInRole(role));
             }

--- a/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.List;
+
+import com.testapp.security.LoginView;
+import com.testapp.security.ProtectedView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests multi-user security context isolation with Spring Security.
+ * Verifies that switching between users' windows correctly saves and
+ * restores Spring SecurityContext.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
+class MultiUserSecurityTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private BrowserlessApplicationContext<Authentication> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews(
+                "com.testapp.security");
+        app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void authenticatedUser_seesProtectedView() {
+        var adminAuth = new UsernamePasswordAuthenticationToken("john",
+                "secret",
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+        var admin = app.newUser(adminAuth);
+        var adminWindow = admin.newWindow();
+
+        // Authenticated user sees the protected view
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+    }
+
+    @Test
+    void anonymousUser_redirectedToLogin() {
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Anonymous user is redirected to login
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> anonWindow.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                anonWindow.getCurrentView());
+    }
+
+    @Test
+    void multipleUsers_securityContextIsolated() {
+        var adminAuth = new UsernamePasswordAuthenticationToken("john",
+                "secret",
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+        var admin = app.newUser(adminAuth);
+        var adminWindow = admin.newWindow();
+
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Admin sees protected view
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+
+        // Anonymous user is redirected to login
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> anonWindow.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                anonWindow.getCurrentView());
+
+        // Switch back to admin — security context should be restored
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView(),
+                "Admin's security context should be restored after switching back");
+    }
+}

--- a/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
@@ -35,9 +35,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.vaadin.browserless.internal.Routes;
 
 /**
- * Tests multi-user security context isolation with Spring Security.
- * Verifies that switching between users' windows correctly saves and
- * restores Spring SecurityContext.
+ * Tests multi-user security context isolation with Spring Security. Verifies
+ * that switching between users' windows correctly saves and restores Spring
+ * SecurityContext.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
@@ -50,8 +50,7 @@ class MultiUserSecurityTest {
 
     @BeforeEach
     void setUp() {
-        Routes routes = new Routes().autoDiscoverViews(
-                "com.testapp.security");
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
         app = SpringBrowserlessApplicationContext.create(routes,
                 applicationContext);
     }
@@ -64,8 +63,7 @@ class MultiUserSecurityTest {
     @Test
     void authenticatedUser_seesProtectedView() {
         var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret",
-                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
         var admin = app.newUser(adminAuth);
         var adminWindow = admin.newWindow();
@@ -91,8 +89,7 @@ class MultiUserSecurityTest {
     @Test
     void multipleUsers_securityContextIsolated() {
         var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret",
-                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
         var admin = app.newUser(adminAuth);
         var adminWindow = admin.newWindow();

--- a/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.browserless;
 
-import java.util.List;
-
 import com.testapp.security.LoginView;
 import com.testapp.security.ProtectedView;
 import org.junit.jupiter.api.AfterEach;
@@ -26,9 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -62,10 +58,7 @@ class MultiUserSecurityTest {
 
     @Test
     void authenticatedUser_seesProtectedView() {
-        var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
-
-        var admin = app.newUser(adminAuth);
+        var admin = app.newUser("john", "USER");
         var adminWindow = admin.newWindow();
 
         // Authenticated user sees the protected view
@@ -88,10 +81,7 @@ class MultiUserSecurityTest {
 
     @Test
     void multipleUsers_securityContextIsolated() {
-        var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
-
-        var admin = app.newUser(adminAuth);
+        var admin = app.newUser("john", "USER");
         var adminWindow = admin.newWindow();
 
         var anon = app.newUser();

--- a/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/MultiUserSecurityTest.java
@@ -42,12 +42,12 @@ class MultiUserSecurityTest {
     @Autowired
     private ApplicationContext applicationContext;
 
-    private BrowserlessApplicationContext<Authentication> app;
+    private SecuredBrowserlessApplicationContext<Authentication> app;
 
     @BeforeEach
     void setUp() {
         Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
-        app = SpringBrowserlessApplicationContext.create(routes,
+        app = SpringBrowserlessApplicationContext.createSecured(routes,
                 applicationContext);
     }
 

--- a/spring/src/test/java/com/vaadin/browserless/SpringLookupInitializerCloseHookTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringLookupInitializerCloseHookTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Asserts that {@link SpringBrowserlessApplicationContext} releases the lookup
+ * initializer's ThreadLocal when the application context is closed.
+ * <p>
+ * Plain JUnit 5 — no {@code SpringExtension}/{@code TestContext}, so the
+ * {@code TestExecutionListener.afterTestMethod} cleanup does not fire and any
+ * leak from {@code app.close()} is observable directly.
+ */
+class SpringLookupInitializerCloseHookTest {
+
+    @BeforeEach
+    @AfterEach
+    void resetLookupThreadLocal() {
+        BrowserlessTestSpringLookupInitializer.clearApplicationContext();
+    }
+
+    @Test
+    void close_clearsLookupApplicationContextThreadLocal() {
+        Assertions.assertNull(
+                BrowserlessTestSpringLookupInitializer.getApplicationContext(),
+                "ThreadLocal must start empty");
+
+        try (var springCtx = new AnnotationConfigApplicationContext()) {
+            springCtx.refresh();
+
+            var app = SpringBrowserlessApplicationContext.create(new Routes(),
+                    springCtx);
+            Assertions.assertSame(springCtx,
+                    BrowserlessTestSpringLookupInitializer
+                            .getApplicationContext(),
+                    "create() must publish the application context to the"
+                            + " lookup initializer ThreadLocal");
+
+            app.close();
+
+            Assertions.assertNull(
+                    BrowserlessTestSpringLookupInitializer
+                            .getApplicationContext(),
+                    "close() must clear the lookup initializer ThreadLocal so"
+                            + " standalone usage doesn't leak across test"
+                            + " methods or threads");
+        }
+    }
+
+    @Test
+    void close_isIdempotent_withCloseHook() {
+        try (var springCtx = new AnnotationConfigApplicationContext()) {
+            springCtx.refresh();
+
+            var app = SpringBrowserlessApplicationContext.create(new Routes(),
+                    springCtx);
+            app.close();
+            Assertions.assertDoesNotThrow(app::close,
+                    "Second close() must be a no-op even with hooks"
+                            + " registered");
+            Assertions.assertNull(
+                    BrowserlessTestSpringLookupInitializer
+                            .getApplicationContext(),
+                    "ThreadLocal must remain cleared after redundant close()");
+        }
+    }
+}

--- a/spring/src/test/java/com/vaadin/browserless/SpringNewUserHelperTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringNewUserHelperTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.security.Principal;
+import java.util.List;
+
+import com.testapp.security.LoginView;
+import com.testapp.security.ProtectedView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.server.VaadinRequest;
+
+/**
+ * Tests the {@code newUser(username, roles...)} helper in
+ * {@link SpringBrowserlessApplicationContext}. The helper builds an
+ * {@link Authentication} via {@link SpringSecurityContextHandler}'s
+ * {@code createCredentials} override, mirroring the conventions of
+ * {@code @WithMockUser}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
+class SpringNewUserHelperTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private BrowserlessApplicationContext<Authentication> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
+        app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void newUser_withUsernameAndRoles_authenticatesUserOnRequest() {
+        var window = app.newUser("john", "DEV", "PO").newWindow();
+
+        Principal principal = VaadinRequest.getCurrent().getUserPrincipal();
+        Assertions.assertNotNull(principal,
+                "Principal should be exposed on the request");
+        Assertions.assertEquals("john", principal.getName());
+
+        Assertions.assertTrue(VaadinRequest.getCurrent().isUserInRole("DEV"));
+        Assertions.assertTrue(VaadinRequest.getCurrent().isUserInRole("PO"));
+        Assertions.assertFalse(VaadinRequest.getCurrent().isUserInRole("CEO"));
+
+        // Helper still drives Vaadin's @PermitAll access control
+        window.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                window.getCurrentView());
+    }
+
+    @Test
+    void newUser_rolesAreNormalisedWithRolePrefix() {
+        app.newUser("john", "DEV").newWindow();
+
+        Authentication auth = SecurityContextHolder.getContext()
+                .getAuthentication();
+        Assertions.assertNotNull(auth, "Authentication should be set");
+        List<String> authorities = auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority).toList();
+        Assertions.assertEquals(List.of("ROLE_DEV"), authorities,
+                "Roles passed without the ROLE_ prefix should be prefixed");
+    }
+
+    @Test
+    void newUser_rolesAlreadyPrefixedAreNotDoublePrefixed() {
+        app.newUser("john", "ROLE_DEV").newWindow();
+
+        Authentication auth = SecurityContextHolder.getContext()
+                .getAuthentication();
+        List<String> authorities = auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority).toList();
+        Assertions.assertEquals(List.of("ROLE_DEV"), authorities,
+                "Roles already prefixed must not be double-prefixed");
+    }
+
+    @Test
+    void anonymousUser_setsAnonymousAuthenticationToken() {
+        app.newUser().newWindow();
+
+        Authentication auth = SecurityContextHolder.getContext()
+                .getAuthentication();
+        Assertions.assertInstanceOf(AnonymousAuthenticationToken.class, auth,
+                "Null credentials must install an AnonymousAuthenticationToken,"
+                        + " mirroring @WithAnonymousUser");
+    }
+
+    @Test
+    void anonymousUser_principalIsNotExposedOnRequest() {
+        var window = app.newUser().newWindow();
+
+        Principal principal = VaadinRequest.getCurrent().getUserPrincipal();
+        Assertions.assertNull(principal,
+                "Anonymous tokens must not be exposed as a request principal,"
+                        + " matching production Spring Security behaviour");
+
+        // And anonymous users still hit the login redirect
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> window.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class, window.getCurrentView());
+    }
+}

--- a/spring/src/test/java/com/vaadin/browserless/SpringNewUserHelperTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringNewUserHelperTest.java
@@ -51,12 +51,12 @@ class SpringNewUserHelperTest {
     @Autowired
     private ApplicationContext applicationContext;
 
-    private BrowserlessApplicationContext<Authentication> app;
+    private SecuredBrowserlessApplicationContext<Authentication> app;
 
     @BeforeEach
     void setUp() {
         Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
-        app = SpringBrowserlessApplicationContext.create(routes,
+        app = SpringBrowserlessApplicationContext.createSecured(routes,
                 applicationContext);
     }
 

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecurityAbsentTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecurityAbsentTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vaadin.browserless.internal.MockRequestCustomizer;
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
+import com.vaadin.flow.di.Lookup;
+
+/**
+ * Verifies that {@link SpringBrowserlessApplicationContext} bootstraps cleanly
+ * when Spring Security is not on the test app's classpath. The detector is
+ * overridden to simulate the absent classpath without actually changing the
+ * Maven-resolved dependencies.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SpringSecurityAbsentTest.TestConfig.class)
+class SpringSecurityAbsentTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @AfterEach
+    void tearDown() {
+        SpringSecuritySupport.overrideDetector(null);
+    }
+
+    @Test
+    void create_withoutSpringSecurity_doesNotInstallSecurityHandler() {
+        SpringSecuritySupport.overrideDetector(() -> false);
+
+        Routes routes = new Routes();
+        try (var app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext)) {
+            Assertions.assertNull(app.getSecurityContextHandler(),
+                    "SpringSecurityContextHandler must not be installed when"
+                            + " Spring Security is absent from the classpath");
+        }
+    }
+
+    @Test
+    void create_withoutSpringSecurity_doesNotRegisterRequestCustomizerBean() {
+        SpringSecuritySupport.overrideDetector(() -> false);
+
+        Routes routes = new Routes();
+        try (var app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext)) {
+            Assertions.assertFalse(
+                    applicationContext.containsBean(
+                            SpringSecurityRequestCustomizer.class.getName()),
+                    "SpringSecurityRequestCustomizer bean must not be"
+                            + " registered when Spring Security is absent");
+        }
+    }
+
+    @Test
+    void create_withoutSpringSecurity_doesNotInstallRequestCustomizerLookup() {
+        SpringSecuritySupport.overrideDetector(() -> false);
+
+        Routes routes = new Routes();
+        try (var app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext)) {
+            Lookup lookup = app.getService().getContext()
+                    .getAttribute(Lookup.class);
+            MockRequestCustomizer customizer = lookup
+                    .lookup(MockRequestCustomizer.class);
+            Assertions.assertFalse(
+                    customizer instanceof SpringSecurityRequestCustomizer,
+                    "SpringSecurityRequestCustomizer must not be registered as"
+                            + " a lookup service when Spring Security is"
+                            + " absent");
+        }
+    }
+
+    @Test
+    void newUser_withoutSpringSecurity_doesNotThrow() {
+        SpringSecuritySupport.overrideDetector(() -> false);
+
+        Routes routes = new Routes();
+        try (var app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext)) {
+            Assertions.assertDoesNotThrow(() -> {
+                var user = app.newUser();
+                user.newWindow();
+            });
+        }
+    }
+
+    @Test
+    void create_withSpringSecurity_installsHandlerAndCustomizer() {
+        // Default detector: actual classpath probe (Spring Security IS present
+        // in the spring module's test classpath)
+        Routes routes = new Routes();
+        try (var app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext)) {
+            Assertions.assertInstanceOf(SpringSecurityContextHandler.class,
+                    app.getSecurityContextHandler(),
+                    "Handler must be installed when Spring Security is present");
+            Assertions.assertTrue(
+                    applicationContext.containsBean(
+                            SpringSecurityRequestCustomizer.class.getName()),
+                    "Customizer bean must be registered when Spring Security"
+                            + " is present");
+            Lookup lookup = app.getService().getContext()
+                    .getAttribute(Lookup.class);
+            Assertions.assertInstanceOf(SpringSecurityRequestCustomizer.class,
+                    lookup.lookup(MockRequestCustomizer.class),
+                    "Customizer must be registered as lookup service when"
+                            + " Spring Security is present");
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+    }
+}

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecurityAbsentTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecurityAbsentTest.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -46,6 +48,19 @@ class SpringSecurityAbsentTest {
     @AfterEach
     void tearDown() {
         SpringSecuritySupport.overrideDetector(null);
+        // The lookup initializer registers SpringSecurityRequestCustomizer
+        // as a singleton in the shared Spring context whenever Spring
+        // Security is present. Unregister it so each test starts with a
+        // clean bean registry and the "without Spring Security" assertions
+        // are not poisoned by an earlier "with Spring Security" test.
+        if (applicationContext instanceof ConfigurableApplicationContext cac) {
+            DefaultListableBeanFactory bf = (DefaultListableBeanFactory) cac
+                    .getBeanFactory();
+            String beanName = SpringSecurityRequestCustomizer.class.getName();
+            if (bf.containsSingleton(beanName)) {
+                bf.destroySingleton(beanName);
+            }
+        }
     }
 
     @Test
@@ -110,11 +125,11 @@ class SpringSecurityAbsentTest {
     }
 
     @Test
-    void create_withSpringSecurity_installsHandlerAndCustomizer() {
+    void createSecured_withSpringSecurity_installsHandlerAndCustomizer() {
         // Default detector: actual classpath probe (Spring Security IS present
         // in the spring module's test classpath)
         Routes routes = new Routes();
-        try (var app = SpringBrowserlessApplicationContext.create(routes,
+        try (var app = SpringBrowserlessApplicationContext.createSecured(routes,
                 applicationContext)) {
             Assertions.assertInstanceOf(SpringSecurityContextHandler.class,
                     app.getSecurityContextHandler(),
@@ -131,6 +146,20 @@ class SpringSecurityAbsentTest {
                     "Customizer must be registered as lookup service when"
                             + " Spring Security is present");
         }
+    }
+
+    @Test
+    void createSecured_withoutSpringSecurity_throws() {
+        SpringSecuritySupport.overrideDetector(() -> false);
+
+        Routes routes = new Routes();
+        var ex = Assertions.assertThrows(IllegalStateException.class,
+                () -> SpringBrowserlessApplicationContext.createSecured(routes,
+                        applicationContext),
+                "createSecured(...) must reject calls when Spring Security is"
+                        + " absent from the classpath");
+        Assertions.assertTrue(ex.getMessage().contains("Spring Security"),
+                "ISE message must mention Spring Security");
     }
 
     @Configuration

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
@@ -35,9 +35,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.vaadin.browserless.internal.Routes;
 
 /**
- * Tests that the Spring security context snapshot is a defensive copy,
- * not a mutable reference. Mutating the live SecurityContext on the
- * thread after switching users must not corrupt the saved snapshot.
+ * Tests that the Spring security context snapshot is a defensive copy, not a
+ * mutable reference. Mutating the live SecurityContext on the thread after
+ * switching users must not corrupt the saved snapshot.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
@@ -63,8 +63,7 @@ class SpringSecuritySnapshotTest {
     @Test
     void mutatingLiveContext_doesNotCorruptSavedSnapshot() {
         var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret",
-                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
         // Create admin user and verify access
         var admin = app.newUser(adminAuth);

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.List;
+
+import com.testapp.security.ProtectedView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vaadin.browserless.internal.Routes;
+
+/**
+ * Tests that the Spring security context snapshot is a defensive copy,
+ * not a mutable reference. Mutating the live SecurityContext on the
+ * thread after switching users must not corrupt the saved snapshot.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
+class SpringSecuritySnapshotTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private BrowserlessApplicationContext<Authentication> app;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
+        app = SpringBrowserlessApplicationContext.create(routes,
+                applicationContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void mutatingLiveContext_doesNotCorruptSavedSnapshot() {
+        var adminAuth = new UsernamePasswordAuthenticationToken("john",
+                "secret",
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+        // Create admin user and verify access
+        var admin = app.newUser(adminAuth);
+        var adminWindow = admin.newWindow();
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView());
+
+        // Switch to anonymous user (saves admin's snapshot)
+        var anon = app.newUser();
+        var anonWindow = anon.newWindow();
+
+        // Mutate the live SecurityContext on the thread
+        SecurityContextHolder.getContext().setAuthentication(null);
+
+        // Switch back to admin — snapshot should NOT be corrupted
+        adminWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                adminWindow.getCurrentView(),
+                "Admin snapshot should survive mutation of the live"
+                        + " SecurityContext");
+    }
+}

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.browserless;
 
-import java.util.List;
-
 import com.testapp.security.ProtectedView;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -25,9 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -62,11 +58,8 @@ class SpringSecuritySnapshotTest {
 
     @Test
     void mutatingLiveContext_doesNotCorruptSavedSnapshot() {
-        var adminAuth = new UsernamePasswordAuthenticationToken("john",
-                "secret", List.of(new SimpleGrantedAuthority("ROLE_USER")));
-
         // Create admin user and verify access
-        var admin = app.newUser(adminAuth);
+        var admin = app.newUser("john", "USER");
         var adminWindow = admin.newWindow();
         adminWindow.navigate(ProtectedView.class);
         Assertions.assertInstanceOf(ProtectedView.class,

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
@@ -57,6 +57,37 @@ class SpringSecuritySnapshotTest {
     }
 
     @Test
+    void mutationOnActiveUser_isCapturedAndRestoredOnSwitchBack() {
+        var admin = app.newUser("john", "USER");
+        var adminWindow = admin.newWindow();
+
+        // Sanity: admin's auth is on the thread.
+        Assertions.assertEquals("john", SecurityContextHolder.getContext()
+                .getAuthentication().getName());
+
+        // Mutate the live SecurityContext *while admin is still active* —
+        // simulating a test that programmatically changes auth mid-flight
+        // (e.g. logging out the current user).
+        SecurityContextHolder.getContext().setAuthentication(null);
+
+        // Switching to another user captures the outgoing (admin's) live
+        // state — including the mutation — into admin's snapshot.
+        var bob = app.newUser("bob", "USER");
+        bob.newWindow();
+
+        // Re-activating admin must restore the *mutated* state, not the
+        // creation-time auth: mutations on the active user are captured at
+        // the user-switch point, per the BrowserlessUserContext contract.
+        adminWindow.activate();
+        Assertions.assertNull(
+                SecurityContextHolder.getContext().getAuthentication(),
+                "Mutations applied while admin was active should survive a"
+                        + " round-trip through bob — captured into admin's"
+                        + " snapshot on the user-switch and restored on"
+                        + " re-activation.");
+    }
+
+    @Test
     void mutatingLiveContext_doesNotCorruptSavedSnapshot() {
         // Create admin user and verify access
         var admin = app.newUser("john", "USER");

--- a/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSecuritySnapshotTest.java
@@ -42,12 +42,12 @@ class SpringSecuritySnapshotTest {
     @Autowired
     private ApplicationContext applicationContext;
 
-    private BrowserlessApplicationContext<Authentication> app;
+    private SecuredBrowserlessApplicationContext<Authentication> app;
 
     @BeforeEach
     void setUp() {
         Routes routes = new Routes().autoDiscoverViews("com.testapp.security");
-        app = SpringBrowserlessApplicationContext.create(routes,
+        app = SpringBrowserlessApplicationContext.createSecured(routes,
                 applicationContext);
     }
 


### PR DESCRIPTION
Introduce `BrowserlessApplicationContext`, `BrowserlessUserContext`, and `BrowserlessUIContext` to enable tests that simulate multiple users and browser tabs sharing a single Vaadin application.

Key changes:
- `BrowserlessApplicationContext` manages a shared VaadinServletService across independent user sessions
- `BrowserlessUserContext` isolates per-user VaadinSession, request, and security context
- `BrowserlessUIContext` represents a single browser tab with automatic thread-local and security context switching
- `SecurityContextHandler` interface with Spring and Quarkus implementations for framework-specific authentication isolation
- Refactor `MockVaadin` to expose `setupServlet()`, `createSessionObjects()`, and `createUI()` as public building blocks
- Enhance `MockPage` to track external navigations via `Page.setLocation()` and `Page.open()`
- Add Java-friendly `principalProvider()` and `roleChecker()` methods to `MockRequest`

Closes #38
