### PR TITLE
refactor: extract shared `BrowserlessDSL` to deduplicate DSL helpers

### DIFF
--- a/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
@@ -25,10 +25,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.internal.Routes;
-import com.vaadin.browserless.internal.ShortcutsKt;
 import com.vaadin.browserless.mocks.MockedUI;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
@@ -36,7 +34,6 @@ import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.HasUrlParameter;
-import com.vaadin.flow.router.RouteParameters;
 
 /**
  * Abstract base for browserless JUnit 5 extensions. Holds all shared state and
@@ -145,8 +142,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return the instantiated view
      */
     public <T extends Component> T navigate(Class<T> target) {
-        getUI().navigate(target);
-        return validateNavigationTarget(target);
+        return BrowserlessDSL.navigate(getUI(), target);
     }
 
     /**
@@ -164,8 +160,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      */
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
             Class<T> target, C parameter) {
-        getUI().navigate(target, parameter);
-        return validateNavigationTarget(target);
+        return BrowserlessDSL.navigate(getUI(), target, parameter);
     }
 
     /**
@@ -181,8 +176,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      */
     public <T extends Component> T navigate(Class<T> target,
             Map<String, String> parameters) {
-        getUI().navigate(target, new RouteParameters(parameters));
-        return validateNavigationTarget(target);
+        return BrowserlessDSL.navigate(getUI(), target, parameters);
     }
 
     /**
@@ -198,8 +192,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      */
     public <T extends Component> T navigate(String location,
             Class<T> expectedTarget) {
-        getUI().navigate(location);
-        return validateNavigationTarget(expectedTarget);
+        return BrowserlessDSL.navigate(getUI(), location, expectedTarget);
     }
 
     /**
@@ -212,8 +205,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return a component query
      */
     public <T extends Component> ComponentQuery<T> find(Class<T> type) {
-        getUI();
-        return BaseBrowserlessTest.internalQuery(type);
+        return BrowserlessDSL.find(getUI(), type);
     }
 
     /**
@@ -230,8 +222,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      */
     public <T extends Component> ComponentQuery<T> find(Class<T> type,
             Component fromThis) {
-        getUI();
-        return new ComponentQuery<>(type).from(fromThis);
+        return BrowserlessDSL.find(getUI(), type, fromThis);
     }
 
     /**
@@ -244,10 +235,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return a component query scoped to the current view
      */
     public <T extends Component> ComponentQuery<T> findInView(Class<T> type) {
-        Component viewComponent = getCurrentView().getElement().getComponent()
-                .orElseThrow(() -> new AssertionError(
-                        "Cannot get Component instance for current view"));
-        return new ComponentQuery<>(type).from(viewComponent);
+        return BrowserlessDSL.findView(getUI(), type);
     }
 
     /**
@@ -256,14 +244,14 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return the current view
      */
     public HasElement getCurrentView() {
-        return getUI().getInternals().getActiveRouterTargetsChain().getFirst();
+        return BrowserlessDSL.getCurrentView(getUI());
     }
 
     /**
      * Simulates a server round-trip, flushing pending component changes.
      */
     public void roundTrip() {
-        BaseBrowserlessTest.roundTrip();
+        BrowserlessDSL.roundTrip(getUI());
     }
 
     /**
@@ -273,7 +261,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return {@code true} if any pending Signals tasks were processed
      */
     public boolean runPendingSignalsTasks() {
-        return runPendingSignalsTasks(100, TimeUnit.MILLISECONDS);
+        return BrowserlessDSL.runPendingSignalsTasks(signalsTestEnvironment);
     }
 
     /**
@@ -287,10 +275,8 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      * @return {@code true} if any pending Signals tasks were processed
      */
     public boolean runPendingSignalsTasks(long maxWaitTime, TimeUnit unit) {
-        if (signalsTestEnvironment != null) {
-            return signalsTestEnvironment.runPendingTasks(maxWaitTime, unit);
-        }
-        return false;
+        return BrowserlessDSL.runPendingSignalsTasks(signalsTestEnvironment,
+                maxWaitTime, unit);
     }
 
     /**
@@ -302,14 +288,7 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
      *            key modifiers
      */
     public void fireShortcut(Key key, KeyModifier... modifiers) {
-        UI ui = getUI();
-        if (ui.hasModalComponent()) {
-            ShortcutsKt._fireShortcut(
-                    ui.getInternals().getActiveModalComponent(), key,
-                    modifiers);
-        } else {
-            ShortcutsKt.fireShortcut(key, modifiers);
-        }
+        BrowserlessDSL.fireShortcut(getUI(), key, modifiers);
     }
 
     private UI getUI() {
@@ -323,18 +302,4 @@ abstract class AbstractBrowserlessExtension implements TesterWrappers {
         return ui;
     }
 
-    private <T extends Component> T validateNavigationTarget(Class<T> target) {
-        HasElement currentView = getCurrentView();
-        if (!target.isAssignableFrom(currentView.getClass())) {
-            if (currentView instanceof MockInternalSeverError) {
-                System.err.println(
-                        currentView.getElement().getProperty("stackTrace"));
-            }
-            throw new IllegalArgumentException(
-                    "Navigation resulted in unexpected class "
-                            + currentView.getClass().getName() + " instead of "
-                            + target.getName());
-        }
-        return target.cast(currentView);
-    }
 }

