### PR TITLE
feat: support extra lookup services in MockVaadinHelper

### DIFF
--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockVaadinHelper.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockVaadinHelper.kt
@@ -9,18 +9,20 @@
  */
 package com.vaadin.browserless.mocks
 
-import java.io.File
-import jakarta.servlet.ServletContext
+import com.vaadin.browserless.internal.findClass
+import com.vaadin.browserless.internal.findClassOrThrow
 import com.vaadin.flow.di.Lookup
 import com.vaadin.flow.di.LookupInitializer
 import com.vaadin.flow.server.VaadinContext
 import com.vaadin.flow.server.VaadinServlet
 import com.vaadin.flow.server.VaadinServletContext
 import com.vaadin.flow.server.startup.LookupServletContainerInitializer
-import com.vaadin.browserless.internal.findClass
-import com.vaadin.browserless.internal.findClassOrThrow
+import jakarta.servlet.ServletContext
+import jakarta.servlet.annotation.HandlesTypes
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.databind.node.ObjectNode
+import java.io.File
+import kotlin.reflect.KClass
 
 object MockVaadinHelper {
 
@@ -94,14 +96,11 @@ object MockVaadinHelper {
 
     private fun init(ctx: ServletContext, lookupServices: Set<Class<*>> = emptySet()) {
 
-        val loaderInitializer = LookupServletContainerInitializer()
-
-        val loaders = mutableSetOf<Class<*>>(
+        val loaders = mutableSetOf(
                 *lookupServices.toTypedArray(),
                 LookupInitializer::class.java,
                 findClassOrThrow("com.vaadin.flow.di.LookupInitializer${'$'}ResourceProviderImpl")
         )
-
         fun tryLoad(className: String) {
             // sometimes customers don't include entire vaadin-core and exclude stuff like fusion on purpose.
             // load the class only if it exists.
@@ -110,10 +109,55 @@ object MockVaadinHelper {
 
         tryLoad("com.vaadin.flow.component.polymertemplate.rpc.PolymerPublishedEventRpcHandler")
         tryLoad("com.vaadin.fusion.frontend.EndpointGeneratorTaskFactoryImpl")
+
+        val loaderInitializer = setupLookupInitializer(loaders)
+
         loaderInitializer.onStartup(loaders, ctx)
 
         // verify that the Lookup has been set
         verifyHasLookup(ctx)
     }
 
+    private fun setupLookupInitializer(services: MutableSet<Class<*>>) : LookupServletContainerInitializer{
+        val initializer = BrowserlessLookupInitializer()
+        initializer.updateServices(services)
+        return initializer
+    }
+
+    internal open class BrowserlessLookupInitializer() : LookupServletContainerInitializer() {
+
+        // Additional services wired through lookup that the testing environment can hook in,
+        // supplementing ones defined in LookupServletContainerInitializer HandlesTypes annotations.
+        //
+        // Example:
+        // mapOf(GeolocationClientFactory::class to BrowserlessGeolocationClientFactory::class)
+        //
+        // Use Object class as a value placeholder for a service without default implementation,
+        // but that can be hooked in by the test class in the services' set
+        // mapOf(Service::class to Object::class)
+        protected open val additionalServices: Map<KClass<*>, KClass<*>> = emptyMap()
+
+        fun updateServices(services: MutableSet<Class<*>>) {
+            additionalServices
+                // skip if the caller already supplied an implementation of the service interface
+                .filterNot { entry -> services.any { entry.key.java.isAssignableFrom(it) } }
+                // ignore additional services without default implementation
+                .filter { it.value != Object::class }
+                .forEach { services.add(it.value.java) }
+        }
+
+        override fun getServiceTypes(): Collection<Class<*>?> {
+            val annotation = LookupServletContainerInitializer::class.java.getAnnotation(HandlesTypes::class.java)
+            checkNotNull(annotation) {
+                ("Cannot collect service types based on "
+                        + HandlesTypes::class.java.getSimpleName()
+                        + " annotation. The default 'getServiceTypes' method implementation can't be used.")
+            }
+            val allServices = annotation.value + additionalServices.keys
+            return setOf(*allServices.map { it.java }.toTypedArray())
+                .filter { clazz: Class<*>? -> clazz != LookupInitializer::class.java }
+                .toSet()
+
+        }
+    }
 }

--- a/shared/src/test/kotlin/com/vaadin/browserless/mocks/BrowserlessLookupInitializerTest.kt
+++ b/shared/src/test/kotlin/com/vaadin/browserless/mocks/BrowserlessLookupInitializerTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020-2026 Vaadin Ltd
+ *
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
+ *
+ *
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ */
+package com.vaadin.browserless.mocks
+
+import com.github.mvysny.dynatest.DynaTest
+import com.vaadin.flow.di.InstantiatorFactory
+import com.vaadin.flow.di.LookupInitializer
+import kotlin.reflect.KClass
+import kotlin.test.expect
+
+class BrowserlessLookupInitializerTest : DynaTest({
+
+    test("updateServices adds default impl when interface is absent") {
+        val initializer = TestInitializer(
+                mapOf(FakeService::class to FakeServiceImpl::class))
+        val services = mutableSetOf<Class<*>>()
+
+        initializer.updateServices(services)
+
+        expect(true) { services.contains(FakeServiceImpl::class.java) }
+    }
+
+    test("updateServices skips entry when caller already supplied an implementation") {
+        val initializer = TestInitializer(
+                mapOf(FakeService::class to FakeServiceImpl::class))
+        val services = mutableSetOf<Class<*>>(OtherFakeServiceImpl::class.java)
+
+        initializer.updateServices(services)
+
+        expect(true) { services.contains(OtherFakeServiceImpl::class.java) }
+        expect(false) { services.contains(FakeServiceImpl::class.java) }
+    }
+
+    test("updateServices skips entries whose default is the Object placeholder") {
+        val initializer = TestInitializer(
+                mapOf(NoDefaultService::class to Object::class))
+        val services = mutableSetOf<Class<*>>()
+
+        initializer.updateServices(services)
+
+        expect(true) { services.isEmpty() }
+    }
+
+    test("getServiceTypes extends parent service types with additionalServices keys") {
+        val initializer = TestInitializer(
+                mapOf(FakeService::class to FakeServiceImpl::class))
+
+        val types = initializer.serviceTypes
+
+        expect(true) { types.contains(FakeService::class.java) }
+        expect(true) { types.contains(InstantiatorFactory::class.java) }
+    }
+
+    test("getServiceTypes excludes LookupInitializer even when added as an additional service") {
+        val initializer = TestInitializer(
+                mapOf(LookupInitializer::class to FakeServiceImpl::class))
+
+        val types = initializer.serviceTypes
+
+        expect(false) { types.contains(LookupInitializer::class.java) }
+    }
+})
+
+private interface FakeService
+private class FakeServiceImpl : FakeService
+private class OtherFakeServiceImpl : FakeService
+private interface NoDefaultService
+
+private class TestInitializer(
+        override val additionalServices: Map<KClass<*>, KClass<*>>
+) : MockVaadinHelper.BrowserlessLookupInitializer() {
+    public override fun getServiceTypes(): Collection<Class<*>?> = super.getServiceTypes()
+}


### PR DESCRIPTION
`LookupServletContainerInitializer` discovers services declared via its `@HandlesTypes` annotation, but the testing environment may need to wire extra services (e.g. `GeolocationClientFactory`) that are not part of that fixed set.

Introduce a `BrowserlessLookupInitializer` that overrides `getServiceTypes` to extend the default service types with an `additionalServices` map, so the testing infrastructure can supply default implementations or expose hook points that tests can override.
