### PR TITLE
feat: add typed withTheme/withoutTheme(ThemeVariant) overloads

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -1250,6 +1250,19 @@ class ComponentQueryTest extends BrowserlessTest {
         Assertions.assertEquals(target, find(Button.class).withTheme(
                 com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY)
                 .single());
+
+        // Adding a second themed button — the same typed filter now matches
+        // both, exercising the variant→theme-name resolution across multiple
+        // hits.
+        Button secondTarget = new Button();
+        secondTarget.addThemeVariants(
+                com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY);
+        UI.getCurrent().getElement().appendChild(secondTarget.getElement());
+
+        Assertions.assertEquals(asList(target, secondTarget),
+                find(Button.class).withTheme(
+                        com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY)
+                        .all());
     }
 
     @Test

--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -1240,6 +1240,38 @@ class ComponentQueryTest extends BrowserlessTest {
     }
 
     @Test
+    void withTheme_themeVariantOverload_matchesByVariantName() {
+        Button target = new Button();
+        target.addThemeVariants(
+                com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY);
+        UI.getCurrent().getElement().appendChild(new Button().getElement(),
+                target.getElement(), new Button().getElement());
+
+        Assertions.assertEquals(target,
+                find(Button.class).withTheme(
+                        com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY)
+                        .single());
+    }
+
+    @Test
+    void withoutTheme_themeVariantOverload_excludesByVariantName() {
+        Button target = new Button();
+        Button noisy1 = new Button();
+        noisy1.addThemeVariants(
+                com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY);
+        Button noisy2 = new Button();
+        noisy2.addThemeVariants(
+                com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY);
+        UI.getCurrent().getElement().appendChild(noisy1.getElement(),
+                target.getElement(), noisy2.getElement());
+
+        Assertions.assertEquals(target,
+                find(Button.class).withoutTheme(
+                        com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY)
+                        .single());
+    }
+
+    @Test
     void withThemeMultipleThemes_getsCorrectComponent() {
         Span target = new Span();
         target.getElement().getThemeList().add("my-theme");

--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -1247,10 +1247,9 @@ class ComponentQueryTest extends BrowserlessTest {
         UI.getCurrent().getElement().appendChild(new Button().getElement(),
                 target.getElement(), new Button().getElement());
 
-        Assertions.assertEquals(target,
-                find(Button.class).withTheme(
-                        com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY)
-                        .single());
+        Assertions.assertEquals(target, find(Button.class).withTheme(
+                com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY)
+                .single());
     }
 
     @Test
@@ -1265,10 +1264,9 @@ class ComponentQueryTest extends BrowserlessTest {
         UI.getCurrent().getElement().appendChild(noisy1.getElement(),
                 target.getElement(), noisy2.getElement());
 
-        Assertions.assertEquals(target,
-                find(Button.class).withoutTheme(
-                        com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY)
-                        .single());
+        Assertions.assertEquals(target, find(Button.class).withoutTheme(
+                com.vaadin.flow.component.button.ButtonVariant.LUMO_PRIMARY)
+                .single());
     }
 
     @Test

--- a/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
@@ -31,6 +31,7 @@ import kotlin.ranges.IntRange;
 import com.vaadin.browserless.internal.LocatorKt;
 import com.vaadin.browserless.internal.SearchSpec;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.shared.ThemeVariant;
 import com.vaadin.flow.dom.Element;
 
 /**
@@ -191,13 +192,40 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Add a theme variant that should be set on the target component. Prefer
+     * this over the raw-string {@link #withTheme(String)} so the IDE can
+     * autocomplete the variant and a typo becomes a compile error.
+     *
+     * <pre>
+     * ui.find(Button.class).withTheme(ButtonVariant.LUMO_PRIMARY).all();
+     * </pre>
+     *
+     * @param variant
+     *            the variant to require on the component
+     * @return this element query instance for chaining
+     */
+    public ComponentQuery<T> withTheme(ThemeVariant variant) {
+        return withThemeName(variant.getVariantName());
+    }
+
+    /**
      * Add theme that should be set on the target component.
      *
      * @param theme
      *            theme that should exist on the component.
      * @return this element query instance for chaining
+     * @deprecated use {@link #withTheme(ThemeVariant)} with the component's
+     *             typed variant enum where possible — it autocompletes in the
+     *             IDE and turns typos into compile errors. This raw-string
+     *             overload remains for callers that need to filter on a theme
+     *             not surfaced through a {@code ThemeVariant} enum.
      */
+    @Deprecated
     public ComponentQuery<T> withTheme(String theme) {
+        return withThemeName(theme);
+    }
+
+    private ComponentQuery<T> withThemeName(String theme) {
         if (locatorSpec.themes == null || locatorSpec.themes.isEmpty()) {
             locatorSpec.themes = theme;
         } else {
@@ -207,13 +235,33 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Add a theme variant that should not be set on the target component.
+     * Prefer this over the raw-string {@link #withoutTheme(String)} for the
+     * same reasons as {@link #withTheme(ThemeVariant)}.
+     *
+     * @param variant
+     *            the variant that should not be present on the component
+     * @return this element query instance for chaining
+     */
+    public ComponentQuery<T> withoutTheme(ThemeVariant variant) {
+        return withoutThemeName(variant.getVariantName());
+    }
+
+    /**
      * Add theme that should not be available on the target component.
      *
      * @param theme
      *            theme that should not exist on the component.
      * @return this element query instance for chaining
+     * @deprecated use {@link #withoutTheme(ThemeVariant)} with the component's
+     *             typed variant enum where possible.
      */
+    @Deprecated
     public ComponentQuery<T> withoutTheme(String theme) {
+        return withoutThemeName(theme);
+    }
+
+    private ComponentQuery<T> withoutThemeName(String theme) {
         if (locatorSpec.withoutThemes == null
                 || locatorSpec.withoutThemes.isEmpty()) {
             locatorSpec.withoutThemes = theme;

--- a/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
@@ -196,9 +196,9 @@ public class ComponentQuery<T extends Component> {
      * this over the raw-string {@link #withTheme(String)} so the IDE can
      * autocomplete the variant and a typo becomes a compile error.
      *
-     * <pre>
+     * <pre>{@code
      * ui.find(Button.class).withTheme(ButtonVariant.LUMO_PRIMARY).all();
-     * </pre>
+     * }</pre>
      *
      * @param variant
      *            the variant to require on the component

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
@@ -34,8 +34,8 @@ public interface HasThemeFilter<C extends Component & HasTheme, SELF extends Loc
 
     /**
      * Requires the matched component to have the given theme variant set.
-     * Prefer this over the raw-string {@link #withTheme(String)} so the IDE
-     * can autocomplete the variant and a typo becomes a compile error.
+     * Prefer this over the raw-string {@link #withTheme(String)} so the IDE can
+     * autocomplete the variant and a typo becomes a compile error.
      *
      * <pre>
      * ui.findButton().withTheme(ButtonVariant.LUMO_PRIMARY).click();
@@ -43,8 +43,7 @@ public interface HasThemeFilter<C extends Component & HasTheme, SELF extends Loc
      */
     @SuppressWarnings("unchecked")
     default SELF withTheme(ThemeVariant variant) {
-        return ((Locator<C, SELF>) this)
-                .applyFilter(q -> q.withTheme(variant));
+        return ((Locator<C, SELF>) this).applyFilter(q -> q.withTheme(variant));
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
@@ -37,9 +37,9 @@ public interface HasThemeFilter<C extends Component & HasTheme, SELF extends Loc
      * Prefer this over the raw-string {@link #withTheme(String)} so the IDE can
      * autocomplete the variant and a typo becomes a compile error.
      *
-     * <pre>
+     * <pre>{@code
      * ui.findButton().withTheme(ButtonVariant.LUMO_PRIMARY).click();
-     * </pre>
+     * }</pre>
      */
     @SuppressWarnings("unchecked")
     default SELF withTheme(ThemeVariant variant) {

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasThemeFilter.java
@@ -17,6 +17,7 @@ package com.vaadin.browserless.locator;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasTheme;
+import com.vaadin.flow.component.shared.ThemeVariant;
 
 /**
  * Mixin for {@link Locator}s whose target component implements
@@ -31,14 +32,54 @@ import com.vaadin.flow.component.HasTheme;
  */
 public interface HasThemeFilter<C extends Component & HasTheme, SELF extends Locator<C, SELF>> {
 
-    /** Requires the matched component to have the given theme set. */
+    /**
+     * Requires the matched component to have the given theme variant set.
+     * Prefer this over the raw-string {@link #withTheme(String)} so the IDE
+     * can autocomplete the variant and a typo becomes a compile error.
+     *
+     * <pre>
+     * ui.findButton().withTheme(ButtonVariant.LUMO_PRIMARY).click();
+     * </pre>
+     */
     @SuppressWarnings("unchecked")
+    default SELF withTheme(ThemeVariant variant) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withTheme(variant));
+    }
+
+    /**
+     * Requires the matched component to have the given theme set.
+     *
+     * @deprecated use {@link #withTheme(ThemeVariant)} with the component's
+     *             typed variant enum where possible. This raw-string overload
+     *             remains for themes not surfaced through a {@code
+     *             ThemeVariant} enum.
+     */
+    @Deprecated
+    @SuppressWarnings({ "unchecked", "deprecation" })
     default SELF withTheme(String theme) {
         return ((Locator<C, SELF>) this).applyFilter(q -> q.withTheme(theme));
     }
 
-    /** Requires the matched component to not have the given theme set. */
+    /**
+     * Requires the matched component to not have the given theme variant set.
+     * Prefer this over the raw-string {@link #withoutTheme(String)} for the
+     * same reasons as {@link #withTheme(ThemeVariant)}.
+     */
     @SuppressWarnings("unchecked")
+    default SELF withoutTheme(ThemeVariant variant) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withoutTheme(variant));
+    }
+
+    /**
+     * Requires the matched component to not have the given theme set.
+     *
+     * @deprecated use {@link #withoutTheme(ThemeVariant)} with the component's
+     *             typed variant enum where possible.
+     */
+    @Deprecated
+    @SuppressWarnings({ "unchecked", "deprecation" })
     default SELF withoutTheme(String theme) {
         return ((Locator<C, SELF>) this)
                 .applyFilter(q -> q.withoutTheme(theme));


### PR DESCRIPTION
ComponentQuery and HasThemeFilter now accept Vaadin's `ThemeVariant` (implemented by every component's variant enum: ButtonVariant, CardVariant, etc.) directly. Replaces verbose call sites like

    ui.find(TrainingCard.class)
            .withTheme(CardVariant.OUTLINED.getVariantName()).all()

with the cleaner

    ui.find(TrainingCard.class).withTheme(CardVariant.OUTLINED).all()

The raw-string overloads `withTheme(String)` and `withoutTheme(String)` on both classes are kept and marked @Deprecated. They stay because some themes aren't surfaced through a typed `ThemeVariant` enum (e.g. custom project-specific themes added via element.getThemeList()) — the deprecation is a nudge, not a removal commitment.

Implementation: the typed overload delegates to a private `with*Name` helper that holds the actual locatorSpec mutation; the deprecated String version delegates to the same helper. Avoids the typed method calling into a deprecated one (and the warning that would generate).

On HasThemeFilter the typed default method just routes through applyFilter to ComponentQuery.withTheme(variant). The deprecated String overload there carries `@SuppressWarnings("deprecation")` since it deliberately calls into the deprecated ComponentQuery method.

New tests in ComponentQueryTest exercise both
`withTheme(ButtonVariant.LUMO_PRIMARY)` and the matching withoutTheme overload, asserting they match by the variant name. The Locator-side typed overload is a one-line delegate to the ComponentQuery one, so transitively covered.