### PR TITLE
fix: report 'not opened' reason for closed LoginOverlay (#114)

### DIFF
--- a/junit6/src/test/java/com/vaadin/flow/component/login/LoginOverlayTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/login/LoginOverlayTesterTest.java
@@ -40,8 +40,12 @@ public class LoginOverlayTesterTest extends BrowserlessTest {
 
     @Test
     void overlayClosed_throwsException() {
-        Assertions.assertThrows(IllegalStateException.class,
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
                 () -> login_.login("user", "user"));
+        Assertions.assertTrue(exception.getMessage().contains("not opened"),
+                "Reason for a closed overlay should be reported, but was: "
+                        + exception.getMessage());
     }
 
     @Test

--- a/shared/src/main/java/com/vaadin/flow/component/login/LoginOverlayTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/login/LoginOverlayTester.java
@@ -47,7 +47,7 @@ public class LoginOverlayTester<T extends LoginOverlay>
     @Override
     protected void notUsableReasons(Consumer<String> collector) {
         super.notUsableReasons(collector);
-        if (getComponent().isOpened()) {
+        if (!getComponent().isOpened()) {
             collector.accept("not opened");
         }
     }


### PR DESCRIPTION
The notUsableReasons() check was inverted, collecting the reason when the overlay was open instead of closed. ensureComponentIsUsable() on a closed LoginOverlay therefore threw without explaining the cause.

Negate the condition to match isUsable() and assert the reason is now present in the thrown message.

Fixes #114 