### PR TITLE
feat: add DashboardTester for widget move/resize/remove

### DIFF
--- a/junit6/src/test/java/com/vaadin/flow/component/dashboard/DashboardTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/dashboard/DashboardTesterTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.BrowserlessTest;
+import com.vaadin.browserless.CommercialTesterWrappers;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.flow.router.RouteConfiguration;
+
+@ViewPackages
+class DashboardTesterTest extends BrowserlessTest
+        implements CommercialTesterWrappers {
+
+    DashboardView view;
+
+    @BeforeEach
+    public void registerView() {
+        RouteConfiguration.forApplicationScope()
+                .setAnnotatedRoute(DashboardView.class);
+        view = navigate(DashboardView.class);
+    }
+
+    @Test
+    void moveWidget_reordersRootWidgets_firesEvent() {
+        test(view.dashboard).moveWidget(view.widget3, 0);
+
+        Assertions.assertEquals(
+                List.of(view.widget3, view.widget1, view.widget2, view.section),
+                view.dashboard.getChildren().toList());
+
+        Assertions.assertEquals(1, view.movedEvents.size());
+        DashboardItemMovedEvent event = view.movedEvents.get(0);
+        Assertions.assertSame(view.widget3, event.getItem());
+        Assertions.assertTrue(event.isFromClient());
+        Assertions.assertTrue(event.getSection().isEmpty());
+    }
+
+    @Test
+    void moveWidget_withinSection_reordersSection_firesEventWithSection() {
+        test(view.dashboard).moveWidget(view.sectionWidget2, 0);
+
+        Assertions.assertEquals(
+                List.of(view.sectionWidget2, view.sectionWidget1),
+                view.section.getWidgets());
+
+        Assertions.assertEquals(1, view.movedEvents.size());
+        DashboardItemMovedEvent event = view.movedEvents.get(0);
+        Assertions.assertSame(view.sectionWidget2, event.getItem());
+        Assertions.assertTrue(event.getSection().isPresent());
+        Assertions.assertSame(view.section, event.getSection().get());
+    }
+
+    @Test
+    void resizeWidget_updatesSpans_firesEvent() {
+        test(view.dashboard).resizeWidget(view.widget1, 2, 3);
+
+        Assertions.assertEquals(2, view.widget1.getColspan());
+        Assertions.assertEquals(3, view.widget1.getRowspan());
+
+        Assertions.assertEquals(1, view.resizedEvents.size());
+        DashboardItemResizedEvent event = view.resizedEvents.get(0);
+        Assertions.assertSame(view.widget1, event.getItem());
+        Assertions.assertTrue(event.isFromClient());
+    }
+
+    @Test
+    void removeWidget_removesWidget_firesEvent() {
+        test(view.dashboard).removeWidget(view.widget2);
+
+        Assertions.assertFalse(
+                view.dashboard.getWidgets().contains(view.widget2));
+        Assertions
+                .assertEquals(
+                        List.of(view.widget1, view.widget3, view.sectionWidget1,
+                                view.sectionWidget2),
+                        view.dashboard.getWidgets());
+
+        Assertions.assertEquals(1, view.removedEvents.size());
+        Assertions.assertSame(view.widget2,
+                view.removedEvents.get(0).getItem());
+    }
+
+    @Test
+    void removeWidget_withCustomHandler_letsApplicationDecide() {
+        AtomicReference<DashboardItemRemoveEvent> captured = new AtomicReference<>();
+        view.dashboard.setItemRemoveHandler(captured::set);
+
+        test(view.dashboard).removeWidget(view.widget1);
+
+        // The handler is invoked but the widget is not removed automatically.
+        Assertions.assertNotNull(captured.get());
+        Assertions.assertSame(view.widget1, captured.get().getItem());
+        Assertions
+                .assertTrue(view.dashboard.getWidgets().contains(view.widget1));
+        Assertions.assertTrue(view.removedEvents.isEmpty());
+
+        // The application removes it explicitly.
+        captured.get().removeItem();
+        Assertions.assertFalse(
+                view.dashboard.getWidgets().contains(view.widget1));
+        Assertions.assertEquals(1, view.removedEvents.size());
+    }
+
+    @Test
+    void interactions_whenNotEditable_throw() {
+        view.dashboard.setEditable(false);
+        DashboardTester<Dashboard> tester = test(view.dashboard);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> tester.moveWidget(view.widget1, 1));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> tester.resizeWidget(view.widget1, 2, 2));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> tester.removeWidget(view.widget1));
+    }
+
+    @Test
+    void interactions_withForeignWidget_throw() {
+        DashboardWidget stray = new DashboardWidget("Stray");
+        DashboardTester<Dashboard> tester = test(view.dashboard);
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> tester.moveWidget(stray, 0));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> tester.resizeWidget(stray, 1, 1));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> tester.removeWidget(stray));
+    }
+}

