### PR TITLE
feat: add `testId` terminal operator to `ComponentQuery`

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -428,6 +428,56 @@ class ComponentQueryTest extends BrowserlessTest {
     }
 
     @Test
+    void testId_matchingComponent_getsComponent() {
+        Element rootElement = getCurrentView().getElement();
+        List<TextField> textFields = IntStream.rangeClosed(1, 5)
+                .mapToObj(idx -> {
+                    TextField field = new TextField();
+                    field.setTestId("test-field-" + idx);
+                    return field;
+                }).peek(field -> rootElement.appendChild(field.getElement()))
+                .toList();
+
+        ComponentQuery<TextField> query = findInView(TextField.class);
+
+        textFields.forEach(field -> Assertions.assertSame(field,
+                query.testId(field.getTestId())));
+    }
+
+    @Test
+    void testId_noMatchingComponent_throws() {
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(new TextField().getElement());
+        TextField textField = new TextField();
+        textField.setTestId("known-test-id");
+        rootElement.appendChild(textField.getElement());
+
+        ComponentQuery<TextField> query = findInView(TextField.class);
+        Assertions.assertThrows(NoSuchElementException.class,
+                () -> query.testId("missing-id"));
+    }
+
+    @Test
+    void testId_matchingDifferentComponentType_throws() {
+        Element rootElement = getCurrentView().getElement();
+        rootElement.appendChild(new TextField().getElement());
+        Button button = new Button();
+        button.setTestId("shared-id");
+        rootElement.appendChild(button.getElement());
+
+        ComponentQuery<TextField> query = findInView(TextField.class);
+        Assertions.assertThrows(NoSuchElementException.class,
+                () -> query.testId("shared-id"));
+    }
+
+    @Test
+    void testId_nullTestId_throws() {
+        ComponentQuery<TextField> query = findInView(TextField.class);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> query.testId(null));
+    }
+
+    @Test
     void withTestId_matchingComponent_getsComponent() {
         Element rootElement = getCurrentView().getElement();
         List<TextField> textFields = IntStream.rangeClosed(1, 5)

--- a/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
@@ -640,6 +640,25 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Executes a search for a component with the given {@code data-testid}
+     * attribute, as set by
+     * {@link com.vaadin.flow.component.Component#setTestId(String)}.
+     *
+     * @param testId
+     *            the test id to look up
+     * @return the component with the given test id
+     *
+     * @throws NoSuchElementException
+     *             if no component is found
+     * @see com.vaadin.flow.component.Component#setTestId(String)
+     */
+    public T testId(String testId) {
+        Objects.requireNonNull(testId, "testId must not be null");
+        withTestId(testId);
+        return find();
+    }
+
+    /**
      * Checks if this {@link ComponentQuery} describes existing components.
      *
      * @return {@literal true} if components are found, otherwise


### PR DESCRIPTION
Pairs with the existing `id` operator, so a component can be looked up directly by its test id without a separate `withTestId().find()` call.

Fixes #83
