### PR TITLE
fix: getSession(false) returns null after session invalidation (#115)

### DIFF
--- a/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockRequestTest.kt
+++ b/junit6/src/test/kotlin/com/vaadin/browserless/mocks/MockRequestTest.kt
@@ -52,12 +52,15 @@ class MockRequestTest : DynaTest({
         expectList("bar", "baz") { request.getParameterValues("foo")!!.toList() }
     }
 
-    test("getSession(false) returns the old invalid session") {
+    test("getSession(false) returns null once the session is invalidated") {
+        // Mirrors the servlet container contract: after invalidation there is
+        // no current session, so getSession(false) must return null rather than
+        // the stale, invalidated session. See issue #115.
         val session = request.session as MockHttpSession
         expect(true) { session.isValid }
         session.setAttribute("foo", "bar")
         session.invalidate()
-        expect(session) { request.getSession(false) }
+        expect(null) { request.getSession(false) }
         expect(false) { session.isValid }
     }
 

--- a/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/mocks/MockRequest.kt
@@ -85,15 +85,25 @@ open class MockRequest(private var session: HttpSession) : HttpServletRequest {
 
     override fun getServletPath(): String = ""
 
-    override fun getSession(create: Boolean): HttpSession {
+    override fun getSession(create: Boolean): HttpSession? {
         val isValid = (session as? MockHttpSession)?.isValid ?: true
-        if (create && !isValid) {
+        if (!isValid) {
+            // Mirror the servlet container contract: once the session has been
+            // invalidated there is no current session, so getSession(false)
+            // must return null (and getSession(true) must create a fresh one).
+            // Returning the stale, invalidated session instead made code that
+            // legitimately touches it after logout (e.g. Spring Security's
+            // HttpSessionSecurityContextRepository.saveContext) throw
+            // IllegalStateException. See issue #115.
+            if (!create) {
+                return null
+            }
             session = MockHttpSession.create(session.servletContext)
         }
         return session
     }
 
-    override fun getSession(): HttpSession = getSession(true)
+    override fun getSession(): HttpSession = getSession(true)!!
 
     override fun getServerName(): String = "127.0.0.1"
 

--- a/spring/src/test/java/com/vaadin/browserless/LogoutTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/LogoutTest.java
@@ -68,7 +68,8 @@ class LogoutTest {
 
         // This is the exact logout sequence from issue #115. The handler
         // invalidates the HttpSession and then asks the
-        // HttpSessionSecurityContextRepository to store the (now empty) context.
+        // HttpSessionSecurityContextRepository to store the (now empty)
+        // context.
         // In a real servlet container request.getSession(false) returns null
         // after invalidation, so saving the empty context is a no-op. The mock
         // request must honour the same contract instead of returning the stale,
@@ -94,8 +95,7 @@ class LogoutTest {
                 "Authentication should be cleared after logout");
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> window.navigate(ProtectedView.class));
-        Assertions.assertInstanceOf(LoginView.class,
-                window.getCurrentView());
+        Assertions.assertInstanceOf(LoginView.class, window.getCurrentView());
     }
 
     @Test

--- a/spring/src/test/java/com/vaadin/browserless/LogoutTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/LogoutTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.testapp.security.LoginView;
+import com.testapp.security.ProtectedView;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.vaadin.flow.server.VaadinServletRequest;
+import com.vaadin.flow.server.VaadinServletResponse;
+
+/**
+ * Reproduces issue #115: invoking Spring Security's
+ * {@link SecurityContextLogoutHandler} from within a browserless test must not
+ * throw, mirroring how it behaves inside a real servlet container.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
+class LogoutTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private SecuredBrowserlessApplicationContext<Authentication> app;
+
+    @BeforeEach
+    void setUp() {
+        app = SpringBrowserlessApplicationContext
+                .createSecured(applicationContext, "com.testapp.security");
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void securityContextLogoutHandler_doesNotThrow() {
+        var user = app.newUser("john", "USER");
+        var window = user.newWindow();
+        window.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                window.getCurrentView());
+
+        // This is the exact logout sequence from issue #115. The handler
+        // invalidates the HttpSession and then asks the
+        // HttpSessionSecurityContextRepository to store the (now empty) context.
+        // In a real servlet container request.getSession(false) returns null
+        // after invalidation, so saving the empty context is a no-op. The mock
+        // request must honour the same contract instead of returning the stale,
+        // invalidated session (which would throw IllegalStateException).
+        Assertions.assertDoesNotThrow(LogoutTest::logout);
+    }
+
+    @Test
+    void afterLogout_sameWindow_redirectsToLogin() {
+        var user = app.newUser("john", "USER");
+        var window = user.newWindow();
+        window.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                window.getCurrentView());
+
+        logout();
+
+        // Logging out clears the authentication, so the now-anonymous user is
+        // redirected to the login view when trying to reach the protected view
+        // again in the same window.
+        Assertions.assertNull(
+                SecurityContextHolder.getContext().getAuthentication(),
+                "Authentication should be cleared after logout");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> window.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                window.getCurrentView());
+    }
+
+    @Test
+    void afterLogout_newUserCanLogInAgain() {
+        var user = app.newUser("john", "USER");
+        var window = user.newWindow();
+        window.navigate(ProtectedView.class);
+        logout();
+
+        // A fresh authenticated user (a new login) gets its own session and
+        // reaches the protected view, proving the invalidated-session teardown
+        // does not leak into subsequent logins.
+        var newUser = app.newUser("jane", "USER");
+        var newWindow = newUser.newWindow();
+        newWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                newWindow.getCurrentView());
+    }
+
+    /**
+     * Performs the issue #115 logout sequence against the currently active
+     * window's request/response.
+     */
+    private static void logout() {
+        new SecurityContextLogoutHandler().logout(
+                VaadinServletRequest.getCurrent().getHttpServletRequest(),
+                VaadinServletResponse.getCurrent().getHttpServletResponse(),
+                null);
+    }
+}


### PR DESCRIPTION
MockRequest.getSession(false) returned the stale, invalidated session instead of null once the session had been invalidated, violating the servlet container contract. This broke logout: Spring Security's SecurityContextLogoutHandler invalidates the HttpSession and then calls HttpSessionSecurityContextRepository.saveContext, which looks up request.getSession(false). In a real container that returns null and the empty-context save is a no-op, but the mock handed back the invalidated MockHttpSession, so removing the security-context attribute threw IllegalStateException("invalidated").

Honour the servlet contract: once invalidated, getSession(false) returns null and getSession(true) creates a fresh session. Add LogoutTest covering the issue #115 sequence plus the logout->redirect-to-login and logout->new-login flows, and update MockRequestTest to assert the corrected behaviour.

Fixes #115