### PR TITLE
docs: document the Locators API in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ end-to-end testing) by covering the fast-feedback layer of the testing pyramid.
   and template parameters
 - **Component queries** — find components by type from the current view or any
   parent layout
+- **Typed locators** — fluent, compile-time-safe `findButton()` /
+  `findTextField()` entry points that combine query filters with tester
+  actions
 - **Keyboard shortcut simulation** — fire shortcuts with modifier keys
 - **Signals / reactive state** — process pending signal tasks in tests
 - **Round-trip simulation** — flush pending server-side changes
@@ -187,6 +190,156 @@ class CartViewTest extends BrowserlessTest {
     }
 }
 ```
+
+## Locators API
+
+The Locators API is a typed, fluent layer over `find(Class)` /
+`ComponentQuery`. Every built-in component tester has a matching `findXxx()`
+entry point that returns a *locator* — an object that exposes both the query
+filters *and* that component's tester actions, so you can find and act on a
+component in a single chain. Resolution is deferred to the first action and
+cached, so a locator can be reused (for example across a `roundTrip()`).
+
+```java
+window.findTextField().withId("name").setValue("World");
+window.findButton().withText("Save").click();
+assertEquals("Saved: World", window.findSpan().withId("echo").getText());
+```
+
+### Availability
+
+The typed `findXxx()` / `use(...)` entry points are available out of the box on
+every `BrowserlessUIContext` window (`app.newUser().newWindow()`), as used in
+the examples here.
+
+The single-user `BrowserlessTest` base class exposes the lower-level
+`find(Class)` query API. To get the same typed locators in a plain
+`BrowserlessTest`, have your test (or a shared base class) implement
+`com.vaadin.browserless.locator.Locators`:
+
+```java
+import com.vaadin.browserless.BrowserlessTest;
+import com.vaadin.browserless.locator.Locators;
+
+class CartViewTest extends BrowserlessTest implements Locators {
+
+    @Test
+    void addItemToCart() {
+        navigate(CartView.class);
+        findButton().withText("Add to cart").click();
+        assertEquals("1", findSpan().withId("cart-count").getText());
+    }
+}
+```
+
+### Filters
+
+Locators carry the common filters directly: `withId`, `withTestId`,
+`withClassName` / `withoutClassName`, `withAttribute` (with or without an
+expected value), `withoutAttribute`, and `withCondition` for an arbitrary
+typed predicate.
+
+Filters that depend on a component capability are mixed in only where the
+component actually supports them, so misuse is a compile error rather than a
+runtime surprise:
+
+| Filter                                | Available when the component is |
+|---------------------------------------|---------------------------------|
+| `withText` / `withTextContaining`     | `HasText`                       |
+| `withLabel` / `withLabelContaining`   | `HasLabel`                      |
+| `withAriaLabel` / `withAriaLabelContaining` | `HasAriaLabel`            |
+| `withValue`                           | `HasValue` (typed to its value) |
+| `withTheme` / `withoutTheme`          | `HasTheme`                      |
+
+```java
+// Button is HasText — compiles
+window.findButton().withText("Save").click();
+
+// TextField is HasLabel + HasValue, but not HasText
+window.findTextField().withLabel("Name").setValue("Ada");
+window.findTextField().withValue("Ada");   // value type is checked: String here
+
+// window.findTextField().withText("Name");  // does NOT compile
+```
+
+For filters not surfaced on the locator (for example `withPropertyValue` or
+`withResultsSize`), use the `with(q -> ...)` escape hatch to reach the
+underlying `ComponentQuery`:
+
+```java
+window.findButton().with(q -> q.withPropertyValue(Button::getText, "Save"))
+        .click();
+```
+
+### Selecting and scoping
+
+When a filter chain matches more than one component, pick one with `atIndex(n)`
+(1-based). Scope the search to a subtree with `inside(component)` or
+`inside(otherLocator)` — the latter resolves its parent lazily, at the moment
+the child is resolved:
+
+```java
+// pick the second button in the view
+window.findButton().atIndex(2).click();
+
+// only look inside a resolved parent
+window.findButton().inside(window.findButton().withId("toolbar")).click();
+```
+
+Beyond the action methods, locators expose `component()` (the single match,
+cached), `components()` (all matches), `exists()` (true if anything matches),
+and `invalidate()` (drop the cached resolution and the `atIndex` pick so the
+next action re-resolves — useful after a UI change replaces the component).
+
+### Seeding with `use(...)`
+
+When the test already holds a component reference, `use(component)` seeds a
+locator with it directly instead of running a query:
+
+```java
+window.use(form.nameField).setValue("Ada");
+window.use(form.submit).click();
+```
+
+### Custom locators
+
+For composite components, subclass `Locator<C, SELF>` and compose the built-in
+locators, scoping them to the composite's subtree with `inside(this)`:
+
+```java
+import com.vaadin.browserless.locator.Locator;
+import com.vaadin.flow.component.button.ButtonLocator;
+import com.vaadin.flow.component.textfield.TextFieldLocator;
+
+public class PersonFormLocator extends Locator<PersonForm, PersonFormLocator> {
+
+    public PersonFormLocator() {
+        super(PersonForm.class);
+    }
+
+    public PersonFormLocator fillIn(String name, String email) {
+        new TextFieldLocator().withId("pf-name").inside(this).setValue(name);
+        new TextFieldLocator().withId("pf-email").inside(this).setValue(email);
+        return this;
+    }
+
+    public void submit() {
+        new ButtonLocator().withId("pf-submit").inside(this).click();
+    }
+}
+```
+
+Invoke a custom locator through the generic `find(Supplier)` entry point:
+
+```java
+window.find(PersonFormLocator::new).fillIn("Ada", "ada@example.com").submit();
+```
+
+### Relationship to `ComponentQuery`
+
+Locators are the typed convenience layer; `find(Class)` and `ComponentQuery`
+remain available for ad-hoc, lower-level queries and for filters not surfaced
+on locators. Use whichever fits — they search the same component tree.
 
 ## Multi-user and multi-window testing
 

--- a/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
+++ b/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
@@ -206,7 +206,7 @@ public class LocatorProcessor extends AbstractProcessor {
      * (value or fqn). For each target, the locator's tester type variables
      * (past the first) are pinned to concrete types when the target's supertype
      * parameterization fixes them — this turns e.g.
-     * {@code getTextField(Class<V>)} into a clean {@code getTextField()} for
+     * {@code findTextField(Class<V>)} into a clean {@code findTextField()} for
      * {@code TextField} (V=String) while still requiring a witness for
      * {@code Grid} (V free per use).
      */

--- a/shared/src/main/java/com/vaadin/browserless/locator/Locator.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/Locator.java
@@ -25,7 +25,7 @@ import com.vaadin.browserless.ComponentQuery;
 import com.vaadin.flow.component.Component;
 
 /**
- * Prototype base class for the {@code get*} tester API. A locator is a fluent
+ * Base class for the {@code find*} tester API. A locator is a fluent
  * combination of a {@link ComponentQuery} filter chain and a tester: the
  * subclass exposes both the filter methods inherited from this class and the
  * action methods specific to the component type.


### PR DESCRIPTION
The README only covered the lower-level ComponentQuery API (find(Class), findInView, $). Add a "Locators API" section covering the typed, fluent find*() entry points: filters (including the capability-gated withText/ withLabel/withValue/withTheme mixins and the with(q -> ...) escape hatch), atIndex/inside scoping, use(component) seeding, and custom locators via find(Supplier). Document availability on BrowserlessUIContext windows and how a BrowserlessTest subclass opts in via `implements Locators`, plus a Features bullet.

Also align the Locator Javadoc with this stable framing: drop the "Prototype" label and fix stale `get*` naming to `find*` in both Locator and LocatorProcessor.
