### PR TITLE
fix: resolve custom testers for component subclasses (#100)

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/CustomDialog.java
+++ b/junit6/src/test/java/com/vaadin/browserless/CustomDialog.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.vaadin.flow.component.dialog.Dialog;
+
+/**
+ * A {@link Dialog} subclass used to verify that a custom tester extending a
+ * concrete built-in tester can wrap a component subtype.
+ */
+public class CustomDialog extends Dialog {
+}

--- a/junit6/src/test/java/com/vaadin/browserless/CustomDialogTester.java
+++ b/junit6/src/test/java/com/vaadin/browserless/CustomDialogTester.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.vaadin.flow.component.dialog.DialogTester;
+
+/**
+ * A custom tester extending the concrete {@link DialogTester} (which binds the
+ * generic component type to {@code Dialog}) while wrapping a {@code Dialog}
+ * subclass. Its constructor declares the narrower {@link CustomDialog} type,
+ * which previously caused instantiation to fail because the constructor was
+ * looked up using the generic-resolved {@code Dialog} type.
+ */
+@Tests(CustomDialog.class)
+public class CustomDialogTester extends DialogTester {
+
+    public CustomDialogTester(CustomDialog component) {
+        super(component);
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/TesterResolutionTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/TesterResolutionTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dialog.DialogTester;
 
 @ComponentTesterPackages("com.vaadin.browserless")
 @ViewPackages(packages = "com.vaadin.browserless")
@@ -51,6 +52,39 @@ public class TesterResolutionTest extends BrowserlessTest {
         TestComponentForConcreteTester component = new TestComponentForConcreteTester();
         Assertions.assertEquals(test(component).getClass(),
                 NonGenericTestTester.class);
+    }
+
+    @Test
+    public void wrapDialogSubclass_typedOverload_returnsCustomTester() {
+        // Reproduces issue #100: a custom tester extending the concrete
+        // DialogTester and wrapping a Dialog subclass. The typed test(Dialog)
+        // overload must return the registered custom tester, which is still a
+        // DialogTester so the historical cast keeps working.
+        CustomDialog dialog = new CustomDialog();
+
+        DialogTester tester = test(dialog);
+        Assertions.assertInstanceOf(CustomDialogTester.class, tester);
+    }
+
+    @Test
+    public void wrapDialogSubclass_explicitTesterClass_returnsCustomTester() {
+        // Reproduces issue #100: instantiating a custom tester explicitly must
+        // not fail with NoSuchMethodException even though the tester's
+        // constructor declares the Dialog subclass rather than Dialog.
+        CustomDialog dialog = new CustomDialog();
+
+        CustomDialogTester tester = test(CustomDialogTester.class, dialog);
+        Assertions.assertNotNull(tester);
+    }
+
+    @Test
+    public void wrapDialogSubclass_asComponent_returnsCustomTester() {
+        // The registry-based resolution must also instantiate the custom tester
+        // when the component is wrapped through the generic test(Component)
+        // path.
+        Component dialog = new CustomDialog();
+
+        Assertions.assertInstanceOf(CustomDialogTester.class, test(dialog));
     }
 
     @Test

--- a/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
+++ b/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
@@ -236,8 +236,20 @@ public abstract class BaseBrowserlessTest {
         return TesterRegistry.wrap(component);
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     protected static <T extends ComponentTester<Y>, Y extends Component> T internalWrap(
             Class<T> wrap, Y component) {
+        // The generated typed overloads in TesterWrappers pass the built-in
+        // tester for the declared parameter type. Prefer a more specific tester
+        // registered via @Tests when one is available, so that a custom tester
+        // for a component subclass is returned instead of the built-in base
+        // tester. Fall back to the requested type when no compatible tester is
+        // registered.
+        Class<? extends ComponentTester> resolved = TesterRegistry
+                .resolve(component.getClass());
+        if (wrap.isAssignableFrom(resolved)) {
+            return (T) TesterRegistry.instantiate(resolved, component);
+        }
         return TesterRegistry.instantiate(wrap, component);
     }
 

--- a/shared/src/main/java/com/vaadin/browserless/TesterRegistry.java
+++ b/shared/src/main/java/com/vaadin/browserless/TesterRegistry.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.browserless;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -215,8 +216,7 @@ final class TesterRegistry {
     static <T extends ComponentTester<Y>, Y extends Component> T instantiate(
             Class<T> testerClass, Y component) {
         try {
-            final Class<?> componentType = detectComponentType(testerClass);
-            return testerClass.getConstructor(componentType)
+            return findConstructor(testerClass, component.getClass())
                     .newInstance(component);
         } catch (InstantiationException | IllegalAccessException
                 | InvocationTargetException | NoSuchMethodException e) {
@@ -224,6 +224,55 @@ final class TesterRegistry {
                     + testerClass.getSimpleName() + " for component "
                     + component.getClass().getSimpleName(), e);
         }
+    }
+
+    /**
+     * Finds the single-argument constructor of the given tester that best
+     * accepts the supplied component type.
+     * <p>
+     * A custom tester may declare its constructor with a narrower parameter
+     * type than the one resolved from the generic {@code ComponentTester<T>}
+     * declaration. For example a tester extending {@code DialogTester} (which
+     * binds {@code T} to {@code Dialog}) can wrap a {@code Dialog} subclass and
+     * declare a constructor taking that subclass. Looking the constructor up
+     * solely by the generic type would fail with a {@link NoSuchMethodException}
+     * because {@link Class#getConstructor} matches parameter types exactly.
+     * <p>
+     * This method instead selects the most specific public constructor whose
+     * sole parameter is assignable from the component's runtime type, falling
+     * back to the generic component type so the original error is reported when
+     * no compatible constructor exists.
+     *
+     * @param testerClass
+     *            the tester class to instantiate
+     * @param componentClass
+     *            the runtime type of the component to wrap
+     * @return a matching constructor
+     * @throws NoSuchMethodException
+     *             if no compatible constructor is found
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends ComponentTester<?>> Constructor<T> findConstructor(
+            Class<T> testerClass, Class<?> componentClass)
+            throws NoSuchMethodException {
+        Constructor<?> bestMatch = null;
+        for (Constructor<?> candidate : testerClass.getConstructors()) {
+            if (candidate.getParameterCount() != 1) {
+                continue;
+            }
+            Class<?> parameterType = candidate.getParameterTypes()[0];
+            if (!parameterType.isAssignableFrom(componentClass)) {
+                continue;
+            }
+            if (bestMatch == null || bestMatch.getParameterTypes()[0]
+                    .isAssignableFrom(parameterType)) {
+                bestMatch = candidate;
+            }
+        }
+        if (bestMatch != null) {
+            return (Constructor<T>) bestMatch;
+        }
+        return testerClass.getConstructor(detectComponentType(testerClass));
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/TesterRegistry.java
+++ b/shared/src/main/java/com/vaadin/browserless/TesterRegistry.java
@@ -235,8 +235,9 @@ final class TesterRegistry {
      * declaration. For example a tester extending {@code DialogTester} (which
      * binds {@code T} to {@code Dialog}) can wrap a {@code Dialog} subclass and
      * declare a constructor taking that subclass. Looking the constructor up
-     * solely by the generic type would fail with a {@link NoSuchMethodException}
-     * because {@link Class#getConstructor} matches parameter types exactly.
+     * solely by the generic type would fail with a
+     * {@link NoSuchMethodException} because {@link Class#getConstructor}
+     * matches parameter types exactly.
      * <p>
      * This method instead selects the most specific public constructor whose
      * sole parameter is assignable from the component's runtime type, falling


### PR DESCRIPTION
Custom testers extending a concrete built-in tester (e.g. DialogTester, which binds the generic component type to Dialog) could not be obtained when wrapping a Dialog subclass:

- TesterRegistry.instantiate looked the constructor up via Class#getConstructor using the generic-resolved component type, which matches parameter types exactly. A custom tester declaring its constructor with the narrower subclass type failed with NoSuchMethodException.
- The generated typed test(Dialog) overload hard-coded DialogTester, shadowing the registry so a registered custom tester was never returned even though it is a DialogTester.

TesterRegistry now selects the most specific public single-argument constructor assignable from the component's runtime type, falling back to the generic type for the original error. internalWrap(Class, component) prefers a more specific tester registered via @Tests when one is assignable to the requested type, so the typed convenience overloads honor custom testers while explicit test(Class, component) calls are unchanged.

Fixes https://github.com/vaadin/browserless-test/issues/100
