### PR TITLE
fix: resolve aria-label via HasAriaLabel for field components

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -904,12 +904,10 @@ class ComponentQueryTest extends BrowserlessTest {
                 "TextField.setAriaLabel should not surface as an"
                         + " aria-label element attribute server-side");
 
-        Assertions.assertSame(description,
-                find(TextField.class).withAriaLabel("Task description")
-                        .single());
-        Assertions.assertSame(description,
-                find(TextField.class).withAriaLabelContaining("description")
-                        .single());
+        Assertions.assertSame(description, find(TextField.class)
+                .withAriaLabel("Task description").single());
+        Assertions.assertSame(description, find(TextField.class)
+                .withAriaLabelContaining("description").single());
         Assertions.assertTrue(
                 find(TextField.class).withAriaLabel("not set").all().isEmpty());
     }

--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -882,6 +882,39 @@ class ComponentQueryTest extends BrowserlessTest {
     }
 
     @Test
+    void withAriaLabel_fieldComponent_matchesViaHasAriaLabel() {
+        // Field components like TextField override HasAriaLabel to back the
+        // accessible name with a property (accessibleName / inner input's
+        // aria-label), not with an element attribute. The matcher must
+        // resolve aria-label via HasAriaLabel.getAriaLabel() so these are
+        // findable. Repro for #90.
+        TextField description = new TextField();
+        description.setAriaLabel("Task description");
+        TextField unrelated = new TextField();
+        unrelated.setAriaLabel("Search");
+        TextField noAria = new TextField();
+
+        UI.getCurrent().getElement().appendChild(description.getElement(),
+                unrelated.getElement(), noAria.getElement());
+
+        // Sanity-check the asymmetry the bug report describes: the value is
+        // NOT on the server-side element as an aria-label attribute.
+        Assertions.assertNull(
+                description.getElement().getAttribute("aria-label"),
+                "TextField.setAriaLabel should not surface as an"
+                        + " aria-label element attribute server-side");
+
+        Assertions.assertSame(description,
+                find(TextField.class).withAriaLabel("Task description")
+                        .single());
+        Assertions.assertSame(description,
+                find(TextField.class).withAriaLabelContaining("description")
+                        .single());
+        Assertions.assertTrue(
+                find(TextField.class).withAriaLabel("not set").all().isEmpty());
+    }
+
+    @Test
     void withLabel_null_throws() {
         ComponentQuery<TestComponent> query = find(TestComponent.class);
         Assertions.assertThrows(IllegalArgumentException.class,

--- a/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
+++ b/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
@@ -23,6 +23,7 @@ import org.jsoup.Jsoup;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasAriaLabel;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.HtmlComponent;
@@ -269,10 +270,17 @@ public final class ElementConditions {
     }
 
     /**
-     * Checks if the component has its {@code aria-label} attribute set to
-     * exactly the given value. Useful for components like {@code Button} that
-     * don't expose a {@code label} property but identify themselves to
-     * assistive technology via {@code aria-label}.
+     * Checks if the component identifies itself to assistive technology via
+     * the given {@code aria-label}. Useful for components like {@code Button}
+     * that don't expose a {@code label} property and for field components
+     * (e.g. {@code TextField}, {@code TextArea}) that surface their accessible
+     * name via {@link HasAriaLabel#setAriaLabel(String)}.
+     * <p>
+     * Resolution prefers {@link HasAriaLabel#getAriaLabel()} when the component
+     * implements it, because field components back the accessible name with a
+     * property (the web component reflects it to the inner input's
+     * {@code aria-label} on the client). Otherwise falls back to reading the
+     * server-side element's {@code aria-label} attribute.
      *
      * @param ariaLabel
      *            the expected aria-label, not {@literal null}
@@ -282,13 +290,14 @@ public final class ElementConditions {
         if (ariaLabel == null) {
             throw new IllegalArgumentException("ariaLabel cannot be null");
         }
-        return component -> ariaLabel
-                .equals(component.getElement().getAttribute("aria-label"));
+        return component -> ariaLabel.equals(resolveAriaLabel(component));
     }
 
     /**
-     * Checks if the component's {@code aria-label} attribute contains the given
-     * text. Comparison is case-sensitive.
+     * Checks if the component's aria-label contains the given text. Comparison
+     * is case-sensitive. Resolution follows the same rules as
+     * {@link #hasAriaLabel(String)} — prefer {@link HasAriaLabel#getAriaLabel()}
+     * over the raw element attribute so that field components are matched.
      *
      * @param text
      *            substring to find in the aria-label, not {@literal null}
@@ -299,9 +308,16 @@ public final class ElementConditions {
             throw new IllegalArgumentException("text cannot be null");
         }
         return component -> {
-            String label = component.getElement().getAttribute("aria-label");
+            String label = resolveAriaLabel(component);
             return label != null && label.contains(text);
         };
+    }
+
+    private static String resolveAriaLabel(Component component) {
+        if (component instanceof HasAriaLabel hal) {
+            return hal.getAriaLabel().orElse(null);
+        }
+        return component.getElement().getAttribute("aria-label");
     }
 
     private static class TextContainsPredicate<T extends Component>

--- a/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
+++ b/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
@@ -270,11 +270,11 @@ public final class ElementConditions {
     }
 
     /**
-     * Checks if the component identifies itself to assistive technology via
-     * the given {@code aria-label}. Useful for components like {@code Button}
-     * that don't expose a {@code label} property and for field components
-     * (e.g. {@code TextField}, {@code TextArea}) that surface their accessible
-     * name via {@link HasAriaLabel#setAriaLabel(String)}.
+     * Checks if the component identifies itself to assistive technology via the
+     * given {@code aria-label}. Useful for components like {@code Button} that
+     * don't expose a {@code label} property and for field components (e.g.
+     * {@code TextField}, {@code TextArea}) that surface their accessible name
+     * via {@link HasAriaLabel#setAriaLabel(String)}.
      * <p>
      * Resolution prefers {@link HasAriaLabel#getAriaLabel()} when the component
      * implements it, because field components back the accessible name with a
@@ -296,8 +296,9 @@ public final class ElementConditions {
     /**
      * Checks if the component's aria-label contains the given text. Comparison
      * is case-sensitive. Resolution follows the same rules as
-     * {@link #hasAriaLabel(String)} — prefer {@link HasAriaLabel#getAriaLabel()}
-     * over the raw element attribute so that field components are matched.
+     * {@link #hasAriaLabel(String)} — prefer
+     * {@link HasAriaLabel#getAriaLabel()} over the raw element attribute so
+     * that field components are matched.
      *
      * @param text
      *            substring to find in the aria-label, not {@literal null}


### PR DESCRIPTION
`withAriaLabel` and `withAriaLabelContaining` used to consult only the server-side element's `aria-label` attribute. That works for Button-style components where `setAriaLabel(String)` directly sets the attribute, but fails silently for field components (TextField, TextArea, etc.) whose `TextFieldBase.setAriaLabel(String)` backs the accessible name with a property — the web component reflects it to the inner input's `aria-label` on the client, so there's no `aria-label` attribute on the server-side element to read.

Resolution now prefers `HasAriaLabel.getAriaLabel()` when the component implements it, and falls back to the element attribute only for components that don't. Same change applied to both `hasAriaLabel` and `ariaLabelContains` matchers in `ElementConditions`.

Repro test added in `ComponentQueryTest#withAriaLabel_fieldComponent_*`, which sanity-checks the asymmetry (TextField doesn't expose aria-label as a server-side element attribute) and then asserts both exact and substring matches.

Fixes #90.