--- a/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
+++ b/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
@@ -38,10 +38,8 @@ import io.github.classgraph.ScanResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.internal.Routes;
-import com.vaadin.browserless.internal.ShortcutsKt;
 import com.vaadin.browserless.internal.UtilsKt;
 import com.vaadin.browserless.mocks.MockedUI;
 import com.vaadin.flow.component.Component;
@@ -50,7 +48,6 @@ import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.HasUrlParameter;
-import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -254,24 +251,7 @@ public abstract class BaseBrowserlessTest {
      * @return instantiated view
      */
     public <T extends Component> T navigate(Class<T> navigationTarget) {
-        verifyAndGetUI().navigate(navigationTarget);
-        return validateNavigationTarget(navigationTarget);
-    }
-
-    private <T extends Component> T validateNavigationTarget(
-            Class<T> navigationTarget) {
-        final HasElement currentView = getCurrentView();
-        if (!navigationTarget.isAssignableFrom(currentView.getClass())) {
-            if (currentView instanceof MockInternalSeverError) {
-                System.err.println(
-                        currentView.getElement().getProperty("stackTrace"));
-            }
-            throw new IllegalArgumentException(
-                    "Navigation resulted in unexpected class "
-                            + currentView.getClass().getName() + " instead of "
-                            + navigationTarget.getName());
-        }
-        return navigationTarget.cast(currentView);
+        return BrowserlessDSL.navigate(verifyAndGetUI(), navigationTarget);
     }
 
     /**
@@ -289,8 +269,8 @@ public abstract class BaseBrowserlessTest {
      */
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
             Class<T> navigationTarget, C parameter) {
-        verifyAndGetUI().navigate(navigationTarget, parameter);
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(verifyAndGetUI(), navigationTarget,
+                parameter);
     }
 
     /**
@@ -307,9 +287,8 @@ public abstract class BaseBrowserlessTest {
      */
     public <T extends Component> T navigate(Class<T> navigationTarget,
             Map<String, String> parameters) {
-        verifyAndGetUI().navigate(navigationTarget,
-                new RouteParameters(parameters));
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(verifyAndGetUI(), navigationTarget,
+                parameters);
     }
 
     /**
@@ -326,8 +305,8 @@ public abstract class BaseBrowserlessTest {
      */
     public <T extends Component> T navigate(String location,
             Class<T> expectedTarget) {
-        verifyAndGetUI().navigate(location);
-        return validateNavigationTarget(expectedTarget);
+        return BrowserlessDSL.navigate(verifyAndGetUI(), location,
+                expectedTarget);
     }
 
     /**
@@ -340,15 +319,7 @@ public abstract class BaseBrowserlessTest {
      *            Key modifiers. Can be empty.
      */
     public void fireShortcut(Key key, KeyModifier... modifiers) {
-        UI ui = verifyAndGetUI();
-        // TODO: should this logic be moved to ShortcutsKt.fireShortcut?
-        if (ui.hasModalComponent()) {
-            ShortcutsKt._fireShortcut(
-                    ui.getInternals().getActiveModalComponent(), key,
-                    modifiers);
-        } else {
-            ShortcutsKt.fireShortcut(key, modifiers);
-        }
+        BrowserlessDSL.fireShortcut(verifyAndGetUI(), key, modifiers);
     }
 
     /**
@@ -357,8 +328,7 @@ public abstract class BaseBrowserlessTest {
      * @return current view
      */
     public HasElement getCurrentView() {
-        return verifyAndGetUI().getInternals().getActiveRouterTargetsChain()
-                .get(0);
+        return BrowserlessDSL.getCurrentView(verifyAndGetUI());
     }
 
     // Protected for access by adapter subclass in legacy module
