### PR TITLE
fix: scope Locator filters via HasX mixin interfaces

### DIFF
--- a/junit6/src/test/java/com/example/locator/LocatorDemoView.java
+++ b/junit6/src/test/java/com/example/locator/LocatorDemoView.java
@@ -19,9 +19,12 @@ import java.util.List;
 
 import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.BigDecimalField;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 
@@ -51,10 +54,23 @@ public class LocatorDemoView extends VerticalLayout {
         people.addItemClickListener(
                 event -> echo.setText("Clicked: " + event.getItem().name()));
 
+        // Typed-value fields exercised by withValue_* tests: each component
+        // has a distinct HasValue<?, V> V (String, BigDecimal, LocalDate,
+        // Boolean), so the generated locator binds withValue to that exact
+        // type via HasValueFilter.
+        BigDecimalField price = new BigDecimalField("Price");
+        price.setId("price");
+
+        DatePicker date = new DatePicker("Date");
+        date.setId("date");
+
+        Checkbox accept = new Checkbox("Accept");
+        accept.setId("accept");
+
         PersonForm personForm = new PersonForm(echo);
         personForm.setId("person-form");
 
-        add(name, save, clear, echo, people, personForm);
+        add(name, save, clear, echo, people, price, date, accept, personForm);
     }
 
     /**

--- a/junit6/src/test/java/com/vaadin/browserless/LocatorApiTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/LocatorApiTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.browserless;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -89,6 +91,55 @@ class LocatorApiTest {
             window.findTextField().withId("name").setValue("hello");
             Assertions.assertEquals("hello", window.findTextField()
                     .withId("name").component().getValue());
+        }
+    }
+
+    @Test
+    void withValue_typedAgainstComponentValueType() {
+        // HasValueFilter threads V from the component's HasValue<?, V>, so
+        // withValue is bound to the component's exact value type — String
+        // for TextField, BigDecimal for BigDecimalField, LocalDate for
+        // DatePicker, Boolean for Checkbox. Wrong types
+        // (e.g. findTextField().withValue(42),
+        // findDatePicker().withValue("2026-05-28"))
+        // would not compile here.
+        try (var app = createApplicationContext()) {
+            var window = app.newUser().newWindow();
+            window.navigate(LocatorDemoView.class);
+
+            // Reuse a fresh locator across the exists() assertions so each
+            // typed-value block reads cleanly. Actions (setValue, click) use
+            // a separate chain — calling them on the stored locator would
+            // narrow its query's count via component()→single() and make a
+            // follow-up withValue(...) that matches nothing throw instead of
+            // returning false.
+
+            window.findTextField().withId("name").setValue("typed");
+            var name = window.findTextField().withId("name");
+            Assertions.assertTrue(name.withValue("typed").exists());
+            Assertions.assertFalse(name.withValue("other").exists());
+
+            BigDecimal priceValue = new BigDecimal("19.95");
+            window.findBigDecimalField().withId("price").setValue(priceValue);
+            var price = window.findBigDecimalField().withId("price");
+            Assertions.assertTrue(price.withValue(priceValue).exists());
+            Assertions.assertFalse(
+                    price.withValue(new BigDecimal("0.00")).exists());
+
+            LocalDate dateValue = LocalDate.of(2026, 5, 28);
+            window.findDatePicker().withId("date").setValue(dateValue);
+            var date = window.findDatePicker().withId("date");
+            Assertions.assertTrue(date.withValue(dateValue).exists());
+            Assertions.assertFalse(
+                    date.withValue(LocalDate.of(1999, 12, 31)).exists());
+
+            var accept = window.findCheckbox().withId("accept");
+            Assertions.assertTrue(accept.withValue(false).exists());
+            Assertions.assertFalse(accept.withValue(true).exists());
+
+            window.findCheckbox().withId("accept").click();
+            Assertions.assertTrue(accept.withValue(true).exists());
+            Assertions.assertFalse(accept.withValue(false).exists());
         }
     }
 

--- a/junit6/src/test/java/com/vaadin/browserless/LocatorApiTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/LocatorApiTest.java
@@ -56,7 +56,7 @@ class LocatorApiTest {
             window.navigate(LocatorDemoView.class);
 
             window.findTextField().withId("name").setValue("World");
-            window.findButton().withCaption("Save").click();
+            window.findButton().withText("Save").click();
 
             // getText() is inherited via SpanTester -> HtmlClickContainer ->
             // HtmlContainerTester. The processor walks the supertype chain, so
@@ -73,7 +73,7 @@ class LocatorApiTest {
             window.navigate(LocatorDemoView.class);
 
             window.findTextField().withId("name").setValue("X");
-            window.findButton().withCaption("Clear").click();
+            window.findButton().withText("Clear").click();
 
             Assertions.assertEquals("", window.findTextField().withId("name")
                     .component().getValue());
@@ -111,7 +111,7 @@ class LocatorApiTest {
             var window = app.newUser().newWindow();
             window.navigate(LocatorDemoView.class);
 
-            var save = window.findButton().withCaption("Save");
+            var save = window.findButton().withText("Save");
             window.findTextField().withId("name").setValue("first");
             save.click();
 
@@ -467,7 +467,7 @@ class LocatorApiTest {
             // atIndex is part of the filter chain — narrowing further
             // does NOT drop the pick. Once the chain is narrowed to a
             // single match, atIndex(2) on a single-match query throws.
-            btn.withCaption("Clear");
+            btn.withText("Clear");
             Assertions.assertThrows(IndexOutOfBoundsException.class,
                     btn::component,
                     "pickIndex stays sticky across filter steps");

--- a/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
+++ b/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
@@ -83,25 +83,59 @@ public class LocatorProcessor extends AbstractProcessor {
 
     /**
      * Mapping from Vaadin {@code Has*} interface FQN to the locator-side
-     * filter-mixin FQN. The processor walks each target's supertype chain
-     * and adds the matching mixin to the generated locator's
+     * filter-mixin descriptor. The processor walks each target's supertype
+     * chain and adds the matching mixin to the generated locator's
      * {@code implements} clause, so e.g. {@code dialogLocator.findButton()
-     * .withLabel("Save")} (Button is HasText, not HasLabel) is a compile
-     * error rather than a silent no-op. Iteration order is deterministic so
-     * generated source is stable across builds.
+     * .withLabel("Save")} (Button is HasText, not HasLabel) is a compile error
+     * rather than a silent no-op. Iteration order is deterministic so generated
+     * source is stable across builds.
+     *
+     * <p>
+     * Two descriptor shapes are supported: {@link Simple} for parameterless
+     * mixins that just need {@code <C, SELF>}, and {@link Typed} for mixins
+     * that need an extra type argument extracted from the matched Vaadin
+     * interface (e.g. {@code HasValue<E, V>}'s {@code V} threaded into
+     * {@code HasValueFilter<C, V, SELF>}).
      */
