### PR TITLE
chore: configure spotless for kotlin sources

### DIFF
--- a/junit6/src/test/kotlin/com/vaadin/browserless/TestInitListener.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/TestInitListener.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/TestUtils.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/TestUtils.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/AllTests.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/AllTests.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/AsyncTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/AsyncTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/AttachedTextField.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/AttachedTextField.kt
@@ -1,13 +1,18 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.browserless.internal
 
 import com.vaadin.flow.component.textfield.TextField

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/BasicUtilsTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/BasicUtilsTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/ComponentUtilsTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/ComponentUtilsTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/CompositeTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/CompositeTest.kt
@@ -1,12 +1,18 @@
 /*
- * Copyright (C) 2000-2026 Vaadin Ltd
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.browserless.internal
 
 import com.vaadin.flow.component.Component

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/DepthFirstTreeIteratorTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/DepthFirstTreeIteratorTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/ElementUtilsTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/ElementUtilsTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/LocatorTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/LocatorTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/MockVaadinTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/MockVaadinTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 @file:Suppress("DEPRECATION")
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/PrettyPrintTreeTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/PrettyPrintTreeTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/RoutesTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/RoutesTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/SearchSpecTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/SearchSpecTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/internal/ShortcutsTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/internal/ShortcutsTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.browserless.internal
 
 import com.github.mvysny.dynatest.DynaNodeGroup

--- a/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockContextTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockContextTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockHttpSessionTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockHttpSessionTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockRequestTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockRequestTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockResponseTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockResponseTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/mocks/SessionAttributeMapTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/mocks/SessionAttributeMapTest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/junit6/src/test/kotlin/com/vaadin/browserless/mocks/Utils.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/mocks/Utils.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,11 @@
                             <file>${maven.multiModuleProjectDirectory}/eclipse/apache2-license-header.txt</file>
                         </licenseHeader>
                     </java>
+                    <kotlin>
+                        <licenseHeader>
+                            <file>${maven.multiModuleProjectDirectory}/eclipse/apache2-license-header.txt</file>
+                        </licenseHeader>
+                    </kotlin>
                 </configuration>
             </plugin>
         </plugins>

--- a/shared/src/main/kotlin/com/vaadin/browserless/component/Grid.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/component/Grid.kt
@@ -1,13 +1,18 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 @file:Suppress("FunctionName")
 
 package com.vaadin.browserless.component

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/BasicUtils.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/BasicUtils.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 @file:Suppress("FunctionName")
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/ComponentUtils.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/ComponentUtils.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/DepthFirstTreeIterator.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/DepthFirstTreeIterator.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/ElementUtils.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/ElementUtils.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/Locator.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/Locator.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 @file:Suppress("FunctionName")
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/PrettyPrintTree.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/PrettyPrintTree.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/Renderers.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/Renderers.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.browserless.internal
 
 import com.vaadin.flow.component.Component

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/Routes.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/Routes.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/Shortcuts.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/Shortcuts.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.browserless.internal
 
 import com.vaadin.flow.component.Component

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/TestingLifecycleHook.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/TestingLifecycleHook.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/Utils.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/Utils.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.internal
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockContext.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockContext.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockHttpEnvironment.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockHttpEnvironment.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockHttpSession.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockHttpSession.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 @file:Suppress("OverridingDeprecatedMember", "DEPRECATION")
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockInstantiator.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockInstantiator.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockResponse.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockResponse.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockService.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockService.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockVaadinHelper.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockVaadinHelper.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockVaadinServlet.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockVaadinServlet.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockVaadinSession.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockVaadinSession.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockedUI.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockedUI.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/SessionAttributeMap.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/SessionAttributeMap.kt
@@ -1,11 +1,17 @@
-/**
- * Copyright (C) 2000-2026 Vaadin Ltd
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Vaadin Commercial License and Service Terms.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full
- * license.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 

--- a/shared/src/test/kotlin/com/vaadin/browserless/internal/AllTests.kt
+++ b/shared/src/test/kotlin/com/vaadin/browserless/internal/AllTests.kt
@@ -1,13 +1,18 @@
 /*
- * Copyright (C) 2020-2026 Vaadin Ltd
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Commercial Vaadin Developer License
- * 4.0 (CVDLv4).
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.browserless.internal
 
 import kotlin.test.expect

--- a/shared/src/test/kotlin/com/vaadin/browserless/mocks/BrowserlessLookupInitializerTest.kt
+++ b/shared/src/test/kotlin/com/vaadin/browserless/mocks/BrowserlessLookupInitializerTest.kt
@@ -1,11 +1,17 @@
 /*
- * Copyright (C) 2020-2026 Vaadin Ltd
+ * Copyright 2000-2026 Vaadin Ltd.
  *
- * This program is available under Commercial Vaadin Developer License
- * 4.0 (CVDLv4).
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.browserless.mocks
 


### PR DESCRIPTION
Also apply formatting to fix license headers on Kotlin files.

Fixes #76
