### PR TITLE
feat: add BreadcrumbsTester.getItemPaths()

### DIFF
--- a/junit6/src/test/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsTesterTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.breadcrumbs;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
@@ -68,6 +69,20 @@ class BreadcrumbsTesterTest extends BrowserlessTest {
     void clickItem_byIndex_navigatesToItemPath() {
         test(view.breadcrumbs).clickItem(1);
         Assertions.assertEquals("breadcrumbs-target", currentPath());
+    }
+
+    @Test
+    void getItemPaths_returnsResolvedHrefs() {
+        Assertions.assertEquals(
+                Arrays.asList("breadcrumbs-target", "breadcrumbs-target", null),
+                test(view.breadcrumbs).getItemPaths());
+    }
+
+    @Test
+    void getItemPaths_skipsHiddenItems() {
+        hideItem("Docs");
+        Assertions.assertEquals(Arrays.asList("breadcrumbs-target", null),
+                test(view.breadcrumbs).getItemPaths());
     }
 
     @Test

--- a/shared/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsTester.java
@@ -48,6 +48,19 @@ public class BreadcrumbsTester<T extends Breadcrumbs>
     }
 
     /**
+     * Gets the resolved navigation path (href) of each breadcrumb item, in
+     * trail order. An item that has no navigable path (such as the current-page
+     * item) is represented by {@code null}; note that {@code null} is distinct
+     * from an empty string, which is the path of the application root.
+     *
+     * @return the item paths, with {@code null} for items that have no path
+     */
+    public List<String> getItemPaths() {
+        ensureComponentIsUsable();
+        return items().map(BreadcrumbsItem::getPath).toList();
+    }
+
+    /**
      * Simulates a click on the item that matches the given label, navigating to
      * its path.
      *


### PR DESCRIPTION
Exposes the resolved navigation path (href) of each breadcrumb item in trail order, so tests can assert link behavior without dropping to BreadcrumbsItem. Path-less items (such as the current page) are represented by null, distinct from an empty string which is the application root.