-    private static final LinkedHashMap<String, String> FILTER_MIXINS = new LinkedHashMap<>();
+    private static final LinkedHashMap<String, FilterMixinHandler> FILTER_MIXINS = new LinkedHashMap<>();
     static {
         FILTER_MIXINS.put("com.vaadin.flow.component.HasLabel",
-                "com.vaadin.browserless.locator.HasLabelFilter");
+                new Simple("com.vaadin.browserless.locator.HasLabelFilter"));
         FILTER_MIXINS.put("com.vaadin.flow.component.HasText",
-                "com.vaadin.browserless.locator.HasTextFilter");
-        FILTER_MIXINS.put("com.vaadin.flow.component.HasAriaLabel",
-                "com.vaadin.browserless.locator.HasAriaLabelFilter");
+                new Simple("com.vaadin.browserless.locator.HasTextFilter"));
+        FILTER_MIXINS.put("com.vaadin.flow.component.HasAriaLabel", new Simple(
+                "com.vaadin.browserless.locator.HasAriaLabelFilter"));
         FILTER_MIXINS.put("com.vaadin.flow.component.HasValue",
-                "com.vaadin.browserless.locator.HasValueFilter");
+                new Typed("com.vaadin.browserless.locator.HasValueFilter", 1));
         FILTER_MIXINS.put("com.vaadin.flow.component.HasTheme",
-                "com.vaadin.browserless.locator.HasThemeFilter");
+                new Simple("com.vaadin.browserless.locator.HasThemeFilter"));
+    }
+
+    /**
+     * Descriptor for a filter mixin entry in {@link #FILTER_MIXINS}. See
+     * {@link Simple} for the common parameterless case and {@link Typed} for
+     * mixins that thread an extra type argument extracted from the matched
+     * Vaadin interface.
+     */
+    private sealed interface FilterMixinHandler permits Simple, Typed {
+        String mixinFqn();
+    }
+
+    /**
+     * A parameterless mixin: the generated locator emits
+     * {@code Mixin<C, SELF>}.
+     */
+    private record Simple(String mixinFqn) implements FilterMixinHandler {
+    }
+
+    /**
+     * A mixin that needs the {@code typeArgIndex}-th type argument of the
+     * matched Vaadin interface inserted between {@code C} and {@code SELF}. For
+     * {@code HasValue<E extends ValueChangeEvent<V>, V>} the index is {@code 1}
+     * (the {@code V}), producing {@code Mixin<C, V, SELF>}.
+     */
+    private record Typed(String mixinFqn,
+            int typeArgIndex) implements FilterMixinHandler {
     }
 
     private static final String OPT_COMMERCIAL_PACKAGES = "locator.commercial.packages";
