### PR TITLE
fix: Register TestSignalEnvironment in Spring and Quarkus base tests

### DIFF
--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
@@ -95,6 +95,7 @@ public abstract class QuarkusBrowserlessTest extends BaseBrowserlessTest
         MockQuarkusServlet servlet = new MockQuarkusServlet(discoverRoutes(),
                 CDI.current().getBeanManager(), MockedUI::new);
         MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+        initSignalsSupport();
     }
 
     @AfterEach

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSignalsTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusSignalsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import com.vaadin.browserless.TestSignalEnvironment;
+import com.vaadin.flow.signals.SignalEnvironment;
+
+/**
+ * Verifies that {@link QuarkusBrowserlessTest} initializes signal support so
+ * that the default effect dispatcher resolves to {@link TestSignalEnvironment}
+ * (a task queue drained by {@code runPendingSignalsTasks}) rather than the
+ * VaadinService thread pool. Without this, mutations on a shared signal
+ * dispatch their async {@code confirm()} through a real thread pool, racing
+ * with the next mutation's synchronous {@code notifyObservers} and silently
+ * dropping notifications.
+ */
+@QuarkusTest
+@Timeout(10)
+class QuarkusSignalsTest extends QuarkusBrowserlessTest {
+
+    @Test
+    void signalEnvironment_defaultDispatcher_routesToTestQueue()
+            throws InterruptedException {
+        var latch = new CountDownLatch(1);
+        SignalEnvironment.getDefaultEffectDispatcher()
+                .execute(latch::countDown);
+
+        Assertions.assertFalse(latch.await(50, TimeUnit.MILLISECONDS),
+                "Task should be queued in the test environment, not "
+                        + "executed immediately on a thread pool. "
+                        + "TestSignalEnvironment is not registered — "
+                        + "QuarkusBrowserlessTest.initVaadinEnvironment must "
+                        + "call initSignalsSupport().");
+        Assertions.assertTrue(runPendingSignalsTasks(),
+                "Expected runPendingSignalsTasks() to process the queued "
+                        + "task, but no TestSignalEnvironment is registered.");
+        Assertions.assertTrue(latch.await(0, TimeUnit.MILLISECONDS),
+                "Task should have executed after draining the test queue");
+    }
+}

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
@@ -95,6 +95,7 @@ public abstract class SpringBrowserlessTest extends BaseBrowserlessTest
         MockSpringServlet servlet = new MockSpringServlet(discoverRoutes(),
                 applicationContext, MockedUI::new);
         MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+        initSignalsSupport();
     }
 
     @AfterEach

--- a/spring/src/test/java/com/vaadin/browserless/SpringSignalsTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringSignalsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.vaadin.flow.signals.SignalEnvironment;
+
+/**
+ * Verifies that {@link SpringBrowserlessTest} initializes signal support so
+ * that the default effect dispatcher resolves to {@link TestSignalEnvironment}
+ * (a task queue drained by {@code runPendingSignalsTasks}) rather than the
+ * VaadinService thread pool. Without this, mutations on a shared signal
+ * dispatch their async {@code confirm()} through a real thread pool, racing
+ * with the next mutation's synchronous {@code notifyObservers} and silently
+ * dropping notifications (see use-cases MUC03 nickname-update flake).
+ */
+@ContextConfiguration(classes = SpringSignalsTest.TestConfig.class)
+@Timeout(10)
+class SpringSignalsTest extends SpringBrowserlessTest {
+
+    @Test
+    void signalEnvironment_defaultDispatcher_routesToTestQueue()
+            throws InterruptedException {
+        var latch = new CountDownLatch(1);
+        SignalEnvironment.getDefaultEffectDispatcher()
+                .execute(latch::countDown);
+
+        Assertions.assertFalse(latch.await(50, TimeUnit.MILLISECONDS),
+                "Task should be queued in the test environment, not "
+                        + "executed immediately on a thread pool. "
+                        + "TestSignalEnvironment is not registered — "
+                        + "SpringBrowserlessTest.initVaadinEnvironment must "
+                        + "call initSignalsSupport().");
+        Assertions.assertTrue(runPendingSignalsTasks(),
+                "Expected runPendingSignalsTasks() to process the queued "
+                        + "task, but no TestSignalEnvironment is registered.");
+        Assertions.assertTrue(latch.await(0, TimeUnit.MILLISECONDS),
+                "Task should have executed after draining the test queue");
+    }
+
+    @Configuration
+    static class TestConfig {
+    }
+}


### PR DESCRIPTION
SpringBrowserlessTest and QuarkusBrowserlessTest both override initVaadinEnvironment without calling super or initSignalsSupport, so TestSignalEnvironment is never registered for their tests. As a result SignalEnvironment.getDefaultEffectDispatcher() resolves to VaadinServiceEnvironment.getExecutor() (a real thread pool) instead of the test queue.

This breaks the determinism that runPendingSignalsTasks() promises: shared signal mutations dispatch their async confirm() through the thread pool, where it later calls notifyObservers on a worker. The bindText effect's UI-aware dispatcher then sees UI.getCurrent() != ui on the worker thread and routes the invalidate via ui.access(...), deferring listener re-registration past the next mutation and silently dropping a notification. Surfaced as the MUC03 nickname- update flake in the vaadin/use-cases repo.

Fix: call initSignalsSupport() from both overrides so the base-class TestSignalEnvironment.register() runs the same way it already does for plain BrowserlessTest tests. Add SpringSignalsTest and QuarkusSignalsTest that verify the default effect dispatcher routes to the test queue (parallels the existing junit6 SignalsTest test effectDispatcher_routesToTestQueue_notServiceThreadPool).
