### PR TITLE
fix: AccordionTester.openDetails simulates a client-side open

### DIFF
--- a/junit6/src/test/java/com/vaadin/flow/component/accordion/AccordionTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/accordion/AccordionTesterTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.accordion;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.OptionalInt;
 
 import org.junit.jupiter.api.Assertions;
@@ -73,6 +75,23 @@ class AccordionTesterTest extends BrowserlessTest {
                 "Green panel should exist");
         Assertions.assertFalse(wrap.hasPanel("Orange"),
                 "No Orange panel is added");
+    }
+
+    @Test
+    void openDetails_viaTester_eventFiredWithFromClientTrue() {
+        final List<Accordion.OpenedChangeEvent> events = new ArrayList<>();
+        view.accordion.addOpenedChangeListener(events::add);
+
+        test(view.accordion).openDetails("Green");
+
+        Assertions.assertEquals(1, events.size(),
+                "Opening a panel should fire a single OpenedChangeEvent");
+        Accordion.OpenedChangeEvent event = events.get(0);
+        Assertions.assertTrue(event.isFromClient(),
+                "Tester open simulates a user interaction and should report isFromClient() == true");
+        Assertions.assertEquals(OptionalInt.of(1), event.getOpenedIndex());
+        Assertions.assertTrue(test(view.accordion).isOpen("Green"),
+                "Green should be open");
     }
 
     @Test

--- a/shared/src/main/java/com/vaadin/flow/component/accordion/AccordionTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/accordion/AccordionTester.java
@@ -19,6 +19,8 @@ import org.jetbrains.annotations.Nullable;
 
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
+import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
+import com.vaadin.flow.internal.nodefeature.PropertyChangeDeniedException;
 
 @Tests(Accordion.class)
 public class AccordionTester<T extends Accordion> extends ComponentTester<T> {
@@ -47,7 +49,21 @@ public class AccordionTester<T extends Accordion> extends ComponentTester<T> {
             throw new IllegalArgumentException(
                     "No dropdown found for '" + summary + "'");
         }
-        getComponent().open(childPanel);
+        // Simulate a user opening the panel so that the resulting
+        // OpenedChangeEvent reports isFromClient() == true, consistent with the
+        // other interaction testers.
+        int index = getComponent().getElement()
+                .indexOfChild(childPanel.getElement());
+        try {
+            getComponent().getElement().getNode()
+                    .getFeature(ElementPropertyMap.class)
+                    .deferredUpdateFromClient("opened", (double) index).run();
+        } catch (PropertyChangeDeniedException e) {
+            throw new IllegalStateException(
+                    "Unable to simulate opening the accordion panel '" + summary
+                            + "'",
+                    e);
+        }
         roundTrip();
     }
 


### PR DESCRIPTION
AccordionTester.openDetails called the server-side Accordion.open(panel) API, so the resulting OpenedChangeEvent reported isFromClient() == false. Every other interaction tester (NativeDetailsTester, MenuBarTester, RadioButtonTester, ...) simulates a user interaction and fires events with fromClient == true. Make openDetails consistent by applying the opened-index update as a client-originated property change, which fires a single OpenedChangeEvent with isFromClient() == true.

Add a test asserting the tester-driven open reports isFromClient() == true.