--- a/junit6/src/test/java/com/vaadin/flow/component/dashboard/DashboardView.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/dashboard/DashboardView.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+
+@Tag("div")
+@Route(value = "dashboard", registerAtStartup = false)
+public class DashboardView extends Component implements HasComponents {
+
+    final Dashboard dashboard = new Dashboard();
+
+    final DashboardWidget widget1 = new DashboardWidget("Widget 1");
+    final DashboardWidget widget2 = new DashboardWidget("Widget 2");
+    final DashboardWidget widget3 = new DashboardWidget("Widget 3");
+
+    final DashboardSection section;
+    final DashboardWidget sectionWidget1 = new DashboardWidget(
+            "Section Widget 1");
+    final DashboardWidget sectionWidget2 = new DashboardWidget(
+            "Section Widget 2");
+
+    final List<DashboardItemMovedEvent> movedEvents = new ArrayList<>();
+    final List<DashboardItemResizedEvent> resizedEvents = new ArrayList<>();
+    final List<DashboardItemRemovedEvent> removedEvents = new ArrayList<>();
+
+    public DashboardView() {
+        dashboard.setEditable(true);
+        dashboard.add(List.of(widget1, widget2, widget3));
+        section = dashboard.addSection("Section");
+        section.add(List.of(sectionWidget1, sectionWidget2));
+
+        dashboard.addItemMovedListener(movedEvents::add);
+        dashboard.addItemResizedListener(resizedEvents::add);
+        dashboard.addItemRemovedListener(removedEvents::add);
+
+        add(dashboard);
+    }
+}

--- a/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
+++ b/locator-processor/src/main/java/com/vaadin/browserless/locator/processor/LocatorProcessor.java
@@ -148,8 +148,9 @@ public class LocatorProcessor extends AbstractProcessor {
     private static final String OPT_COMMERCIAL_ENTRYPOINT_FQN = "locator.commercial.entrypoint.fqn";
     private static final String DEFAULT_ENTRYPOINT_FQN = "com.vaadin.browserless.locator.GeneratedLocators";
     private static final String DEFAULT_COMMERCIAL_ENTRYPOINT_FQN = "com.vaadin.browserless.locator.GeneratedCommercialLocators";
-    private static final List<String> DEFAULT_COMMERCIAL_PACKAGES = List
-            .of("com.vaadin.flow.component.charts");
+    private static final List<String> DEFAULT_COMMERCIAL_PACKAGES = List.of(
+            "com.vaadin.flow.component.charts",
+            "com.vaadin.flow.component.dashboard");
 
     /**
      * Public methods that we never delegate from the locator. These belong to

--- a/shared/src/main/java/com/vaadin/browserless/CommercialTesterWrappers.java
+++ b/shared/src/main/java/com/vaadin/browserless/CommercialTesterWrappers.java
@@ -17,6 +17,8 @@ package com.vaadin.browserless;
 
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.ChartTester;
+import com.vaadin.flow.component.dashboard.Dashboard;
+import com.vaadin.flow.component.dashboard.DashboardTester;
 
 /**
  * Provides factory method to create testers for commercial components.
@@ -33,6 +35,18 @@ public interface CommercialTesterWrappers {
      */
     default ChartTester<Chart> test(Chart chart) {
         return BaseBrowserlessTest.internalWrap(ChartTester.class, chart);
+    }
+
+    /**
+     * Create a tester for the given Dashboard instance.
+     *
+     * @param dashboard
+     *            the dashboard instance to be tested
+     * @return a DashboardTester instance wrapping the given dashboard
+     */
+    default DashboardTester<Dashboard> test(Dashboard dashboard) {
+        return BaseBrowserlessTest.internalWrap(DashboardTester.class,
+                dashboard);
     }
 
 }

