### PR TITLE
fix: don't leak count=(1,1) from `ComponentQuery.find()`

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -934,6 +934,26 @@ class ComponentQueryTest extends BrowserlessTest {
     }
 
     @Test
+    void single_doesNotLeakResultsSizeConstraint() {
+        Div div1 = new Div();
+        Div div2 = new Div();
+        UI.getCurrent().getElement().appendChild(div1.getElement(),
+                div2.getElement());
+
+        ComponentQuery<Div> query = find(Div.class)
+                .withCondition(d -> d == div1);
+        Assertions.assertSame(div1, query.single());
+
+        // After single(), the spec's count must be back to whatever
+        // it was before (default (0, MAX) here). Narrowing to zero
+        // matches and calling all() must not trip the count
+        // assertion.
+        query.withCondition(d -> false);
+        Assertions.assertTrue(query.all().isEmpty(),
+                "single() must not leak (1, 1) into the query spec");
+    }
+
+    @Test
     void withMaxResults_resultsSizeWithinUpperBound_getsComponents() {
         Div div1 = new Div();
         Div div2 = new Div();

--- a/junit6/src/test/java/com/vaadin/browserless/LocatorApiTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/LocatorApiTest.java
@@ -481,6 +481,70 @@ class LocatorApiTest {
     }
 
     @Test
+    void invalidate_clearsAtIndexPick_soNextComponentCallExpectsSingleMatch() {
+        try (var app = createApplicationContext()) {
+            var window = app.newUser().newWindow();
+            window.navigate(LocatorDemoView.class);
+
+            var btn = window.findButton().atIndex(1);
+            Assertions.assertTrue(btn.exists());
+            Assertions.assertNotNull(btn.component());
+
+            btn.invalidate();
+
+            // The filter chain itself is intact, so exists() still
+            // sees the three buttons. But component() now falls back
+            // to single() because invalidate() rewound the atIndex
+            // pick — that is the documented "single match expected"
+            // contract until the caller re-applies atIndex(int).
+            Assertions.assertTrue(btn.exists());
+            Assertions.assertThrows(NoSuchElementException.class,
+                    btn::component);
+        }
+    }
+
+    @Test
+    void invalidate_preservesFilterSetResultsSize() {
+        try (var app = createApplicationContext()) {
+            var window = app.newUser().newWindow();
+            window.navigate(LocatorDemoView.class);
+
+            var btn = window.findButton().with(q -> q.withResultsSize(1));
+            Assertions.assertThrows(AssertionError.class, btn::exists,
+                    "count=(1,1) on 3 matches must fail");
+
+            btn.invalidate();
+
+            // invalidate() rewinds resolution state but not the
+            // filter chain. A user-set results-size constraint is
+            // part of the chain and must survive.
+            Assertions.assertThrows(AssertionError.class, btn::exists,
+                    "invalidate() must preserve user-set results-size");
+        }
+    }
+
+    @Test
+    void singleResolutionDoesNotLeakCountConstraint() {
+        try (var app = createApplicationContext()) {
+            var window = app.newUser().newWindow();
+            window.navigate(LocatorDemoView.class);
+
+            // withId narrows to (0, 1). component() routes through
+            // single() → find(); the (1, 1) it forces internally
+            // must not leak into the persistent query spec.
+            var loc = window.findTextField().withId("name");
+            Assertions.assertNotNull(loc.component());
+
+            // Narrow the chain to zero matches. With (0, 1)
+            // preserved, exists() simply returns false. With a
+            // leaked (1, 1), the count check throws.
+            loc.withCaption("definitely-no-such-caption-12345");
+            Assertions.assertFalse(loc.exists(),
+                    "find() must not leak (1, 1) into the filter chain");
+        }
+    }
+
+    @Test
     void atIndex_zeroOrNegativeThrows() {
         // No app context needed — the validation runs on the locator itself
         // before any resolution attempt.

--- a/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
@@ -617,8 +617,6 @@ public class ComponentQuery<T extends Component> {
     public T id(String id) {
         Objects.requireNonNull(id, "id must not be null");
         withId(id);
-        // Exactly one element with given id is expected
-        locatorSpec.count = new IntRange(1, 1);
         return find();
     }
 
@@ -663,6 +661,10 @@ public class ComponentQuery<T extends Component> {
     }
 
     protected T find() {
+        // Snapshot and restore so resolution's "expect exactly one"
+        // constraint doesn't leak into the persistent spec and
+        // pollute later chain steps.
+        IntRange savedCount = locatorSpec.count;
         locatorSpec.count = new IntRange(1, 1);
         try {
             if (context != null) {
@@ -673,6 +675,8 @@ public class ComponentQuery<T extends Component> {
         } catch (AssertionError e) {
             // Happens when found component(s) are not of the expected type
             throw new NoSuchElementException(e.getMessage());
+        } finally {
+            locatorSpec.count = savedCount;
         }
     }
 


### PR DESCRIPTION
`find()` permanently set `locatorSpec.count = (1,1)` before running the search. The mutation persisted after the call, so subsequent `withMinResults`/`withMaxResults` composed against the leaked range, and follow-up `all()`/`exists()` calls failed the count assertion on any zero- or multi-match chain.

Snapshot the count on entry and restore it in a `finally` block. Drop the now-redundant explicit `(1,1)` assignment in `id(String)` since `find()` owns the requirement.

Regression tests at both `ComponentQuery` and `Locator` layers, plus one codifying that `Locator.invalidate()` preserves filter-set count constraints.