@@ -335,7 +369,7 @@ public class LocatorProcessor extends AbstractProcessor {
                 out.println("@javax.annotation.processing.Generated(\""
                         + LocatorProcessor.class.getName() + "\")");
                 String filterMixinsImpl = renderFilterMixinImplements(target,
-                        componentTypeExpr, selfType);
+                        componentTypeExpr, selfType, freeExtras);
                 out.println("public class " + locatorSimple
                         + locatorTypeParamDecl + " extends " + LOCATOR_FQN + "<"
                         + componentTypeExpr + ", " + selfType + "> implements "
@@ -481,60 +515,171 @@ public class LocatorProcessor extends AbstractProcessor {
     }
 
     /**
-     * Walks the target's supertype chain looking for {@code interfaceFqn} in
-     * the transitive interface set. Returns {@code true} on first hit. Stops
-     * at the top of the chain naturally because
-     * {@link Types#directSupertypes(TypeMirror)} returns the empty list for
-     * {@code java.lang.Object}.
-     */
-    private boolean implementsInterface(TypeElement target,
-            String interfaceFqn) {
-        TypeElement itf = processingEnv.getElementUtils()
-                .getTypeElement(interfaceFqn);
-        if (itf == null) {
-            // The interface isn't on the classpath of the compiled module
-            // (e.g. a tester module that doesn't ship flow-server). Skip
-            // the mixin rather than failing the build.
-            return false;
-        }
-        TypeMirror erasure = processingEnv.getTypeUtils()
-                .erasure(itf.asType());
-        return containsErasure(target.asType(), erasure);
-    }
-
-    private boolean containsErasure(TypeMirror tm, TypeMirror erasure) {
-        if (tm == null || tm.getKind() != TypeKind.DECLARED) {
-            return false;
-        }
-        Types types = processingEnv.getTypeUtils();
-        if (types.isSameType(types.erasure(tm), erasure)) {
-            return true;
-        }
-        for (TypeMirror sup : types.directSupertypes(tm)) {
-            if (containsErasure(sup, erasure)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Build the comma-prefixed implements-clause fragment for the filter
-     * mixins that apply to {@code target}. The returned string starts with
+     * Build the comma-prefixed implements-clause fragment for the filter mixins
+     * that apply to {@code target}. The returned string starts with
      * {@code ", "} when non-empty, so it appends cleanly after the existing
      * {@code Clickable<...>} implements entry; empty when none apply.
      */
     private String renderFilterMixinImplements(TypeElement target,
-            String componentTypeExpr, String selfType) {
+            String componentTypeExpr, String selfType,
+            List<TypeParameterElement> freeExtras) {
+        Map<String, TypeMirror> supertypes = indexSupertypes(target);
         StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> e : FILTER_MIXINS.entrySet()) {
-            if (implementsInterface(target, e.getKey())) {
-                sb.append(", ").append(e.getValue()).append('<')
-                        .append(componentTypeExpr).append(", ").append(selfType)
-                        .append('>');
+        for (Map.Entry<String, FilterMixinHandler> e : FILTER_MIXINS
+                .entrySet()) {
+            TypeMirror match = supertypes.get(e.getKey());
+            if (match == null) {
+                continue;
+            }
+            switch (e.getValue()) {
+            case Simple s -> sb.append(", ").append(s.mixinFqn()).append('<')
+                    .append(componentTypeExpr).append(", ").append(selfType)
+                    .append('>');
+            case Typed t -> {
+                String extracted = extractTypeArg(match, t.typeArgIndex(),
+                        target, freeExtras);
+                if (extracted == null) {
+                    note(Diagnostic.Kind.NOTE,
+                            "Skipping " + t.mixinFqn() + " for "
+                                    + target.getQualifiedName()
+                                    + ": cannot resolve type-arg index "
+                                    + t.typeArgIndex() + " of " + e.getKey()
+                                    + " (raw, wildcard, or unmapped type"
+                                    + " variable).");
+                } else {
+                    sb.append(", ").append(t.mixinFqn()).append('<')
+                            .append(componentTypeExpr).append(", ")
+                            .append(extracted).append(", ").append(selfType)
+                            .append('>');
+                }
+            }
             }
         }
         return sb.toString();
+    }
+
+    /**
+     * Walk the target's supertype graph once and index every declared supertype
+     * by its erased FQN, keyed to the parameterized form. The
+     * {@link Map#putIfAbsent} guard both breaks diamond cycles and makes the
+     * traversal O(unique supertypes) regardless of how many filter mixins query
+     * it afterwards.
+     */
+    private Map<String, TypeMirror> indexSupertypes(TypeElement target) {
+        Map<String, TypeMirror> idx = new HashMap<>();
+        collectSupertypes(target.asType(), idx);
+        return idx;
+    }
+
+    private void collectSupertypes(TypeMirror tm, Map<String, TypeMirror> idx) {
+        if (tm == null || tm.getKind() != TypeKind.DECLARED) {
+            return;
+        }
+        Types types = processingEnv.getTypeUtils();
+        String erasedFqn = types.erasure(tm).toString();
+        if (idx.putIfAbsent(erasedFqn, tm) != null) {
+            return;
+        }
+        for (TypeMirror sup : types.directSupertypes(tm)) {
+            collectSupertypes(sup, idx);
+        }
+    }
+
+    /**
+     * Extract type-argument {@code idx} from {@code parameterizedMatch} (the
+     * target's parameterization of a matched Vaadin interface) and render it as
+     * a Java type expression, substituting the target's type-parameter names
+     * with the locator's free-extra names so the result is valid in the
+     * locator's class header.
+     * <p>
+     * Returns {@code null} to signal "unresolvable" in three defense-in-depth
+     * cases — raw interface use, top-level wildcard, or a type variable that
+     * isn't in the substitution map. None of the current Vaadin components hit
+     * these; callers should emit a {@link Diagnostic.Kind#NOTE} so a future
+     * component that does is visible.
+     */
+    private String extractTypeArg(TypeMirror parameterizedMatch, int idx,
+            TypeElement target, List<TypeParameterElement> freeExtras) {
+        if (parameterizedMatch == null
+                || parameterizedMatch.getKind() != TypeKind.DECLARED) {
+            return null;
+        }
+        List<? extends TypeMirror> args = ((DeclaredType) parameterizedMatch)
+                .getTypeArguments();
+        if (args.size() <= idx) {
+            return null;
+        }
+        TypeMirror arg = args.get(idx);
+        if (arg.getKind() == TypeKind.WILDCARD) {
+            // Top-level wildcards are illegal as a class-header type argument
+            // — e.g. `implements HasValueFilter<C, ?, SELF>` does not compile.
+            return null;
+        }
+        Map<String, String> subst = buildTargetSubst(target, freeExtras);
+        String rendered = new SubstitutingTypeRenderer(subst).visit(arg);
+        // A target type variable substituted to "?" (no matching free extra)
+        // would render as a top-level wildcard, which is illegal in a class
+        // header — guard the rendered form too, not just the kind of `arg`.
+        if (rendered.equals("?") || rendered.startsWith("? extends ")
+                || rendered.startsWith("? super ")) {
+            return null;
+        }
+        // If the rendered form still references a type variable that wasn't in
+        // the substitution map, it would emit an unbound name in the locator
+        // header. SubstitutingTypeRenderer falls back to the variable's own
+        // simple name, so we detect by re-checking the rendered form against
+        // the target's type parameters that don't have a substitution.
+        for (TypeParameterElement tp : target.getTypeParameters()) {
+            String name = tp.getSimpleName().toString();
+            if (!subst.containsKey(name) && containsName(rendered, name)) {
+                return null;
+            }
+        }
+        return rendered;
+    }
+
+    /**
+     * Build the positional {@code target-TP-name → freeExtra-name} map used to
+     * rename type-variable references from the target's namespace into the
+     * locator's namespace. Mirrors {@link #renderTargetTypeExpr}'s positional
+     * substitution and {@code ?} fallback when there's no matching free extra.
+     */
+    private Map<String, String> buildTargetSubst(TypeElement target,
+            List<TypeParameterElement> freeExtras) {
+        Map<String, String> subst = new HashMap<>();
+        List<? extends TypeParameterElement> targetTps = target
+                .getTypeParameters();
+        for (int i = 0; i < targetTps.size(); i++) {
+            String name = targetTps.get(i).getSimpleName().toString();
+            if (i < freeExtras.size()) {
+                subst.put(name, freeExtras.get(i).getSimpleName().toString());
+            } else {
+                subst.put(name, "?");
+            }
+        }
+        return subst;
+    }
+
+    private static boolean containsName(String s, String name) {
+        // Whole-word match so "T" doesn't match inside "TextField".
+        int len = s.length();
+        int nlen = name.length();
+        int from = 0;
+        while (from <= len - nlen) {
+            int hit = s.indexOf(name, from);
+            if (hit < 0) {
+                return false;
+            }
+            boolean leftOk = hit == 0
+                    || !Character.isJavaIdentifierPart(s.charAt(hit - 1));
+            boolean rightOk = hit + nlen == len
+                    || !Character.isJavaIdentifierPart(s.charAt(hit + nlen));
+            if (leftOk && rightOk) {
+                return true;
+            }
+            from = hit + 1;
+        }
+        return false;
     }
 
     private TypeMirror findInstanceOf(TypeMirror tm, TypeMirror targetErasure) {

--- a/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
+++ b/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
@@ -80,6 +80,30 @@ public class LocatorProcessor extends AbstractProcessor {
     private static final String COMPONENT_TESTER_FQN = "com.vaadin.browserless.ComponentTester";
     private static final String LOCATOR_FQN = "com.vaadin.browserless.locator.Locator";
     private static final String CLICKABLE_FQN = "com.vaadin.browserless.Clickable";
+
+    /**
+     * Mapping from Vaadin {@code Has*} interface FQN to the locator-side
+     * filter-mixin FQN. The processor walks each target's supertype chain
+     * and adds the matching mixin to the generated locator's
+     * {@code implements} clause, so e.g. {@code dialogLocator.findButton()
+     * .withLabel("Save")} (Button is HasText, not HasLabel) is a compile
+     * error rather than a silent no-op. Iteration order is deterministic so
+     * generated source is stable across builds.
+     */
+    private static final LinkedHashMap<String, String> FILTER_MIXINS = new LinkedHashMap<>();
+    static {
+        FILTER_MIXINS.put("com.vaadin.flow.component.HasLabel",
+                "com.vaadin.browserless.locator.HasLabelFilter");
+        FILTER_MIXINS.put("com.vaadin.flow.component.HasText",
+                "com.vaadin.browserless.locator.HasTextFilter");
+        FILTER_MIXINS.put("com.vaadin.flow.component.HasAriaLabel",
+                "com.vaadin.browserless.locator.HasAriaLabelFilter");
+        FILTER_MIXINS.put("com.vaadin.flow.component.HasValue",
+                "com.vaadin.browserless.locator.HasValueFilter");
+        FILTER_MIXINS.put("com.vaadin.flow.component.HasTheme",
+                "com.vaadin.browserless.locator.HasThemeFilter");
+    }
+
     private static final String OPT_COMMERCIAL_PACKAGES = "locator.commercial.packages";
     private static final String OPT_ENTRYPOINT_FQN = "locator.entrypoint.fqn";
     private static final String OPT_COMMERCIAL_ENTRYPOINT_FQN = "locator.commercial.entrypoint.fqn";
@@ -310,10 +334,13 @@ public class LocatorProcessor extends AbstractProcessor {
                 out.print(renderClassJavadoc(target, tester));
                 out.println("@javax.annotation.processing.Generated(\""
                         + LocatorProcessor.class.getName() + "\")");
+                String filterMixinsImpl = renderFilterMixinImplements(target,
+                        componentTypeExpr, selfType);
                 out.println("public class " + locatorSimple
                         + locatorTypeParamDecl + " extends " + LOCATOR_FQN + "<"
                         + componentTypeExpr + ", " + selfType + "> implements "
-                        + CLICKABLE_FQN + "<" + componentTypeExpr + "> {");
+                        + CLICKABLE_FQN + "<" + componentTypeExpr + ">"
+                        + filterMixinsImpl + " {");
                 out.println();
                 out.println(ctor);
                 out.println(useCtor);
@@ -451,6 +478,63 @@ public class LocatorProcessor extends AbstractProcessor {
             }
         }
         return pinned;
+    }
+
+    /**
+     * Walks the target's supertype chain looking for {@code interfaceFqn} in
+     * the transitive interface set. Returns {@code true} on first hit. Stops
+     * at the top of the chain naturally because
+     * {@link Types#directSupertypes(TypeMirror)} returns the empty list for
+     * {@code java.lang.Object}.
+     */
+    private boolean implementsInterface(TypeElement target,
+            String interfaceFqn) {
+        TypeElement itf = processingEnv.getElementUtils()
+                .getTypeElement(interfaceFqn);
+        if (itf == null) {
+            // The interface isn't on the classpath of the compiled module
+            // (e.g. a tester module that doesn't ship flow-server). Skip
+            // the mixin rather than failing the build.
+            return false;
+        }
+        TypeMirror erasure = processingEnv.getTypeUtils()
+                .erasure(itf.asType());
+        return containsErasure(target.asType(), erasure);
+    }
+
+    private boolean containsErasure(TypeMirror tm, TypeMirror erasure) {
+        if (tm == null || tm.getKind() != TypeKind.DECLARED) {
+            return false;
+        }
+        Types types = processingEnv.getTypeUtils();
+        if (types.isSameType(types.erasure(tm), erasure)) {
+            return true;
+        }
+        for (TypeMirror sup : types.directSupertypes(tm)) {
+            if (containsErasure(sup, erasure)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Build the comma-prefixed implements-clause fragment for the filter
+     * mixins that apply to {@code target}. The returned string starts with
+     * {@code ", "} when non-empty, so it appends cleanly after the existing
+     * {@code Clickable<...>} implements entry; empty when none apply.
+     */
+    private String renderFilterMixinImplements(TypeElement target,
+            String componentTypeExpr, String selfType) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> e : FILTER_MIXINS.entrySet()) {
+            if (implementsInterface(target, e.getKey())) {
+                sb.append(", ").append(e.getValue()).append('<')
+                        .append(componentTypeExpr).append(", ").append(selfType)
+                        .append('>');
+            }
+        }
+        return sb.toString();
     }
 
     private TypeMirror findInstanceOf(TypeMirror tm, TypeMirror targetErasure) {

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasAriaLabelFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasAriaLabelFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.locator;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasAriaLabel;
+
+/**
+ * Mixin for {@link Locator}s whose target component implements
+ * {@link HasAriaLabel}. Exposes {@code aria-label}-based filter methods that
+ * would be meaningless on components that don't expose the attribute, turning
+ * an inapplicable call into a compile error rather than a silent no-op.
+ *
+ * @param <C>
+ *            the component type, bound to {@link HasAriaLabel}
+ * @param <SELF>
+ *            the concrete locator subtype, used for fluent chaining
+ */
+public interface HasAriaLabelFilter<C extends Component & HasAriaLabel, SELF extends Locator<C, SELF>> {
+
+    /**
+     * Requires the matched component's {@code aria-label} attribute to be
+     * exactly the given value.
+     */
+    @SuppressWarnings("unchecked")
+    default SELF withAriaLabel(String ariaLabel) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withAriaLabel(ariaLabel));
+    }
+
+    /**
+     * Requires the matched component's {@code aria-label} attribute to contain
+     * the given text.
+     */
+    @SuppressWarnings("unchecked")
+    default SELF withAriaLabelContaining(String text) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withAriaLabelContaining(text));
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasLabelFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasLabelFilter.java
@@ -22,9 +22,9 @@ import com.vaadin.flow.component.HasLabel;
  * Mixin for {@link Locator}s whose target component implements
  * {@link HasLabel}. Exposes label-based filter methods that would be
  * meaningless on components without a label, turning a call like
- * {@code findButton().withLabel("Save")} (Button is {@link
- * com.vaadin.flow.component.HasText}, not {@code HasLabel}) into a compile
- * error rather than a silent no-op.
+ * {@code findButton().withLabel("Save")} (Button is
+ * {@link com.vaadin.flow.component.HasText}, not {@code HasLabel}) into a
+ * compile error rather than a silent no-op.
  *
  * @param <C>
  *            the component type, bound to {@link HasLabel}
@@ -40,8 +40,7 @@ public interface HasLabelFilter<C extends Component & HasLabel, SELF extends Loc
      */
     @SuppressWarnings("unchecked")
     default SELF withLabel(String label) {
-        return ((Locator<C, SELF>) this)
-                .applyFilter(q -> q.withLabel(label));
+        return ((Locator<C, SELF>) this).applyFilter(q -> q.withLabel(label));
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasLabelFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasLabelFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.locator;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasLabel;
+
+/**
+ * Mixin for {@link Locator}s whose target component implements
+ * {@link HasLabel}. Exposes label-based filter methods that would be
+ * meaningless on components without a label, turning a call like
+ * {@code findButton().withLabel("Save")} (Button is {@link
+ * com.vaadin.flow.component.HasText}, not {@code HasLabel}) into a compile
+ * error rather than a silent no-op.
+ *
+ * @param <C>
+ *            the component type, bound to {@link HasLabel}
+ * @param <SELF>
+ *            the concrete locator subtype, used for fluent chaining
+ */
+public interface HasLabelFilter<C extends Component & HasLabel, SELF extends Locator<C, SELF>> {
+
+    /**
+     * Requires the matched component's {@code label} property to be exactly the
+     * given value. Use this for form fields where the end user identifies a
+     * field by its label.
+     */
+    @SuppressWarnings("unchecked")
+    default SELF withLabel(String label) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withLabel(label));
+    }
+
+    /**
+     * Requires the matched component's {@code label} property to contain the
+     * given text.
+     */
+    @SuppressWarnings("unchecked")
+    default SELF withLabelContaining(String text) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withLabelContaining(text));
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasTextFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasTextFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.locator;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasText;
+
+/**
+ * Mixin for {@link Locator}s whose target component implements
+ * {@link HasText}. Exposes text-based filter methods that would be
+ * meaningless on components without textual content, turning a call like
+ * {@code findTextField().withText("foo")} ({@code TextField} is
+ * {@link com.vaadin.flow.component.HasValue}/{@link
+ * com.vaadin.flow.component.HasLabel}, not {@code HasText}) into a compile
+ * error rather than a silent no-op.
+ *
+ * @param <C>
+ *            the component type, bound to {@link HasText}
+ * @param <SELF>
+ *            the concrete locator subtype, used for fluent chaining
+ */
+public interface HasTextFilter<C extends Component & HasText, SELF extends Locator<C, SELF>> {
+
+    /** Requires the text content of the component to equal the given text. */
+    @SuppressWarnings("unchecked")
+    default SELF withText(String text) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withText(text));
+    }
+
+    /** Requires the text content of the component to contain the given text. */
+    @SuppressWarnings("unchecked")
+    default SELF withTextContaining(String text) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withTextContaining(text));
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasTextFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasTextFilter.java
@@ -19,13 +19,12 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasText;
 
 /**
- * Mixin for {@link Locator}s whose target component implements
- * {@link HasText}. Exposes text-based filter methods that would be
- * meaningless on components without textual content, turning a call like
+ * Mixin for {@link Locator}s whose target component implements {@link HasText}.
+ * Exposes text-based filter methods that would be meaningless on components
+ * without textual content, turning a call like
  * {@code findTextField().withText("foo")} ({@code TextField} is
- * {@link com.vaadin.flow.component.HasValue}/{@link
- * com.vaadin.flow.component.HasLabel}, not {@code HasText}) into a compile
- * error rather than a silent no-op.
+ * {@link com.vaadin.flow.component.HasValue}/{@link com.vaadin.flow.component.HasLabel},
+ * not {@code HasText}) into a compile error rather than a silent no-op.
  *
  * @param <C>
  *            the component type, bound to {@link HasText}
@@ -37,8 +36,7 @@ public interface HasTextFilter<C extends Component & HasText, SELF extends Locat
     /** Requires the text content of the component to equal the given text. */
     @SuppressWarnings("unchecked")
     default SELF withText(String text) {
-        return ((Locator<C, SELF>) this)
-                .applyFilter(q -> q.withText(text));
+        return ((Locator<C, SELF>) this).applyFilter(q -> q.withText(text));
     }
 
     /** Requires the text content of the component to contain the given text. */

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.locator;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasTheme;
+
+/**
+ * Mixin for {@link Locator}s whose target component implements
+ * {@link HasTheme}. Exposes theme-based filter methods that would be
+ * meaningless on components without theme support, turning an inapplicable
+ * call into a compile error rather than a silent no-op.
+ *
+ * @param <C>
+ *            the component type, bound to {@link HasTheme}
+ * @param <SELF>
+ *            the concrete locator subtype, used for fluent chaining
+ */
+public interface HasThemeFilter<C extends Component & HasTheme, SELF extends Locator<C, SELF>> {
+
+    /** Requires the matched component to have the given theme set. */
+    @SuppressWarnings("unchecked")
+    default SELF withTheme(String theme) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withTheme(theme));
+    }
+
+    /** Requires the matched component to not have the given theme set. */
+    @SuppressWarnings("unchecked")
+    default SELF withoutTheme(String theme) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withoutTheme(theme));
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
@@ -21,8 +21,8 @@ import com.vaadin.flow.component.HasTheme;
 /**
  * Mixin for {@link Locator}s whose target component implements
  * {@link HasTheme}. Exposes theme-based filter methods that would be
- * meaningless on components without theme support, turning an inapplicable
- * call into a compile error rather than a silent no-op.
+ * meaningless on components without theme support, turning an inapplicable call
+ * into a compile error rather than a silent no-op.
  *
  * @param <C>
  *            the component type, bound to {@link HasTheme}
@@ -34,8 +34,7 @@ public interface HasThemeFilter<C extends Component & HasTheme, SELF extends Loc
     /** Requires the matched component to have the given theme set. */
     @SuppressWarnings("unchecked")
     default SELF withTheme(String theme) {
-        return ((Locator<C, SELF>) this)
-                .applyFilter(q -> q.withTheme(theme));
+        return ((Locator<C, SELF>) this).applyFilter(q -> q.withTheme(theme));
     }
 
     /** Requires the matched component to not have the given theme set. */

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasValueFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasValueFilter.java
@@ -24,16 +24,22 @@ import com.vaadin.flow.component.HasValue;
  * be meaningless on components without a value, turning an inapplicable call
  * into a compile error rather than a silent no-op.
  * <p>
