### PR TITLE
feat: add `withTestId` filter to `ComponentQuery` and `Locator`

### DIFF
--- a/junit6/src/test/java/com/example/locator/LocatorDemoView.java
+++ b/junit6/src/test/java/com/example/locator/LocatorDemoView.java
@@ -44,6 +44,7 @@ public class LocatorDemoView extends VerticalLayout {
         Button save = new Button("Save",
                 e -> echo.setText("Saved: " + name.getValue()));
         save.setId("save");
+        save.setTestId("save-button");
 
         Button clear = new Button("Clear", e -> name.setValue(""));
         clear.setAriaLabel("Reset form");

--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -428,6 +428,64 @@ class ComponentQueryTest extends BrowserlessTest {
     }
 
     @Test
+    void withTestId_matchingComponent_getsComponent() {
+        Element rootElement = getCurrentView().getElement();
+        List<TextField> textFields = IntStream.rangeClosed(1, 5)
+                .mapToObj(idx -> {
+                    TextField field = new TextField();
+                    field.setTestId("test-field-" + idx);
+                    return field;
+                }).peek(field -> rootElement.appendChild(field.getElement()))
+                .toList();
+
+        for (TextField expected : textFields) {
+            List<TextField> result = findInView(TextField.class)
+                    .withTestId(expected.getTestId()).all();
+            Assertions.assertIterableEquals(Collections.singleton(expected),
+                    result);
+        }
+    }
+
+    @Test
+    void withTestId_noMatchingComponent_emptyList() {
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(new TextField().getElement());
+        TextField textField = new TextField();
+        textField.setTestId("known-test-id");
+        rootElement.appendChild(textField.getElement());
+
+        ComponentQuery<TextField> query = findInView(TextField.class);
+        Assertions.assertTrue(query.withTestId("missing-id").all().isEmpty());
+    }
+
+    @Test
+    void withTestId_matchingDifferentComponentType_emptyList() {
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(new TextField().getElement());
+        Button button = new Button();
+        button.setTestId("shared-id");
+        rootElement.appendChild(button.getElement());
+
+        ComponentQuery<TextField> query = findInView(TextField.class);
+        Assertions.assertTrue(query.withTestId("shared-id").all().isEmpty());
+    }
+
+    @Test
+    void withTestId_duplicateTestId_failsCountAssertion() {
+        Element rootElement = getCurrentView().getElement();
+        TextField first = new TextField();
+        first.setTestId("duplicate");
+        TextField second = new TextField();
+        second.setTestId("duplicate");
+        rootElement.appendChild(first.getElement(), second.getElement());
+
+        ComponentQuery<TextField> query = findInView(TextField.class)
+                .withTestId("duplicate");
+        // withTestId caps the expected count at 0..1, just like withId.
+        Assertions.assertThrows(AssertionError.class, query::all);
+    }
+
+    @Test
     void withPropertyValue_matchingValue_findsComponent() {
         Element rootElement = getCurrentView().getElement();
         TextField textField = new TextField();

--- a/junit6/src/test/java/com/vaadin/browserless/LocatorApiTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/LocatorApiTest.java
@@ -236,6 +236,22 @@ class LocatorApiTest {
     }
 
     @Test
+    void filterChain_withTestId_selectsButton() {
+        try (var app = createApplicationContext()) {
+            var window = app.newUser().newWindow();
+            window.navigate(LocatorDemoView.class);
+
+            window.findTextField().withId("name").setValue("Ada");
+
+            // The Save button is tagged with data-testid="save-button" via
+            // Component#setTestId.
+            window.findButton().withTestId("save-button").click();
+            Assertions.assertEquals("Saved: Ada",
+                    window.findSpan().withId("echo").component().getText());
+        }
+    }
+
+    @Test
     void filterChain_expandedSurface() {
         try (var app = createApplicationContext()) {
             var window = app.newUser().newWindow();

--- a/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
@@ -117,6 +117,25 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Requires the component to have the given {@code data-testid} attribute,
+     * as set by {@link com.vaadin.flow.component.Component#setTestId(String)}.
+     * <p>
+     * Test ids are expected to be unique within the UI, so a match always
+     * resolves to at most one component (just like {@link #withId(String)}).
+     *
+     * @param testId
+     *            the test id to look up
+     * @return this element query instance for chaining
+     * @see com.vaadin.flow.component.Component#setTestId(String)
+     */
+    public ComponentQuery<T> withTestId(String testId) {
+        locatorSpec.testId = testId;
+        // At most one element with given test-id is expected
+        locatorSpec.count = new IntRange(0, 1);
+        return this;
+    }
+
+    /**
      * Requires the components to satisfy the given condition.
      *
      * @param condition
@@ -685,6 +704,7 @@ public class ComponentQuery<T extends Component> {
     private static class LocatorSpec<T extends Component> {
 
         String id;
+        String testId;
         String caption;
         boolean captionExactMatch = false;
         String placeholder;
@@ -701,6 +721,8 @@ public class ComponentQuery<T extends Component> {
         public Unit populate(SearchSpec<T> spec) {
             if (id != null)
                 spec.setId(id);
+            if (testId != null)
+                spec.setTestId(testId);
             if (caption != null && captionExactMatch)
                 spec.setCaption(caption);
             else if (caption != null)

--- a/shared/src/main/java/com/vaadin/browserless/locator/Locator.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/Locator.java
@@ -106,6 +106,17 @@ public abstract class Locator<C extends Component, SELF extends Locator<C, SELF>
         return self();
     }
 
+    /**
+     * Requires the matched component to have the given {@code data-testid}
+     * attribute, as set by
+     * {@link com.vaadin.flow.component.Component#setTestId(String)}.
+     */
+    public SELF withTestId(String testId) {
+        resetCache();
+        query.withTestId(testId);
+        return self();
+    }
+
     /** Requires the matched component to have all the given CSS class names. */
     public SELF withClassName(String... className) {
         resetCache();

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/Locator.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/Locator.kt
@@ -27,6 +27,7 @@ import com.vaadin.flow.router.InternalServerError
  * for more details.
  * @property clazz the class of the component we are searching for.
  * @property id the required [Component.getId]; if null, no particular id is matched.
+ * @property testId the required [Component.getTestId] (i.e. the `data-testid` attribute); if null, no particular test id is matched.
  * @property caption the required [Component.caption]; if null, no particular caption is matched.
  * @property placeholder the required [Component.placeholder]; if null, no particular placeholder is matched.
  * @property text the [com.vaadin.flow.dom.Element.getText]
@@ -41,6 +42,7 @@ import com.vaadin.flow.router.InternalServerError
 class SearchSpec<T : Component>(
         val clazz: Class<T>,
         var id: String? = null,
+        var testId: String? = null,
         var caption: String? = null,
         var placeholder: String? = null,
         var text: String? = null,
@@ -56,6 +58,7 @@ class SearchSpec<T : Component>(
     override fun toString(): String {
         val list = mutableListOf<String>(if (clazz.simpleName.isBlank()) clazz.name else clazz.simpleName)
         if (id != null) list.add("id='$id'")
+        if (testId != null) list.add("testId='$testId'")
         if (caption != null) list.add("caption='$caption'")
         if (placeholder != null) list.add("placeholder='$placeholder'")
         if (text != null) list.add("text='$text'")
@@ -85,6 +88,7 @@ class SearchSpec<T : Component>(
         val p = mutableListOf<(Component)->Boolean>()
         p.add { component -> clazz.isInstance(component)}
         if (id != null) p.add { component -> component.id_ == id }
+        if (testId != null) p.add { component -> component.testId == testId }
         if (caption != null) p.add { component -> component.caption == caption }
         if (placeholder != null) p.add { component -> component.placeholder == placeholder }
         if (!classes.isNullOrBlank()) p.add { component -> component.hasAllClasses(classes!!) }


### PR DESCRIPTION
Mirrors Flow's `Component.setTestId(String)` / `getTestId()` so tests can
select components by their `data-testid` attribute, just like `withId`.
Treats test ids as unique, so a match resolves to at most one component.

Fixes #73 