--- a/shared/src/main/java/com/vaadin/flow/component/dashboard/DashboardTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/dashboard/DashboardTester.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.dashboard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import com.vaadin.browserless.ComponentTester;
+import com.vaadin.browserless.Tests;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.internal.JacksonUtils;
+
+/**
+ * Tester for the {@link Dashboard} component.
+ * <p>
+ * Simulates the interactions a user performs on an editable dashboard:
+ * reordering, resizing and removing widgets. Each method fires the same
+ * client-side event the web component sends, so the dashboard updates its
+ * server-side model and notifies any registered listeners exactly as it would
+ * in a browser. All three actions require the dashboard to be editable
+ * ({@link Dashboard#setEditable(boolean)}), mirroring the component: a user
+ * cannot move, resize or remove widgets otherwise.
+ *
+ * @param <T>
+ *            the dashboard type
+ * @since 1.1
+ */
+@Tests(Dashboard.class)
+public class DashboardTester<T extends Dashboard> extends ComponentTester<T> {
+
+    /**
+     * Wrap given component for testing.
+     *
+     * @param component
+     *            target component
+     */
+    public DashboardTester(T component) {
+        super(component);
+    }
+
+    /**
+     * Simulates a user dragging the given widget to a new position within its
+     * current container (the dashboard root, or the section it belongs to).
+     *
+     * @param widget
+     *            the widget to move, not {@code null}
+     * @param toIndex
+     *            the target index among the widget's siblings
+     * @throws IllegalStateException
+     *             if the dashboard is not editable
+     * @throws IllegalArgumentException
+     *             if the widget is not in this dashboard or the target index is
+     *             out of bounds
+     */
+    public void moveWidget(DashboardWidget widget, int toIndex) {
+        ensureComponentIsUsable();
+        ensureEditable();
+
+        DashboardSection section = findSection(widget);
+        List<Component> siblings = section == null
+                ? new ArrayList<>(getComponent().getChildren().toList())
+                : new ArrayList<>(section.getWidgets());
+
+        int from = siblings.indexOf(widget);
+        if (from < 0) {
+            throw new IllegalArgumentException(
+                    "The widget is not part of this dashboard");
+        }
+        if (toIndex < 0 || toIndex >= siblings.size()) {
+            throw new IllegalArgumentException("Target index " + toIndex
+                    + " is out of bounds (0.." + (siblings.size() - 1) + ")");
+        }
+        siblings.remove(from);
+        siblings.add(toIndex, widget);
+
+        ObjectNode eventData = JacksonUtils.createObjectNode();
+        eventData.put("event.detail.item", nodeId(widget));
+        if (section == null) {
+            eventData.set("event.detail.items", idArray(siblings));
+        } else {
+            eventData.set("event.detail.items",
+                    topLevelArrayWithSection(section, siblings));
+            eventData.put("event.detail.section", nodeId(section));
+        }
+        fireDomEvent("dashboard-item-moved-flow", eventData);
+        roundTrip();
+    }
+
+    /**
+     * Simulates a user resizing the given widget to the given column and row
+     * span.
+     *
+     * @param widget
+     *            the widget to resize, not {@code null}
+     * @param colspan
+     *            the new column span
+     * @param rowspan
+     *            the new row span
+     * @throws IllegalStateException
+     *             if the dashboard is not editable
+     * @throws IllegalArgumentException
+     *             if the widget is not in this dashboard
+     */
+    public void resizeWidget(DashboardWidget widget, int colspan, int rowspan) {
+        ensureComponentIsUsable();
+        ensureEditable();
+        ensureWidget(widget);
+
+        ObjectNode eventData = JacksonUtils.createObjectNode();
+        eventData.put("event.detail.item.id", nodeId(widget));
+        eventData.put("event.detail.item.colspan", colspan);
+        eventData.put("event.detail.item.rowspan", rowspan);
+        fireDomEvent("dashboard-item-resized", eventData);
+        roundTrip();
+    }
+
+    /**
+     * Simulates a user removing the given widget by clicking its remove button.
+     * <p>
+     * If the dashboard has a custom
+     * {@link Dashboard#setItemRemoveHandler(DashboardItemRemoveHandler) remove
+     * handler}, it receives the event and decides whether to remove the widget;
+     * otherwise the widget is removed immediately.
+     *
+     * @param widget
+     *            the widget to remove, not {@code null}
+     * @throws IllegalStateException
+     *             if the dashboard is not editable
+     * @throws IllegalArgumentException
+     *             if the widget is not in this dashboard
+     */
+    public void removeWidget(DashboardWidget widget) {
+        ensureComponentIsUsable();
+        ensureEditable();
+        ensureWidget(widget);
+
+        DashboardSection section = findSection(widget);
+        ObjectNode eventData = JacksonUtils.createObjectNode();
+        eventData.put("event.detail.item.id", nodeId(widget));
+        if (section != null) {
+            eventData.put("event.detail.section?.id", nodeId(section));
+        }
+        fireDomEvent("dashboard-item-before-remove", eventData);
+        roundTrip();
+    }
+
+    private void ensureEditable() {
+        if (!getComponent().isEditable()) {
+            throw new IllegalStateException(
+                    "Dashboard is not editable. A user can only move, resize or "
+                            + "remove widgets when the dashboard is in edit mode "
+                            + "(setEditable(true)).");
+        }
+    }
+
+    private void ensureWidget(DashboardWidget widget) {
+        if (!getComponent().getWidgets().contains(widget)) {
+            throw new IllegalArgumentException(
+                    "The widget is not part of this dashboard");
+        }
+    }
+
+    private DashboardSection findSection(DashboardWidget widget) {
+        return getComponent().getChildren()
+                .filter(DashboardSection.class::isInstance)
+                .map(DashboardSection.class::cast)
+                .filter(section -> section.getWidgets().contains(widget))
+                .findFirst().orElse(null);
+    }
+
+    private ArrayNode idArray(List<? extends Component> components) {
+        ArrayNode array = JacksonUtils.createArrayNode();
+        for (Component component : components) {
+            array.add(JacksonUtils.createObjectNode().put("id",
+                    nodeId(component)));
+        }
+        return array;
+    }
+
+    private ArrayNode topLevelArrayWithSection(DashboardSection section,
+            List<Component> reorderedSectionWidgets) {
+        ArrayNode array = JacksonUtils.createArrayNode();
+        for (Component child : getComponent().getChildren().toList()) {
+            ObjectNode entry = JacksonUtils.createObjectNode().put("id",
+                    nodeId(child));
+            if (child == section) {
+                entry.set("items", idArray(reorderedSectionWidgets));
+            }
+            array.add(entry);
+        }
+        return array;
+    }
+
+    private static int nodeId(Component component) {
+        return component.getElement().getNode().getId();
+    }
+}


### PR DESCRIPTION
Adds a tester for the commercial Dashboard component that simulates the interactions a user performs on an editable dashboard: reordering, resizing and removing widgets (at the dashboard root and within sections). Each method fires the same client-side DOM event the web component sends, so the dashboard updates its server-side model and notifies registered listeners exactly as in a browser; all three require edit mode, mirroring the component.

Registers test(Dashboard) in CommercialTesterWrappers and routes the generated findDashboard() locator to GeneratedCommercialLocators by adding the dashboard package to the processor's commercial-package list. Covered by DashboardTesterTest.