- * The {@code HasValue<?, ?>} bound keeps this mixin signature simple: the
- * underlying {@link com.vaadin.browserless.ComponentQuery#withValue} takes a
- * raw {@code V}, so threading the value type through here buys nothing.
+ * The value type {@code V} is threaded through the mixin header so the compiler
+ * enforces it against the component's actual value type: e.g.
+ * {@code findTextField().withValue(42)} fails to compile because
+ * {@code TextField} is {@code HasValue<?, String>}, not
+ * {@code HasValue<?, Integer>}.
  *
  * @param <C>
- *            the component type, bound to {@link HasValue}
+ *            the component type, bound to {@link HasValue} with value type
+ *            {@code V}
+ * @param <V>
+ *            the value type exposed by the component's {@link HasValue}
+ *            parameterization
  * @param <SELF>
  *            the concrete locator subtype, used for fluent chaining
  */
-public interface HasValueFilter<C extends Component & HasValue<?, ?>, SELF extends Locator<C, SELF>> {
+public interface HasValueFilter<C extends Component & HasValue<?, V>, V, SELF extends Locator<C, SELF>> {
 
     /**
      * Requires the matched component to implement {@code HasValue} and to have
@@ -41,7 +47,7 @@ public interface HasValueFilter<C extends Component & HasValue<?, ?>, SELF exten
      * {@code null}.
      */
     @SuppressWarnings("unchecked")
-    default <V> SELF withValue(V expectedValue) {
+    default SELF withValue(V expectedValue) {
         return ((Locator<C, SELF>) this)
                 .applyFilter(q -> q.withValue(expectedValue));
     }

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasValueFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasValueFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.locator;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasValue;
+
+/**
+ * Mixin for {@link Locator}s whose target component implements
+ * {@link HasValue}. Exposes the {@code withValue} filter that would otherwise
+ * be meaningless on components without a value, turning an inapplicable call
+ * into a compile error rather than a silent no-op.
+ * <p>
+ * The {@code HasValue<?, ?>} bound keeps this mixin signature simple: the
+ * underlying {@link com.vaadin.browserless.ComponentQuery#withValue} takes a
+ * raw {@code V}, so threading the value type through here buys nothing.
+ *
+ * @param <C>
+ *            the component type, bound to {@link HasValue}
+ * @param <SELF>
+ *            the concrete locator subtype, used for fluent chaining
+ */
+public interface HasValueFilter<C extends Component & HasValue<?, ?>, SELF extends Locator<C, SELF>> {
+
+    /**
+     * Requires the matched component to implement {@code HasValue} and to have
+     * the given value. Has no effect when {@code expectedValue} is
+     * {@code null}.
+     */
+    @SuppressWarnings("unchecked")
+    default <V> SELF withValue(V expectedValue) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withValue(expectedValue));
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/locator/Locator.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/Locator.java
@@ -314,15 +314,14 @@ public abstract class Locator<C extends Component, SELF extends Locator<C, SELF>
     }
 
     /**
-     * Package-private hook for mixin interfaces in the same package
-     * (e.g. {@link HasLabelFilter}, {@link HasTextFilter}). Resets the
-     * resolution cache, applies the given operation to the underlying
+     * Package-private hook for mixin interfaces in the same package (e.g.
+     * {@link HasLabelFilter}, {@link HasTextFilter}). Resets the resolution
+     * cache, applies the given operation to the underlying
      * {@link ComponentQuery}, and returns {@code self()} for fluent chaining.
      * <p>
      * Mixin defaults call this from a {@code default} method bound to a
-     * specific Vaadin {@code Has*} interface, which gates the filter at
-     * compile time to component types where the filter is actually
-     * meaningful.
+     * specific Vaadin {@code Has*} interface, which gates the filter at compile
+     * time to component types where the filter is actually meaningful.
      */
     SELF applyFilter(Consumer<ComponentQuery<C>> op) {
         resetCache();

--- a/shared/src/main/java/com/vaadin/browserless/locator/Locator.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/Locator.java
@@ -17,6 +17,7 @@ package com.vaadin.browserless.locator;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
@@ -105,80 +106,6 @@ public abstract class Locator<C extends Component, SELF extends Locator<C, SELF>
         return self();
     }
 
-    /**
-     * Requires the matched component to have a caption equal to the given text.
-     */
-    public SELF withCaption(String caption) {
-        resetCache();
-        query.withCaption(caption);
-        return self();
-    }
-
-    /**
-     * Requires the matched component to have a caption containing the given
-     * text.
-     */
-    public SELF withCaptionContaining(String text) {
-        resetCache();
-        query.withCaptionContaining(text);
-        return self();
-    }
-
-    /**
-     * Requires the matched component's {@code label} property to be exactly the
-     * given value. Use this for form fields where the end user identifies a
-     * field by its label.
-     */
-    public SELF withLabel(String label) {
-        resetCache();
-        query.withLabel(label);
-        return self();
-    }
-
-    /**
-     * Requires the matched component's {@code label} property to contain the
-     * given text.
-     */
-    public SELF withLabelContaining(String text) {
-        resetCache();
-        query.withLabelContaining(text);
-        return self();
-    }
-
-    /**
-     * Requires the matched component's {@code aria-label} attribute to be
-     * exactly the given value.
-     */
-    public SELF withAriaLabel(String ariaLabel) {
-        resetCache();
-        query.withAriaLabel(ariaLabel);
-        return self();
-    }
-
-    /**
-     * Requires the matched component's {@code aria-label} attribute to contain
-     * the given text.
-     */
-    public SELF withAriaLabelContaining(String text) {
-        resetCache();
-        query.withAriaLabelContaining(text);
-        return self();
-    }
-
-    /** Requires the text content of the component to equal the given text. */
-    public SELF withText(String text) {
-        resetCache();
-        query.withText(text);
-        return self();
-    }
-
-    /** Requires the text content of the component to contain the given text. */
-    public SELF withTextContaining(String text) {
-        resetCache();
-        query.withTextContaining(text);
-        return self();
-    }
-
     /** Requires the matched component to have all the given CSS class names. */
     public SELF withClassName(String... className) {
         resetCache();
@@ -192,20 +119,6 @@ public abstract class Locator<C extends Component, SELF extends Locator<C, SELF>
     public SELF withoutClassName(String... className) {
         resetCache();
         query.withoutClassName(className);
-        return self();
-    }
-
-    /** Requires the matched component to have the given theme set. */
-    public SELF withTheme(String theme) {
-        resetCache();
-        query.withTheme(theme);
-        return self();
-    }
-
-    /** Requires the matched component to not have the given theme set. */
-    public SELF withoutTheme(String theme) {
-        resetCache();
-        query.withoutTheme(theme);
         return self();
     }
 
@@ -240,17 +153,6 @@ public abstract class Locator<C extends Component, SELF extends Locator<C, SELF>
     public SELF withoutAttribute(String attribute, String value) {
         resetCache();
         query.withoutAttribute(attribute, value);
-        return self();
-    }
-
-    /**
-     * Requires the matched component to implement {@code HasValue} and to have
-     * the given value. Has no effect when {@code expectedValue} is
-     * {@code null}.
-     */
-    public <V> SELF withValue(V expectedValue) {
-        resetCache();
-        query.withValue(expectedValue);
         return self();
     }
 
@@ -408,6 +310,23 @@ public abstract class Locator<C extends Component, SELF extends Locator<C, SELF>
     public SELF invalidate() {
         resetCache();
         pickIndex = 0;
+        return self();
+    }
+
+    /**
+     * Package-private hook for mixin interfaces in the same package
+     * (e.g. {@link HasLabelFilter}, {@link HasTextFilter}). Resets the
+     * resolution cache, applies the given operation to the underlying
+     * {@link ComponentQuery}, and returns {@code self()} for fluent chaining.
+     * <p>
+     * Mixin defaults call this from a {@code default} method bound to a
+     * specific Vaadin {@code Has*} interface, which gates the filter at
+     * compile time to component types where the filter is actually
+     * meaningful.
+     */
+    SELF applyFilter(Consumer<ComponentQuery<C>> op) {
+        resetCache();
+        op.accept(query);
         return self();
     }
 


### PR DESCRIPTION
Filter methods on the generated *Locator classes that only make sense for specific Vaadin capabilities used to be inherited unconditionally from the base Locator. That meant calls like
`dialogLocator.findButton().withLabel("Save")` compiled fine but silently no-op'd — Button doesn't implement HasLabel (only HasText). Bad DX. After this change the same call is a compile error and the IDE only suggests filters that actually apply.

Treating this as a bugfix rather than a feature: the new Locator API isn't in a stable release yet, so no deprecation cycle is owed for the methods that moved off the base or for the dropped `withCaption*`.

The mechanism — five small mixin interfaces in
`com.vaadin.browserless.locator`, each mirroring a Vaadin `HasX` interface:

  - HasLabelFilter      — withLabel, withLabelContaining
  - HasTextFilter       — withText, withTextContaining
  - HasAriaLabelFilter  — withAriaLabel, withAriaLabelContaining
  - HasValueFilter      — withValue
  - HasThemeFilter      — withTheme, withoutTheme

Each mixin is parameterized as `<C extends Component & HasX, SELF extends Locator<C, SELF>>` and exposes the filters as default methods that route through a new package-private `Locator.applyFilter(Consumer <ComponentQuery<C>>)` hook. The unchecked cast inside each default is safe by the SELF self-type bound.

Base Locator keeps the always-applicable filters: withId, withClassName/ withoutClassName, withAttribute*, withCondition, with(UnaryOperator), inside, atIndex.

withCaption / withCaptionContaining are dropped entirely from Locator. Callers were expected to use the typed alternatives (withLabel / withText / withAriaLabel) anyway. ComponentQuery's own withCaption stays put — that's the older API and is not in scope for this fix.

LocatorProcessor changes:

  - New FILTER_MIXINS map (LinkedHashMap for deterministic emit order) mapping each Vaadin HasX FQN to its corresponding mixin FQN.
  - New implementsInterface() / containsErasure() helpers that walk target.asType() through Types.directSupertypes() recursively.
  - renderFilterMixinImplements() builds the parameterized HasXFilter<componentType, selfType> entries and appends them to the existing `implements Clickable<...>` clause.
  - Targets that match no HasX interface emit unchanged output.

Verified on the generated output:

  - ButtonLocator implements Clickable + HasTextFilter + HasAriaLabelFilter + HasThemeFilter (no HasLabelFilter, no HasValueFilter — Button doesn't implement those).
  - TextFieldLocator implements all of HasLabelFilter + HasAriaLabelFilter + HasValueFilter + HasThemeFilter.
  - SpanLocator implements just Clickable + HasTextFilter.

Demonstrated compile error after the change:
    new ButtonLocator().withLabel("Save") produces "method withLabel cannot be found", while
    new ButtonLocator().withText("Save")
and
    new TextFieldLocator().withLabel("Email")
still compile.

Migration in this commit:

  - LocatorApiTest.java — 4 sites of `findButton().withCaption("X")` rewritten to `findButton().withText("X")`. (The button text "Save" / "Clear" was always what the caption was resolving to via the fallback chain.) One additional site that uses `ComponentQuery.withCaption` inside a `.with(q -> ...)` escape hatch is unchanged — that's ComponentQuery's API, not Locator's.
  - PersonFormLocator (hand-written test fixture) — no changes needed; PersonForm doesn't implement any of the gated interfaces and the locator doesn't call any of the moved filters.

For end users with hand-written custom Locators: opt in to a given filter by adding the mixin to your own `implements` clause. The mechanism is symmetric with the generated locators.

Validation: all 4 test suites green (1012 + 20 + 29 + 27).