@@ -371,11 +341,6 @@ public abstract class BaseBrowserlessTest {
     protected static <T extends ComponentTester<Y>, Y extends Component> T internalWrap(
             Class<T> wrap, Y component) {
         return initialize(wrap, component);
-    }
-
-    protected static <T extends Component> ComponentQuery<T> internalQuery(
-            Class<T> componentType) {
-        return new ComponentQuery<>(componentType);
     }
 
     /**
@@ -437,8 +402,7 @@ public abstract class BaseBrowserlessTest {
      */
     public <T extends Component> ComponentQuery<T> find(
             Class<T> componentType) {
-        verifyAndGetUI();
-        return internalQuery(componentType);
+        return BrowserlessDSL.find(verifyAndGetUI(), componentType);
     }
 
     /**
@@ -455,8 +419,7 @@ public abstract class BaseBrowserlessTest {
      */
     public <T extends Component> ComponentQuery<T> find(Class<T> componentType,
             Component fromThis) {
-        verifyAndGetUI();
-        return new ComponentQuery<>(componentType).from(fromThis);
+        return BrowserlessDSL.find(verifyAndGetUI(), componentType, fromThis);
     }
 
     /**
@@ -470,10 +433,7 @@ public abstract class BaseBrowserlessTest {
      */
     public <T extends Component> ComponentQuery<T> findInView(
             Class<T> componentType) {
-        Component viewComponent = getCurrentView().getElement().getComponent()
-                .orElseThrow(() -> new AssertionError(
-                        "Cannot get Component instance for current view"));
-        return new ComponentQuery<>(componentType).from(viewComponent);
+        return BrowserlessDSL.findView(verifyAndGetUI(), componentType);
     }
 
     /**
@@ -561,11 +521,7 @@ public abstract class BaseBrowserlessTest {
      * Simulates a server round-trip, flushing pending component changes.
      */
     protected static void roundTrip() {
-        UI.getCurrent().getInternals().getStateTree()
-                .collectChanges(nodeChange -> {
-                });
-        UI.getCurrent().getInternals().getStateTree()
-                .runExecutionsBeforeClientResponse();
+        BrowserlessDSL.roundTrip(UI.getCurrent());
     }
 
     /**
@@ -589,7 +545,7 @@ public abstract class BaseBrowserlessTest {
      * @see TestSignalEnvironment#runPendingTasks(long, TimeUnit)
      */
     protected final boolean runPendingSignalsTasks() {
-        return runPendingSignalsTasks(100, TimeUnit.MILLISECONDS);
+        return BrowserlessDSL.runPendingSignalsTasks(signalsTestEnvironment);
     }
 
     /**
@@ -621,11 +577,8 @@ public abstract class BaseBrowserlessTest {
      */
     protected final boolean runPendingSignalsTasks(long maxWaitTime,
             TimeUnit unit) {
-        if (this.signalsTestEnvironment != null) {
-            return this.signalsTestEnvironment.runPendingTasks(maxWaitTime,
-                    unit);
-        }
-        return false;
+        return BrowserlessDSL.runPendingSignalsTasks(signalsTestEnvironment,
+                maxWaitTime, unit);
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessDSL.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessDSL.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.vaadin.browserless.internal.MockInternalSeverError;
+import com.vaadin.browserless.internal.ShortcutsKt;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.KeyModifier;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.RouteParameters;
+
+/**
+ * Shared DSL logic for browserless testing. All methods are static utilities
+ * that take a {@link UI} parameter, so callers can supply the UI from
+ * thread-locals or from a stored reference as appropriate.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+final class BrowserlessDSL {
+
+    private BrowserlessDSL() {
+    }
+
+    static <T extends Component> T navigate(UI ui, Class<T> target) {
+        ui.navigate(target);
+        return validateNavigationTarget(ui, target);
+    }
+
+    static <C, T extends Component & HasUrlParameter<C>> T navigate(UI ui,
+            Class<T> target, C parameter) {
+        ui.navigate(target, parameter);
+        return validateNavigationTarget(ui, target);
+    }
+
+    static <T extends Component> T navigate(UI ui, Class<T> target,
+            Map<String, String> parameters) {
+        ui.navigate(target, new RouteParameters(parameters));
+        return validateNavigationTarget(ui, target);
+    }
+
+    static <T extends Component> T navigate(UI ui, String location,
+            Class<T> expectedTarget) {
+        ui.navigate(location);
+        return validateNavigationTarget(ui, expectedTarget);
+    }
+
+    static <T extends Component> T validateNavigationTarget(UI ui,
+            Class<T> target) {
+        HasElement currentView = getCurrentView(ui);
+        if (!target.isAssignableFrom(currentView.getClass())) {
+            if (currentView instanceof MockInternalSeverError) {
+                System.err.println(
+                        currentView.getElement().getProperty("stackTrace"));
+            }
+            throw new IllegalArgumentException(
+                    "Navigation resulted in unexpected class "
+                            + currentView.getClass().getName() + " instead of "
+                            + target.getName());
+        }
+        return target.cast(currentView);
+    }
+
+    static HasElement getCurrentView(UI ui) {
+        return ui.getInternals().getActiveRouterTargetsChain().get(0);
+    }
+
+    static <T extends Component> ComponentQuery<T> find(UI ui,
+            Class<T> componentType) {
+        return new ComponentQuery<>(componentType);
+    }
+
+    static <T extends Component> ComponentQuery<T> find(UI ui,
+            Class<T> componentType, Component fromThis) {
+        return new ComponentQuery<>(componentType).from(fromThis);
+    }
+
+    static <T extends Component> ComponentQuery<T> findView(UI ui,
+            Class<T> componentType) {
+        Component viewComponent = getCurrentView(ui).getElement().getComponent()
+                .orElseThrow(() -> new AssertionError(
+                        "Cannot get Component instance for current view"));
+        return new ComponentQuery<>(componentType).from(viewComponent);
+    }
+
+    static void fireShortcut(UI ui, Key key, KeyModifier... modifiers) {
+        if (ui.hasModalComponent()) {
+            ShortcutsKt._fireShortcut(
+                    ui.getInternals().getActiveModalComponent(), key,
+                    modifiers);
+        } else {
+            ShortcutsKt.fireShortcut(key, modifiers);
+        }
+    }
+
+    static void roundTrip(UI ui) {
+        ui.getInternals().getStateTree().collectChanges(nodeChange -> {
+        });
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+    }
+
+    static boolean runPendingSignalsTasks(
+            TestSignalEnvironment signalsTestEnvironment) {
+        return runPendingSignalsTasks(signalsTestEnvironment, 100,
+                TimeUnit.MILLISECONDS);
+    }
+
+    static boolean runPendingSignalsTasks(
+            TestSignalEnvironment signalsTestEnvironment, long maxWaitTime,
+            TimeUnit unit) {
+        if (signalsTestEnvironment != null) {
+            return signalsTestEnvironment.runPendingTasks(maxWaitTime, unit);
+        }
+        return false;
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -19,17 +19,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import com.vaadin.browserless.internal.MockInternalSeverError;
 import com.vaadin.browserless.internal.MockPage;
 import com.vaadin.browserless.internal.MockVaadin;
-import com.vaadin.browserless.internal.ShortcutsKt;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.HasUrlParameter;
-import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
@@ -158,8 +155,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      */
     public <T extends Component> T navigate(Class<T> navigationTarget) {
         activate();
-        ui.navigate(navigationTarget);
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(ui, navigationTarget);
     }
 
     /**
@@ -178,8 +174,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <C, T extends Component & HasUrlParameter<C>> T navigate(
             Class<T> navigationTarget, C parameter) {
         activate();
-        ui.navigate(navigationTarget, parameter);
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(ui, navigationTarget, parameter);
     }
 
     /**
@@ -196,8 +191,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <T extends Component> T navigate(Class<T> navigationTarget,
             Map<String, String> parameters) {
         activate();
-        ui.navigate(navigationTarget, new RouteParameters(parameters));
-        return validateNavigationTarget(navigationTarget);
+        return BrowserlessDSL.navigate(ui, navigationTarget, parameters);
     }
 
     /**
@@ -215,8 +209,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <T extends Component> T navigate(String location,
             Class<T> expectedTarget) {
         activate();
-        ui.navigate(location);
-        return validateNavigationTarget(expectedTarget);
+        return BrowserlessDSL.navigate(ui, location, expectedTarget);
     }
 
     /**
@@ -232,7 +225,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <T extends Component> ComponentQuery<T> find(
             Class<T> componentType) {
         activate();
-        return new ComponentQuery<>(componentType);
+        return BrowserlessDSL.find(ui, componentType);
     }
 
     /**
@@ -250,7 +243,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <T extends Component> ComponentQuery<T> find(Class<T> componentType,
             Component fromThis) {
         activate();
-        return new ComponentQuery<>(componentType).from(fromThis);
+        return BrowserlessDSL.find(ui, componentType, fromThis);
     }
 
     /**
@@ -266,10 +259,7 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     public <T extends Component> ComponentQuery<T> findInView(
             Class<T> componentType) {
         activate();
-        Component viewComponent = getCurrentView().getElement().getComponent()
-                .orElseThrow(() -> new AssertionError(
-                        "Cannot get Component instance for current view"));
-        return new ComponentQuery<>(componentType).from(viewComponent);
+        return BrowserlessDSL.findView(ui, componentType);
     }
 
     /**
@@ -311,32 +301,13 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
     }
 
     /**
-     * Simulates a keyboard shortcut performed on the browser.
-     *
-     * @param key
-     *            primary key of the shortcut; must not be a {@link KeyModifier}
-     * @param modifiers
-     *            key modifiers; can be empty
-     */
-    public void fireShortcut(Key key, KeyModifier... modifiers) {
-        activate();
-        if (ui.hasModalComponent()) {
-            ShortcutsKt._fireShortcut(
-                    ui.getInternals().getActiveModalComponent(), key,
-                    modifiers);
-        } else {
-            ShortcutsKt.fireShortcut(key, modifiers);
-        }
-    }
-
-    /**
      * Gets the current view displayed in this window.
      *
      * @return the current view
      */
     public HasElement getCurrentView() {
         activate();
-        return ui.getInternals().getActiveRouterTargetsChain().get(0);
+        return BrowserlessDSL.getCurrentView(ui);
     }
 
     /**
@@ -344,7 +315,21 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      */
     public void roundTrip() {
         activate();
-        BaseBrowserlessTest.roundTrip();
+        BrowserlessDSL.roundTrip(ui);
+    }
+
+    /**
+     * Simulates a keyboard shortcut performed on the browser.
+     *
+     * @param key
+     *            primary key of the shortcut. This must not be a
+     *            {@link KeyModifier}.
+     * @param modifiers
+     *            key modifiers. Can be empty.
+     */
+    public void fireShortcut(Key key, KeyModifier... modifiers) {
+        activate();
+        BrowserlessDSL.fireShortcut(ui, key, modifiers);
     }
 
     /**
@@ -379,11 +364,8 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
      */
     public boolean runPendingSignalsTasks(long maxWaitTime, TimeUnit unit) {
         activate();
-        TestSignalEnvironment env = user.getApp().getSignalsTestEnvironment();
-        if (env == null) {
-            return false;
-        }
-        return env.runPendingTasks(maxWaitTime, unit);
+        return BrowserlessDSL.runPendingSignalsTasks(
+                user.getApp().getSignalsTestEnvironment(), maxWaitTime, unit);
     }
 
     /**
@@ -510,22 +492,6 @@ public class BrowserlessUIContext implements TesterWrappers, AutoCloseable {
         } else {
             user.clearThreadLocals();
         }
-    }
-
-    private <T extends Component> T validateNavigationTarget(
-            Class<T> navigationTarget) {
-        HasElement currentView = getCurrentView();
-        if (!navigationTarget.isAssignableFrom(currentView.getClass())) {
-            if (currentView instanceof MockInternalSeverError) {
-                System.err.println(
-                        currentView.getElement().getProperty("stackTrace"));
-            }
-            throw new IllegalArgumentException(
-                    "Navigation resulted in unexpected class "
-                            + currentView.getClass().getName() + " instead of "
-                            + navigationTarget.getName());
-        }
-        return navigationTarget.cast(currentView);
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/ComponentTester.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentTester.java
@@ -139,7 +139,7 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      */
     public <R extends Component> ComponentQuery<R> find(
             Class<R> componentType) {
-        return BaseBrowserlessTest.internalQuery(componentType).from(component);
+        return new ComponentQuery<>(componentType).from(component);
     }
 
     /**
@@ -412,8 +412,8 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      */
     protected <R extends Component> List<R> findAllByQuery(
             Class<R> componentType, Consumer<ComponentQuery<R>> queryBuilder) {
-        ComponentQuery<R> query = BaseBrowserlessTest
-                .internalQuery(componentType).from(component);
+        ComponentQuery<R> query = new ComponentQuery<>(componentType)
+                .from(component);
         queryBuilder.accept(query);
         // Make sure consumer didn't change the starting component
         query.from(component);


### PR DESCRIPTION
After the multi-user/multi-window feature landed, `BaseBrowserlessTest`, `BrowserlessUIContext`, and `AbstractBrowserlessExtension` each carried their own near-identical copies of `navigate`, `validateNavigationTarget`, `getCurrentView`, `$` / `$view`, `roundTrip`, `fireShortcut`, and `runPendingSignalsTasks`.

Extract a package-private `BrowserlessDSL` utility with static methods that take the `UI` as a parameter, and rewrite the three call sites to delegate. Public method names (`$`, `$view`, `get`, `getView`) are intentionally left unchanged here; the rename to `find` / `findView` will be handled in a follow-up PR.

Inline the two remaining callers of `BaseBrowserlessTest.internalQuery` in `ComponentTester` and drop the helper.
