### PR TITLE
feat: expose public withPlaceholder filter on ComponentQuery and Locator

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ComponentQueryTest.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.component.masterdetaillayout.MasterDetailLayout;
+import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.textfield.TextFieldBase;
@@ -924,6 +925,69 @@ class ComponentQueryTest extends BrowserlessTest {
         ComponentQuery<TestComponent> query = find(TestComponent.class);
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> query.withAriaLabel(null));
+    }
+
+    @Test
+    void withPlaceholder_exactMatch_getsCorrectComponent() {
+        // Wiring test for #92 — the search engine already supported filtering
+        // by placeholder via LocatorSpec.placeholder; expose it through a
+        // public withPlaceholder(String) entry point. Two different
+        // HasPlaceholder component types (TextField + EmailField) are used so
+        // the test also asserts the filter works across the HasPlaceholder
+        // hierarchy, not just on TextField.
+        TextField search = new TextField();
+        search.setPlaceholder("Search…");
+        EmailField email = new EmailField();
+        email.setPlaceholder("name@example.com");
+        TextField noPlaceholder = new TextField();
+
+        UI.getCurrent().getElement().appendChild(search.getElement(),
+                email.getElement(), noPlaceholder.getElement());
+
+        Assertions.assertSame(search,
+                find(TextField.class).withPlaceholder("Search…").single());
+        Assertions.assertSame(email, find(EmailField.class)
+                .withPlaceholder("name@example.com").single());
+        Assertions.assertTrue(
+                find(TextField.class).withPlaceholder("nope").all().isEmpty());
+    }
+
+    @Test
+    void withPlaceholder_null_throws() {
+        ComponentQuery<TextField> query = find(TextField.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withPlaceholder(null));
+    }
+
+    @Test
+    void withPlaceholderContaining_substringMatch() {
+        TextField search = new TextField();
+        search.setPlaceholder("Search for orders…");
+        EmailField email = new EmailField();
+        email.setPlaceholder("you@example.com");
+        TextField unrelated = new TextField();
+        unrelated.setPlaceholder("Full name");
+        TextField noPlaceholder = new TextField();
+
+        UI.getCurrent().getElement().appendChild(search.getElement(),
+                email.getElement(), unrelated.getElement(),
+                noPlaceholder.getElement());
+
+        Assertions.assertSame(search, find(TextField.class)
+                .withPlaceholderContaining("orders").single());
+        Assertions.assertSame(email, find(EmailField.class)
+                .withPlaceholderContaining("example.com").single());
+        Assertions.assertIterableEquals(List.of(search, unrelated),
+                find(TextField.class).withPlaceholderContaining(" ").all());
+        Assertions.assertTrue(find(TextField.class)
+                .withPlaceholderContaining("nope").all().isEmpty());
+    }
+
+    @Test
+    void withPlaceholderContaining_null_throws() {
+        ComponentQuery<TextField> query = find(TextField.class);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> query.withPlaceholderContaining(null));
     }
 
     @Test

--- a/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
+++ b/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
@@ -107,6 +107,9 @@ public class LocatorProcessor extends AbstractProcessor {
                 new Simple("com.vaadin.browserless.locator.HasTextFilter"));
         FILTER_MIXINS.put("com.vaadin.flow.component.HasAriaLabel", new Simple(
                 "com.vaadin.browserless.locator.HasAriaLabelFilter"));
