### PR TITLE
fix: locator finds components placed in component slots

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/CardSlotTraversalTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/CardSlotTraversalTest.java
@@ -24,9 +24,9 @@ import com.vaadin.flow.component.card.Card;
 /**
  * Reproduces a locator-traversal bug: components placed in a {@link Card}'s
  * slots (header, header-suffix, header-prefix, footer, title, media) are not
- * found by {@code find(...)} or {@code ui.findButton()} even though they
- * render in the browser. The locator engine only walks the regular Flow
- * component tree and misses content attached via the Card's slot setters.
+ * found by {@code find(...)} or {@code ui.findButton()} even though they render
+ * in the browser. The locator engine only walks the regular Flow component tree
+ * and misses content attached via the Card's slot setters.
  * <p>
  * Reduced from the standalone repro in {@code tmp/card-locator-repro}.
  */
@@ -50,24 +50,24 @@ class CardSlotTraversalTest extends BrowserlessTest {
         getCurrentView().getElement().appendChild(card.getElement());
 
         // Control: a button in the card content slot (regular getChildren()).
-        Assertions.assertTrue(find(Button.class)
-                .withText("Content button").exists(),
+        Assertions.assertTrue(
+                find(Button.class).withText("Content button").exists(),
                 "button in card content slot must be locatable");
 
         // The bug — each of the slotted buttons must be locatable too, but
         // currently isn't because the locator engine only walks the regular
         // Flow tree and misses content attached via Card's slot setters.
-        Assertions.assertTrue(find(Button.class)
-                .withText("Header-suffix button").exists(),
+        Assertions.assertTrue(
+                find(Button.class).withText("Header-suffix button").exists(),
                 "button in card header-suffix slot must be locatable");
-        Assertions.assertTrue(find(Button.class)
-                .withText("Header-prefix button").exists(),
+        Assertions.assertTrue(
+                find(Button.class).withText("Header-prefix button").exists(),
                 "button in card header-prefix slot must be locatable");
-        Assertions.assertTrue(find(Button.class)
-                .withText("Header button").exists(),
+        Assertions.assertTrue(
+                find(Button.class).withText("Header button").exists(),
                 "button in card header slot must be locatable");
-        Assertions.assertTrue(find(Button.class)
-                .withText("Footer button").exists(),
+        Assertions.assertTrue(
+                find(Button.class).withText("Footer button").exists(),
                 "button in card footer slot must be locatable");
     }
 }

--- a/junit6/src/test/java/com/vaadin/browserless/CardSlotTraversalTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/CardSlotTraversalTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.card.Card;
+
+/**
+ * Reproduces a locator-traversal bug: components placed in a {@link Card}'s
+ * slots (header, header-suffix, header-prefix, footer, title, media) are not
+ * found by {@code find(...)} or {@code ui.findButton()} even though they
+ * render in the browser. The locator engine only walks the regular Flow
+ * component tree and misses content attached via the Card's slot setters.
+ * <p>
+ * Reduced from the standalone repro in {@code tmp/card-locator-repro}.
+ */
+class CardSlotTraversalTest extends BrowserlessTest {
+
+    @Test
+    void cardContent_slottedAndPlain_allLocatable() {
+        Button contentButton = new Button("Content button");
+        Button headerSuffixButton = new Button("Header-suffix button");
+        Button headerPrefixButton = new Button("Header-prefix button");
+        Button headerButton = new Button("Header button");
+        Button footerButton = new Button("Footer button");
+
+        Card card = new Card();
+        card.add(contentButton);
+        card.setHeaderSuffix(headerSuffixButton);
+        card.setHeaderPrefix(headerPrefixButton);
+        card.setHeader(headerButton);
+        card.addToFooter(footerButton);
+
+        getCurrentView().getElement().appendChild(card.getElement());
+
+        // Control: a button in the card content slot (regular getChildren()).
+        Assertions.assertTrue(find(Button.class)
+                .withText("Content button").exists(),
+                "button in card content slot must be locatable");
+
+        // The bug — each of the slotted buttons must be locatable too, but
+        // currently isn't because the locator engine only walks the regular
+        // Flow tree and misses content attached via Card's slot setters.
+        Assertions.assertTrue(find(Button.class)
+                .withText("Header-suffix button").exists(),
+                "button in card header-suffix slot must be locatable");
+        Assertions.assertTrue(find(Button.class)
+                .withText("Header-prefix button").exists(),
+                "button in card header-prefix slot must be locatable");
+        Assertions.assertTrue(find(Button.class)
+                .withText("Header button").exists(),
+                "button in card header slot must be locatable");
+        Assertions.assertTrue(find(Button.class)
+                .withText("Footer button").exists(),
+                "button in card footer slot must be locatable");
+    }
+}

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/TestingLifecycleHook.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/TestingLifecycleHook.kt
@@ -123,7 +123,24 @@ interface TestingLifecycleHook {
         }
         // Also include virtual children.
         // Issue: https://github.com/mvysny/karibu-testing/issues/85
-        else -> (component.children.toList() + component._getVirtualChildren()).distinct()
+        //
+        // Plus slotted children, which are regular DOM children with a
+        // `slot` attribute (added via SlotUtils.addToSlot — Card header,
+        // Dialog footer, etc.). Some components override getChildren() to
+        // filter those out (see Card.getChildren), making them invisible
+        // to the locator if we only consulted component.children. We pick
+        // them up directly from the element tree so the locator finds
+        // them like the user would in the browser.
+        else -> {
+            val regular = component.children.toList()
+            val slotted = component.element.children
+                .filter { !it.isTextNode && it.hasAttribute("slot") }
+                .toList()
+                .mapNotNull { it.component.orElse(null) }
+                .filter { it !in regular }
+            val virtual = component._getVirtualChildren()
+            (regular + slotted + virtual).distinct()
+        }
     }
 
 


### PR DESCRIPTION
Quickly vibed "solution" for another component tree traversal issues (case Card in my app). Haven't checked throuhgly, but I think we should (probably in some upcoming release try to resolve/unify all existing hacks and try to settle as much as possible for the new ComponentUtil.getAllChildren() method.

Claude's explanation why it was done this way:

Components like Card, Dialog, and similar slot-using parents add children via `SlotUtils.addToSlot`, which does plain `parent.element.appendChild(child)` + `child.setAttribute("slot", ...)`. The slotted children are regular DOM children, just with a `slot` attribute. Card (and friends) then override `getChildren()` to filter out children with that attribute — so `card.getChildren()` only reports the content slot, hiding the rest.

`TestingLifecycleHook.getAllChildren`'s default branch was

    component.children.toList() + component._getVirtualChildren()

which trusts `getChildren()` and missed slotted children entirely. The locator API ended up unable to find buttons placed in a Card's header / header-prefix / header-suffix / footer slots even though they render in the browser.

Fix: in the same default branch, additionally pick up children with the `slot` attribute directly from the element tree. Conservative delta — keeps `component.children` as the primary source (so cases like ContextMenu, whose `getChildren()` returns logical items not represented in the element tree, still work), and adds slotted ones only when the component's own `getChildren()` filtered them out.

Repro test: `CardSlotTraversalTest` exercises all four Card slot setters plus `add()`. Without the fix, the first slotted assertion fails. Reduced from the standalone repro in `tmp/card-locator-repro`.
