### PR TITLE
feat: support Signals in multi-user context API

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextDSLTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessUIContextDSLTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.example.base.signals.SignalsView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.html.NativeButtonTester;
+
+/**
+ * Covers the {@link BrowserlessUIContext} DSL methods that mirror
+ * {@link BaseBrowserlessTest}: {@link BrowserlessUIContext#fireShortcut} and
+ * the explicit-tester {@link BrowserlessUIContext#test(Class, Y)} overload.
+ */
+class BrowserlessUIContextDSLTest {
+
+    private BrowserlessApplicationContext app;
+    private BrowserlessUIContext window;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes()
+                .autoDiscoverViews(SignalsView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+        window = app.newUser().newWindow();
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void fireShortcut_uiListener_invokedForExactMatch() {
+        AtomicInteger eventsCounter = new AtomicInteger();
+        window.getUI().addShortcutListener(eventsCounter::incrementAndGet,
+                Key.KEY_W, KeyModifier.ALT, KeyModifier.SHIFT);
+
+        window.fireShortcut(Key.KEY_W);
+        Assertions.assertEquals(0, eventsCounter.get());
+
+        window.fireShortcut(Key.KEY_W, KeyModifier.ALT);
+        Assertions.assertEquals(0, eventsCounter.get());
+
+        window.fireShortcut(Key.KEY_W, KeyModifier.ALT, KeyModifier.SHIFT);
+        Assertions.assertEquals(1, eventsCounter.get());
+    }
+
+    @Test
+    void testWithExplicitTester_wrapsComponentWithGivenTester() {
+        var view = window.navigate(SignalsView.class);
+        NativeButtonTester tester = window.test(NativeButtonTester.class,
+                view.incrementButton);
+        Assertions.assertNotNull(tester);
+        tester.click();
+        // Effect runs synchronously for on-attach signals.
+        Assertions.assertEquals("Counter: 1", view.counter.getText());
+    }
+
+}

--- a/junit6/src/test/java/com/vaadin/browserless/SignalsContextTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/SignalsContextTest.java
@@ -140,7 +140,8 @@ class SignalsContextTest {
     }
 
     @Test
-    void applicationContextClose_unregistersSignalEnvironment() {
+    void applicationContextClose_unregistersSignalEnvironment()
+            throws InterruptedException {
         // Pre-condition: the test environment is registered.
         Assertions.assertNotNull(app.getSignalsTestEnvironment(),
                 "Application context must have a signals test environment "
@@ -149,6 +150,25 @@ class SignalsContextTest {
         // Closing the app must unregister the test environment, restoring
         // the default dispatcher to whatever was active before.
         app.close();
+
+        // The application context must clear its reference to the test
+        // environment on close.
+        Assertions.assertNull(app.getSignalsTestEnvironment(),
+                "Application context must clear its signals test "
+                        + "environment reference after close");
+
+        // Directly probe the global registry: with the test environment
+        // unregistered, the default effect dispatcher must no longer queue
+        // tasks on the (now orphaned) test queue. It should fall through to
+        // the immediate executor (or any remaining environment), so the
+        // task runs without anyone calling runPendingSignalsTasks().
+        var latch = new CountDownLatch(1);
+        SignalEnvironment.getDefaultEffectDispatcher()
+                .execute(latch::countDown);
+        Assertions.assertTrue(latch.await(50, TimeUnit.MILLISECONDS),
+                "After close(), tasks submitted to the default effect "
+                        + "dispatcher must not be intercepted by the "
+                        + "closed test environment's queue");
 
         // Re-opening a fresh context must re-install a working test
         // environment — proving the previous unregister fully released the

--- a/junit6/src/test/java/com/vaadin/browserless/SignalsContextTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/SignalsContextTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.example.base.signals.SignalsView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import com.vaadin.browserless.internal.Routes;
+import com.vaadin.flow.signals.SignalEnvironment;
+
+/**
+ * Mirrors {@link SignalsTest} but drives the scenarios through the
+ * {@link BrowserlessApplicationContext} / {@link BrowserlessUserContext} /
+ * {@link BrowserlessUIContext} API, verifying that the context surface offers
+ * the same Signals-testing capabilities as {@link BrowserlessTest}.
+ */
+@Timeout(10)
+class SignalsContextTest {
+
+    private BrowserlessApplicationContext app;
+    private BrowserlessUIContext window;
+
+    @BeforeEach
+    void setUp() {
+        Routes routes = new Routes()
+                .autoDiscoverViews(SignalsView.class.getPackageName());
+        app = BrowserlessApplicationContext.create(routes);
+        window = app.newUser().newWindow();
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void attachedComponent_triggerSignal_effectEvaluatedSynchronously() {
+        var view = window.navigate(SignalsView.class);
+        var counterTester = window.test(view.counter);
+        Assertions.assertEquals("Counter: 0", counterTester.getText());
+
+        window.test(view.incrementButton).click();
+        Assertions.assertEquals("Counter: 1", counterTester.getText());
+    }
+
+    @Test
+    void detachedComponent_triggerSignal_effectEvaluatedOnAttach() {
+        var view = window.navigate(SignalsView.class);
+        var counterTester = window.test(view.counter);
+        Assertions.assertEquals("Counter: 0", counterTester.getText());
+        view.counter.removeFromParent();
+        Assertions.assertFalse(counterTester.isUsable());
+
+        window.test(view.incrementButton).click();
+        Assertions.assertEquals("Counter: 0", view.counter.getText());
+
+        view.add(view.counter);
+        Assertions.assertEquals("Counter: 1", view.counter.getText());
+    }
+
+    @Test
+    void attachedComponent_triggerSignalFromNonUIThread_effectEvaluatedAsynchronously() {
+        var view = window.navigate(SignalsView.class);
+        var counterTester = window.test(view.asyncCounter);
+        Assertions.assertEquals("Counter: 0", counterTester.getText());
+        CompletableFuture.runAsync(() -> {
+            view.asyncNumberSignal.incrementBy(10.0);
+        });
+        window.runPendingSignalsTasks();
+        Assertions.assertEquals("Counter: 10", counterTester.getText());
+    }
+
+    @Test
+    void attachedComponent_triggerSignalFromNonUIThreadThroughComponentEffect_effectEvaluatedAsynchronously() {
+        var view = window.navigate(SignalsView.class);
+        var counterTester = window.test(view.asyncCounter);
+        Assertions.assertEquals("Counter: 0", counterTester.getText());
+        window.test(view.quickBackgroundTaskButton).click();
+        window.runPendingSignalsTasks(300, TimeUnit.MILLISECONDS);
+        Assertions.assertEquals("Counter: 10", counterTester.getText());
+    }
+
+    @Test
+    void effectDispatcher_routesToTestQueue_notServiceThreadPool()
+            throws InterruptedException {
+        // On the test thread, both VaadinServiceEnvironment (from MockVaadin)
+        // and TestSignalEnvironment are active. The default effect dispatcher
+        // must resolve to TestSignalEnvironment's queue (via registerFirst)
+        // so that runPendingSignalsTasks() can drive effect execution
+        // deterministically. Without registerFirst,
+        // VaadinServiceEnvironment's thread pool would be used instead,
+        // making effects run asynchronously outside the test's control.
+        window.navigate(SignalsView.class);
+
+        var latch = new CountDownLatch(1);
+        SignalEnvironment.getDefaultEffectDispatcher()
+                .execute(latch::countDown);
+
+        Assertions.assertFalse(latch.await(50, TimeUnit.MILLISECONDS),
+                "Task should be queued, not executed immediately on a "
+                        + "thread pool");
+        window.runPendingSignalsTasks();
+        Assertions.assertTrue(latch.await(0, TimeUnit.MILLISECONDS),
+                "Task should have executed after draining the test queue");
+    }
+
+    @Test
+    void attachedComponent_slowEffect_effectEvaluatedAsynchronously() {
+        var view = window.navigate(SignalsView.class);
+        var counterTester = window.test(view.asyncWithDelayCounter);
+        Assertions.assertEquals("Counter: 0 (delayed)",
+                counterTester.getText());
+        window.test(view.slowBackgroundTaskButton).click();
+        Assertions.assertTrue(
+                window.runPendingSignalsTasks(300, TimeUnit.MILLISECONDS),
+                "Expected pending signals tasks to be run");
+        Assertions.assertEquals("Counter: 10 (delayed)",
+                counterTester.getText());
+    }
+
+    @Test
+    void applicationContextClose_unregistersSignalEnvironment() {
+        // Pre-condition: the test environment is registered.
+        Assertions.assertNotNull(app.getSignalsTestEnvironment(),
+                "Application context must have a signals test environment "
+                        + "registered while open");
+
+        // Closing the app must unregister the test environment, restoring
+        // the default dispatcher to whatever was active before.
+        app.close();
+
+        // Re-opening a fresh context must re-install a working test
+        // environment — proving the previous unregister fully released the
+        // global registry.
+        app = BrowserlessApplicationContext.create(new Routes()
+                .autoDiscoverViews(SignalsView.class.getPackageName()));
+        window = app.newUser().newWindow();
+        var view = window.navigate(SignalsView.class);
+        CompletableFuture
+                .runAsync(() -> view.asyncNumberSignal.incrementBy(7.0));
+        window.runPendingSignalsTasks();
+        Assertions.assertEquals("Counter: 7",
+                window.test(view.asyncCounter).getText());
+    }
+
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -74,6 +74,7 @@ public class BrowserlessApplicationContext implements AutoCloseable {
     private final UIFactory uiFactory;
     private final List<Runnable> closeHooks;
     private final List<BrowserlessUserContext> users = new ArrayList<>();
+    private TestSignalEnvironment signalsTestEnvironment;
     private boolean closed;
 
     BrowserlessApplicationContext(VaadinServletService service,
@@ -81,6 +82,10 @@ public class BrowserlessApplicationContext implements AutoCloseable {
         this.service = service;
         this.uiFactory = uiFactory;
         this.closeHooks = closeHooks;
+        // Always-on Signals support, mirroring BaseBrowserlessTest. Registered
+        // here so it covers session-init listeners fired by
+        // BrowserlessUserContext.
+        this.signalsTestEnvironment = TestSignalEnvironment.register();
     }
 
     /**
@@ -152,6 +157,10 @@ public class BrowserlessApplicationContext implements AutoCloseable {
             user.close();
         }
         users.clear();
+        if (signalsTestEnvironment != null) {
+            signalsTestEnvironment.unregister();
+            signalsTestEnvironment = null;
+        }
         MockVaadin.fireServiceDestroy(service);
         VaadinService.setCurrent(null);
         List<RuntimeException> hookFailures = new ArrayList<>();
@@ -176,6 +185,10 @@ public class BrowserlessApplicationContext implements AutoCloseable {
 
     UIFactory getUIFactory() {
         return uiFactory;
+    }
+
+    TestSignalEnvironment getSignalsTestEnvironment() {
+        return signalsTestEnvironment;
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -17,12 +17,16 @@ package com.vaadin.browserless;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.browserless.internal.MockPage;
 import com.vaadin.browserless.internal.MockVaadin;
+import com.vaadin.browserless.internal.ShortcutsKt;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.RouteParameters;
@@ -309,6 +313,44 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
+     * Wraps a component in the given {@link ComponentTester}.
+     *
+     * @param tester
+     *            test wrapper to use
+     * @param component
+     *            component to wrap
+     * @param <T>
+     *            the tester type
+     * @param <Y>
+     *            the component type
+     * @return the initialized tester for the component
+     */
+    public <T extends ComponentTester<Y>, Y extends Component> T test(
+            Class<T> tester, Y component) {
+        activate();
+        return BaseBrowserlessTest.internalWrap(tester, component);
+    }
+
+    /**
+     * Simulates a keyboard shortcut performed on the browser.
+     *
+     * @param key
+     *            primary key of the shortcut; must not be a {@link KeyModifier}
+     * @param modifiers
+     *            key modifiers; can be empty
+     */
+    public void fireShortcut(Key key, KeyModifier... modifiers) {
+        activate();
+        if (ui.hasModalComponent()) {
+            ShortcutsKt._fireShortcut(
+                    ui.getInternals().getActiveModalComponent(), key,
+                    modifiers);
+        } else {
+            ShortcutsKt.fireShortcut(key, modifiers);
+        }
+    }
+
+    /**
      * Gets the current view displayed in this window.
      *
      * @return the current view
@@ -324,6 +366,45 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public void roundTrip() {
         activate();
         BaseBrowserlessTest.roundTrip();
+    }
+
+    /**
+     * Processes all pending Signals tasks with a default max wait time of 100
+     * milliseconds. Convenience for tests that need to wait for asynchronous
+     * Signal effects triggered from background threads or non-UI contexts.
+     *
+     * <p>
+     * If this window's {@link VaadinSession} lock is held by the current
+     * thread, it is temporarily released during the wait to allow background
+     * threads to acquire the lock and enqueue tasks.
+     *
+     * @return {@code true} if any pending Signals tasks were processed
+     * @see #runPendingSignalsTasks(long, TimeUnit)
+     */
+    public boolean runPendingSignalsTasks() {
+        return runPendingSignalsTasks(100, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Processes all pending Signals tasks, waiting up to the specified timeout
+     * for the first task to arrive. Once the first task is found, all remaining
+     * tasks in the queue are processed immediately without additional waiting.
+     *
+     * @param maxWaitTime
+     *            the maximum time to wait for the first task to arrive in the
+     *            given time unit. If &lt;= 0, returns immediately if no tasks
+     *            are available.
+     * @param unit
+     *            the time unit of the timeout value
+     * @return {@code true} if any pending Signals tasks were processed
+     */
+    public boolean runPendingSignalsTasks(long maxWaitTime, TimeUnit unit) {
+        activate();
+        TestSignalEnvironment env = user.getApp().getSignalsTestEnvironment();
+        if (env == null) {
+            return false;
+        }
+        return env.runPendingTasks(maxWaitTime, unit);
     }
 
     /**


### PR DESCRIPTION
`BrowserlessApplicationContext` / `BrowserlessUserContext` / `BrowserlessUIContext` did not register the test `SignalEnvironment`, so signal effects ran on the real thread pool and tests driving the context API could not flush them deterministically. Two smaller DSL methods — `fireShortcut` and `test(Class, Y)` — were also missing compared to `BrowserlessTest`.

Register `TestSignalEnvironment` over the application context lifecycle and expose `runPendingSignalsTasks`, `fireShortcut`, and the explicit tester `test(Class, Y)` on `BrowserlessUIContext`.
