### PR TITLE
fix: keep new windows unauthenticated after logout

### DIFF
--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -88,7 +88,8 @@ public class BrowserlessUIContext
         // UI.setCurrent itself after instantiating the UI, so leaving it
         // alone avoids clobbering a prior UI if createUI throws before
         // reaching its own UI.setCurrent. On same-user re-entry the security
-        // restore is a no-op (snapshot matches live thread state).
+        // snapshot is intentionally not restored, so the live thread state
+        // (including any logout) is preserved for the new window.
         user.applySessionThreadLocals();
 
         try {
@@ -142,8 +143,9 @@ public class BrowserlessUIContext
         }
 
         // Install this user's Vaadin thread-locals and UI, restoring the
-        // user's security snapshot. On same-user re-entry the security
-        // restore is a no-op (snapshot matches live thread state).
+        // user's security snapshot. On same-user re-entry the snapshot is
+        // intentionally not restored, so a logout (or any security mutation)
+        // made in a sibling window stays visible.
         user.applyUIThreadLocals(ui);
 
         activeContext.set(this);

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUserContext.java
@@ -52,8 +52,12 @@ import com.vaadin.flow.server.VaadinSession;
  * The security snapshot is <strong>per-user, not per-window</strong>: all of a
  * user's windows share one snapshot. Security-context mutations made while one
  * window is active persist on the thread and remain visible to other windows of
- * the same user; the snapshot is re-captured only on user-switch, so same-user
- * window switches don't touch it.
+ * the same user, including newly opened ones: the snapshot is neither saved nor
+ * restored on a same-user window switch, so it is touched only on a
+ * user-switch. Consequently a logout performed in one window leaves the user
+ * logged out in every other window — to authenticate again, create a fresh user
+ * context with {@link BrowserlessApplicationContext#newUser()} rather than
+ * reusing this one.
  *
  * @see BrowserlessApplicationContext#newUser()
  * @see BrowserlessUIContext
@@ -163,6 +167,12 @@ public class BrowserlessUserContext implements AutoCloseable {
      * The window is automatically activated (thread-locals set) and a new UI is
      * created. If a route target for {@code ""} is registered, the UI will
      * navigate to it.
+     * <p>
+     * A window opened after the user has logged out shares the user's
+     * logged-out security state: it does not restore the pre-logout snapshot.
+     * To log in again, create a fresh user context with
+     * {@link BrowserlessApplicationContext#newUser()} instead of reusing this
+     * one.
      *
      * @return the new UI context
      */
@@ -332,13 +342,26 @@ public class BrowserlessUserContext implements AutoCloseable {
      * Restores this user's security context onto the current thread. Called
      * automatically by {@link BrowserlessUIContext#activate()} when switching
      * to this user.
+     * <p>
+     * Restoring is skipped when the currently-active window already belongs to
+     * this user: the live thread then holds this user's authoritative security
+     * state, and restoring the snapshot would clobber a mutation a sibling
+     * window made (e.g. a logout). This mirrors the save side, which only
+     * captures the snapshot on a cross-user switch — so same-user window
+     * switches neither save nor restore, and a logout in one window is observed
+     * by the user's other windows, existing and newly opened.
      */
     void restoreSecurityContext() {
         SecurityContextHandler<?> handler = app.getSecurityContextHandler();
-        if (handler != null) {
-            // Contract: handler.restoreContext(null) clears the context.
-            handler.restoreContext(securitySnapshot);
+        if (handler == null) {
+            return;
         }
+        BrowserlessUIContext active = BrowserlessUIContext.getActive();
+        if (active != null && active.getUser() == this) {
+            return;
+        }
+        // Contract: handler.restoreContext(null) clears the context.
+        handler.restoreContext(securitySnapshot);
     }
 
     private void checkNotClosed() {

--- a/spring/src/test/java/com/vaadin/browserless/LogoutTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/LogoutTest.java
@@ -37,6 +37,10 @@ import com.vaadin.flow.server.VaadinServletResponse;
  * Reproduces issue #115: invoking Spring Security's
  * {@link SecurityContextLogoutHandler} from within a browserless test must not
  * throw, mirroring how it behaves inside a real servlet container.
+ * <p>
+ * Also covers issue #127: a logout in one window must leave new windows of the
+ * same user unauthenticated, rather than restoring a stale authenticated
+ * security snapshot.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = SecurityTestConfig.NavigationAccessControlConfig.class)
@@ -96,6 +100,72 @@ class LogoutTest {
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> window.navigate(ProtectedView.class));
         Assertions.assertInstanceOf(LoginView.class, window.getCurrentView());
+    }
+
+    @Test
+    void afterLogout_newWindow_isAlsoUnauthenticated() {
+        var user = app.newUser("john", "USER");
+        var window = user.newWindow();
+        window.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                window.getCurrentView());
+
+        // Clear the authentication by *replacing* the security context, the
+        // way SecurityContextHolder.clearContext() (and a fresh per-request
+        // context load in a real container) does. This is deliberately not the
+        // SecurityContextLogoutHandler used by the other tests: that handler
+        // clears auth with an in-place context.setAuthentication(null), which
+        // mutates the very object the per-user snapshot aliases and so happens
+        // to clear the snapshot too, masking this bug. A replacing clear leaves
+        // the saved snapshot authenticated and exposes #127.
+        SecurityContextHolder.clearContext();
+
+        // Opening another window for the *same* user after logout must not
+        // restore the stale authenticated snapshot. The new window must
+        // observe the logged-out state, mirroring a real application where
+        // logging out in one tab logs the user out of all tabs, existing and
+        // new (issue #127).
+        var newWindow = user.newWindow();
+        Assertions.assertNull(
+                SecurityContextHolder.getContext().getAuthentication(),
+                "Authentication should remain cleared in a window opened after"
+                        + " logout");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> newWindow.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                newWindow.getCurrentView());
+    }
+
+    @Test
+    void afterLogout_switchUserAndBack_newWindowStillUnauthenticated() {
+        var user = app.newUser("john", "USER");
+        var window = user.newWindow();
+        window.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                window.getCurrentView());
+
+        logout();
+
+        // Switch to a different user. The cross-user switch captures the
+        // outgoing (logged-out) user's live state into its snapshot.
+        var other = app.newUser("jane", "USER");
+        var otherWindow = other.newWindow();
+        otherWindow.navigate(ProtectedView.class);
+        Assertions.assertInstanceOf(ProtectedView.class,
+                otherWindow.getCurrentView());
+
+        // Switch back to the logged-out user via a new window: it must still
+        // be unauthenticated. This guards that the same-user no-clobber rule
+        // does not suppress a legitimate cross-user restore (issue #127).
+        var newWindow = user.newWindow();
+        Assertions.assertNull(
+                SecurityContextHolder.getContext().getAuthentication(),
+                "Original user must remain logged out after a round-trip"
+                        + " through another user");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> newWindow.navigate(ProtectedView.class));
+        Assertions.assertInstanceOf(LoginView.class,
+                newWindow.getCurrentView());
     }
 
     @Test


### PR DESCRIPTION
After a logout, opening another window for the same user restored a stale authenticated security snapshot, leaving the user logged out in one window but logged in in the next.

Skip restoring the per-user security snapshot on same-user window switches so the live post-logout state is preserved. Add `LogoutTest` coverage for opening a window after logout.

Fixes #127