+        FILTER_MIXINS.put("com.vaadin.flow.component.HasPlaceholder",
+                new Simple(
+                        "com.vaadin.browserless.locator.HasPlaceholderFilter"));
         FILTER_MIXINS.put("com.vaadin.flow.component.HasValue",
                 new Typed("com.vaadin.browserless.locator.HasValueFilter", 1));
         FILTER_MIXINS.put("com.vaadin.flow.component.HasTheme",

--- a/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
@@ -353,6 +353,7 @@ public class ComponentQuery<T extends Component> {
      *            the expected placeholder, not {@literal null}
      * @return this element query instance for chaining
      * @see com.vaadin.flow.component.HasPlaceholder#getPlaceholder()
+     * @since 1.1
      */
     public ComponentQuery<T> withPlaceholder(String placeholder) {
         if (placeholder == null) {
@@ -370,6 +371,7 @@ public class ComponentQuery<T extends Component> {
      * @param text
      *            substring to find in the placeholder, not {@literal null}
      * @return this element query instance for chaining
+     * @since 1.1
      */
     public ComponentQuery<T> withPlaceholderContaining(String text) {
         locatorSpec.predicates.add(ElementConditions.placeholderContains(text));

--- a/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
@@ -344,6 +344,39 @@ public class ComponentQuery<T extends Component> {
     }
 
     /**
+     * Requires the component's {@code placeholder} to be exactly the given
+     * value. Useful for toolbar / search fields that intentionally omit a
+     * stacked label and identify themselves to the user via placeholder text
+     * instead.
+     *
+     * @param placeholder
+     *            the expected placeholder, not {@literal null}
+     * @return this element query instance for chaining
+     * @see com.vaadin.flow.component.HasPlaceholder#getPlaceholder()
+     */
+    public ComponentQuery<T> withPlaceholder(String placeholder) {
+        if (placeholder == null) {
+            throw new IllegalArgumentException("placeholder must not be null");
+        }
+        locatorSpec.placeholder = placeholder;
+        return this;
+    }
+
+    /**
+     * Requires the component's {@code placeholder} to contain the given text.
+     * Comparison is case-sensitive. Read in the same way as
+     * {@link #withPlaceholder(String)}.
+     *
+     * @param text
+     *            substring to find in the placeholder, not {@literal null}
+     * @return this element query instance for chaining
+     */
+    public ComponentQuery<T> withPlaceholderContaining(String text) {
+        locatorSpec.predicates.add(ElementConditions.placeholderContains(text));
+        return this;
+    }
+
+    /**
      * Requires the component's {@code aria-label} attribute to be exactly the
      * given value. Useful for components like {@code Button} that don't carry a
      * visible label property but identify themselves to assistive technology

--- a/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
+++ b/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
@@ -24,6 +24,7 @@ import org.jsoup.Jsoup;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasAriaLabel;
+import com.vaadin.flow.component.HasPlaceholder;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.HtmlComponent;
@@ -266,13 +267,13 @@ public final class ElementConditions {
 
     /**
      * Checks if the component's {@code placeholder} contains the given text.
-     * Resolution prefers
-     * {@link com.vaadin.flow.component.HasPlaceholder#getPlaceholder()} —
-     * components that don't implement {@code HasPlaceholder} are never matched
-     * (they have no placeholder to test against). Comparison is case-sensitive.
+     * Resolution prefers {@link HasPlaceholder#getPlaceholder()} — components
+     * that don't implement {@code HasPlaceholder} are never matched (they have
+     * no placeholder to test against). Comparison is case-sensitive.
      *
      * @param text
      *            substring to find in the placeholder, not {@literal null}
+     * @since 1.1
      */
     public static <T extends Component> Predicate<T> placeholderContains(
             String text) {
@@ -280,7 +281,7 @@ public final class ElementConditions {
             throw new IllegalArgumentException("text cannot be null");
         }
         return component -> {
-            if (component instanceof com.vaadin.flow.component.HasPlaceholder hp) {
+            if (component instanceof HasPlaceholder hp) {
                 String placeholder = hp.getPlaceholder();
                 return placeholder != null && placeholder.contains(text);
             }

--- a/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
+++ b/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
@@ -264,6 +264,30 @@ public final class ElementConditions {
         return substring ? actual.contains(expected) : actual.equals(expected);
     }
 
+    /**
+     * Checks if the component's {@code placeholder} contains the given text.
+     * Resolution prefers
+     * {@link com.vaadin.flow.component.HasPlaceholder#getPlaceholder()} —
+     * components that don't implement {@code HasPlaceholder} are never matched
+     * (they have no placeholder to test against). Comparison is case-sensitive.
+     *
+     * @param text
+     *            substring to find in the placeholder, not {@literal null}
+     */
+    public static <T extends Component> Predicate<T> placeholderContains(
+            String text) {
+        if (text == null) {
+            throw new IllegalArgumentException("text cannot be null");
+        }
+        return component -> {
+            if (component instanceof com.vaadin.flow.component.HasPlaceholder hp) {
+                String placeholder = hp.getPlaceholder();
+                return placeholder != null && placeholder.contains(text);
+            }
+            return false;
+        };
+    }
+
     private static String referringLabelText(Component root, String id) {
         return ComponentUtil.streamDescendants(root).map(Component::getElement)
                 // Element.getTag() throws on text nodes; skip them first.

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasPlaceholderFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasPlaceholderFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.locator;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasPlaceholder;
+
+/**
+ * Mixin for {@link Locator}s whose target component implements
+ * {@link HasPlaceholder}. Exposes placeholder-based filter methods that would
+ * be meaningless on components without a placeholder, turning a call like
+ * {@code findButton().withPlaceholder("...")} (Button is not
+ * {@code HasPlaceholder}) into a compile error rather than a silent no-op.
+ *
+ * @param <C>
+ *            the component type, bound to {@link HasPlaceholder}
+ * @param <SELF>
+ *            the concrete locator subtype, used for fluent chaining
+ */
+public interface HasPlaceholderFilter<C extends Component & HasPlaceholder, SELF extends Locator<C, SELF>> {
+
+    /**
+     * Requires the matched component's {@code placeholder} to be exactly the
+     * given value. Useful for toolbar / search fields that intentionally omit a
+     * stacked label and identify themselves to the user via placeholder text
+     * instead.
+     */
+    @SuppressWarnings("unchecked")
+    default SELF withPlaceholder(String placeholder) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withPlaceholder(placeholder));
+    }
+
+    /**
+     * Requires the matched component's {@code placeholder} to contain the given
+     * text.
+     */
+    @SuppressWarnings("unchecked")
+    default SELF withPlaceholderContaining(String text) {
+        return ((Locator<C, SELF>) this)
+                .applyFilter(q -> q.withPlaceholderContaining(text));
+    }
+}


### PR DESCRIPTION
The search engine already supported filtering by placeholder via `LocatorSpec.placeholder` (populated into `SearchSpec.setPlaceholder`), but no public method exposed it. Wire it up:

  - `ComponentQuery.withPlaceholder(String)` — sets locatorSpec placeholder, with a null guard mirroring withId / withClassName.
  - `HasPlaceholderFilter` — new locator mixin gated by Vaadin's `HasPlaceholder` interface. Same pattern as HasLabelFilter etc., so `findButton().withPlaceholder("…")` (Button is not HasPlaceholder) becomes a compile error rather than a silent no-op.
  - `LocatorProcessor.FILTER_MIXINS` adds the `HasPlaceholder → HasPlaceholderFilter` entry, so every @Tests-annotated tester whose target implements HasPlaceholder (TextField, TextArea, PasswordField, DatePicker, ComboBox, …) gets the typed `withPlaceholder` on its generated locator.

Verified on the generated output: `TextFieldLocator implements … HasPlaceholderFilter<TextField, TextFieldLocator>` and `ButtonLocator` does NOT. Compile-check confirms `new ButtonLocator().withPlaceholder()` fails with `method withPlaceholder cannot be found`.

Tests added in `ComponentQueryTest`:
  - `withPlaceholder_exactMatch_getsCorrectComponent` — three TextFields (Search, email, no-placeholder) selected by their placeholder text.
  - `withPlaceholder_null_throws` — null guard.

All four suites green: 1030 junit6 (+2) + 20 shared + 29 spring + 27 quarkus.

Fixes #92.