### PR TITLE
docs: reconcile @since tags against release history

### DIFF
--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessTest.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessTest.java
@@ -112,6 +112,7 @@ import org.junit.jupiter.api.BeforeEach;
  * @see BrowserlessExtension
  *
  * @see BrowserlessClassExtension
+ * @since 1.0
  */
 public abstract class BrowserlessTest extends BaseBrowserlessTest
         implements TesterWrappers {

--- a/junit6/src/main/java/com/vaadin/browserless/TreeOnFailureExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/TreeOnFailureExtension.java
@@ -27,6 +27,8 @@ import com.vaadin.flow.component.UI;
  * <p>
  * This can help with identifying a problem that has happened in the test where
  * a component is missing or has faulty data.
+ *
+ * @since 1.0
  */
 public class TreeOnFailureExtension implements AfterTestExecutionCallback {
 

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
@@ -77,6 +77,8 @@ import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
  * fires <em>after</em> all extension {@code beforeEach} callbacks — in
  * particular after {@code QuarkusTestExtension.beforeEach()}, which activates
  * the CDI request scope and applies {@code @TestSecurity} identities.
+ *
+ * @since 1.0
  */
 public abstract class QuarkusBrowserlessTest extends BaseBrowserlessTest
         implements TesterWrappers {

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusSecurityCustomizer.java
@@ -25,6 +25,8 @@ import com.vaadin.browserless.mocks.MockRequest;
  * Configures mock request with authentication details from Quarkus Security.
  *
  * For internal use only.
+ *
+ * @since 1.0
  */
 public class QuarkusSecurityCustomizer implements MockRequestCustomizer {
 

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusTestLookupInitializer.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusTestLookupInitializer.java
@@ -32,6 +32,8 @@ import com.vaadin.flow.server.VaadinContext;
  * Currently, provides integration with Quarkus security.
  *
  * For internal use only.
+ *
+ * @since 1.0
  */
 public class QuarkusTestLookupInitializer extends LookupInitializer {
 

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/mocks/MockQuarkusServlet.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/mocks/MockQuarkusServlet.java
@@ -35,6 +35,8 @@ import com.vaadin.quarkus.QuarkusVaadinServlet;
  * Makes sure that the {@link #routes} are properly registered, and that
  * {@link MockQuarkusServletService} is used instead of vanilla
  * {@link com.vaadin.quarkus.QuarkusVaadinServletService}.
+ *
+ * @since 1.0
  */
 public class MockQuarkusServlet extends QuarkusVaadinServlet {
 

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/mocks/MockQuarkusServletService.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/mocks/MockQuarkusServletService.java
@@ -38,6 +38,8 @@ import com.vaadin.quarkus.QuarkusVaadinServletService;
  * {@link com.vaadin.flow.server.VaadinSession}.</li>
  * </ul>
  * The class is intentionally opened, to be extensible in user's library.
+ *
+ * @since 1.0
  */
 public class MockQuarkusServletService extends QuarkusVaadinServletService {
 

--- a/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
+++ b/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.server.VaadinSession;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @see ViewPackages
+ * @since 1.0
  */
 public abstract class BaseBrowserlessTest {
 

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessTestSetupException.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessTestSetupException.java
@@ -18,6 +18,8 @@ package com.vaadin.browserless;
 /**
  * Exception thrown by {@link BaseBrowserlessTest} methods when the mock
  * environment has not been set up correctly.
+ *
+ * @since 1.0
  */
 public class BrowserlessTestSetupException extends RuntimeException {
     public BrowserlessTestSetupException(String message) {

--- a/shared/src/main/java/com/vaadin/browserless/Clickable.java
+++ b/shared/src/main/java/com/vaadin/browserless/Clickable.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.ComponentUtil;
  *
  * @param <T>
  *            the type of component being tested
+ * @since 1.0
  */
 public interface Clickable<T extends Component> {
 

--- a/shared/src/main/java/com/vaadin/browserless/CommercialTesterWrappers.java
+++ b/shared/src/main/java/com/vaadin/browserless/CommercialTesterWrappers.java
@@ -22,6 +22,8 @@ import com.vaadin.flow.component.dashboard.DashboardTester;
 
 /**
  * Provides factory method to create testers for commercial components.
+ *
+ * @since 1.0
  */
 @SuppressWarnings("unchecked")
 public interface CommercialTesterWrappers {
@@ -43,6 +45,7 @@ public interface CommercialTesterWrappers {
      * @param dashboard
      *            the dashboard instance to be tested
      * @return a DashboardTester instance wrapping the given dashboard
+     * @since 1.1
      */
     default DashboardTester<Dashboard> test(Dashboard dashboard) {
         return BaseBrowserlessTest.internalWrap(DashboardTester.class,

--- a/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentQuery.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.dom.Element;
  * @param <T>
  *            the type of the component(s) to search for
  * @see ComponentTester
+ * @since 1.0
  */
 public class ComponentQuery<T extends Component> {
 

--- a/shared/src/main/java/com/vaadin/browserless/ComponentTester.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentTester.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 public class ComponentTester<T extends Component> implements Clickable<T> {
 

--- a/shared/src/main/java/com/vaadin/browserless/ComponentTesterPackages.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentTesterPackages.java
@@ -27,6 +27,8 @@ import java.lang.annotation.Target;
  * <p/>
  * This makes adding custom component wrappers simpler as they can then use
  * package protected fields and methods.
+ *
+ * @since 1.0
  */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
+++ b/shared/src/main/java/com/vaadin/browserless/ElementConditions.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.dom.Element;
  * conditions.
  *
  * @see ComponentQuery#withCondition(Predicate)
+ * @since 1.0
  */
 public final class ElementConditions {
 

--- a/shared/src/main/java/com/vaadin/browserless/LitRendererTestUtil.java
+++ b/shared/src/main/java/com/vaadin/browserless/LitRendererTestUtil.java
@@ -29,6 +29,8 @@ import com.vaadin.flow.function.ValueProvider;
 
 /**
  * Utility methods for unit testing properties and functions of LitRenderers.
+ *
+ * @since 1.0
  */
 public class LitRendererTestUtil {
 

--- a/shared/src/main/java/com/vaadin/browserless/MetaKeys.java
+++ b/shared/src/main/java/com/vaadin/browserless/MetaKeys.java
@@ -17,6 +17,8 @@ package com.vaadin.browserless;
 
 /**
  * Class for setting any down meta keys for events supporting meta keys.
+ *
+ * @since 1.0
  */
 public class MetaKeys {
     private boolean ctrl = false;

--- a/shared/src/main/java/com/vaadin/browserless/MouseButton.java
+++ b/shared/src/main/java/com/vaadin/browserless/MouseButton.java
@@ -28,6 +28,8 @@ package com.vaadin.browserless;
  * <dt>4: The second additional button, typically the forward button</dt>
  * <dt>5+: More additional buttons without any typical meanings</dt>
  * </dl>
+ *
+ * @since 1.0
  */
 public enum MouseButton {
 

--- a/shared/src/main/java/com/vaadin/browserless/SerializationDebugUtil.java
+++ b/shared/src/main/java/com/vaadin/browserless/SerializationDebugUtil.java
@@ -29,6 +29,9 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * @since 1.0
+ */
 public final class SerializationDebugUtil {
 
     private SerializationDebugUtil() {

--- a/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
+++ b/shared/src/main/java/com/vaadin/browserless/TestSignalEnvironment.java
@@ -60,6 +60,8 @@ import com.vaadin.flow.signals.SignalEnvironment;
  *
  * <p>
  * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 1.0
  */
 public class TestSignalEnvironment extends SignalEnvironment {
 

--- a/shared/src/main/java/com/vaadin/browserless/TesterWrappers.java
+++ b/shared/src/main/java/com/vaadin/browserless/TesterWrappers.java
@@ -147,6 +147,9 @@ import com.vaadin.flow.component.virtuallist.VirtualList;
 import com.vaadin.flow.component.virtuallist.VirtualListTester;
 import com.vaadin.flow.router.RouterLink;
 
+/**
+ * @since 1.0
+ */
 @SuppressWarnings("unchecked")
 public interface TesterWrappers {
 

--- a/shared/src/main/java/com/vaadin/browserless/Tests.java
+++ b/shared/src/main/java/com/vaadin/browserless/Tests.java
@@ -28,6 +28,8 @@ import com.vaadin.flow.component.Component;
  * <p/>
  * This is used for automatically selecting a wrapper implementation for a given
  * component.
+ *
+ * @since 1.0
  */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/shared/src/main/java/com/vaadin/browserless/ViewPackages.java
+++ b/shared/src/main/java/com/vaadin/browserless/ViewPackages.java
@@ -29,6 +29,8 @@ import java.lang.annotation.Target;
  *
  * If both {@link #classes()} and {@link #packages()} are empty, the scan is
  * assumed to be limited to the annotated class package.
+ *
+ * @since 1.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/shared/src/main/java/com/vaadin/browserless/locator/HasPlaceholderFilter.java
+++ b/shared/src/main/java/com/vaadin/browserless/locator/HasPlaceholderFilter.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.HasPlaceholder;
  *            the component type, bound to {@link HasPlaceholder}
  * @param <SELF>
  *            the concrete locator subtype, used for fluent chaining
+ * @since 1.1
  */
 public interface HasPlaceholderFilter<C extends Component & HasPlaceholder, SELF extends Locator<C, SELF>> {
 
@@ -37,8 +38,6 @@ public interface HasPlaceholderFilter<C extends Component & HasPlaceholder, SELF
      * given value. Useful for toolbar / search fields that intentionally omit a
      * stacked label and identify themselves to the user via placeholder text
      * instead.
-     *
-     * @since 1.1
      */
     @SuppressWarnings("unchecked")
     default SELF withPlaceholder(String placeholder) {
@@ -49,8 +48,6 @@ public interface HasPlaceholderFilter<C extends Component & HasPlaceholder, SELF
     /**
      * Requires the matched component's {@code placeholder} to contain the given
      * text.
-     *
-     * @since 1.1
      */
     @SuppressWarnings("unchecked")
     default SELF withPlaceholderContaining(String text) {

--- a/shared/src/main/java/com/vaadin/flow/component/accordion/AccordionTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/accordion/AccordionTester.java
@@ -22,6 +22,9 @@ import com.vaadin.browserless.Tests;
 import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
 import com.vaadin.flow.internal.nodefeature.PropertyChangeDeniedException;
 
+/**
+ * @since 1.0
+ */
 @Tests(Accordion.class)
 public class AccordionTester<T extends Accordion> extends ComponentTester<T> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsTester.java
@@ -23,6 +23,9 @@ import com.vaadin.browserless.Tests;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 
+/**
+ * @since 1.1
+ */
 @Tests(Breadcrumbs.class)
 public class BreadcrumbsTester<T extends Breadcrumbs>
         extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/button/ButtonTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/button/ButtonTester.java
@@ -24,6 +24,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(Button.class)
 public class ButtonTester<T extends Button> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/charts/ChartTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/charts/ChartTester.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.component.charts.model.Series;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(Chart.class)
 public class ChartTester<T extends Chart> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupTester.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.data.binder.HasItemComponents;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(fqn = "com.vaadin.flow.component.checkbox.CheckboxGroup")
 public class CheckboxGroupTester<T extends CheckboxGroup<V>, V>

--- a/shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxTester.java
@@ -26,6 +26,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(Checkbox.class)
 public class CheckboxTester<T extends Checkbox> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/combobox/ComboBoxTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/combobox/ComboBoxTester.java
@@ -29,6 +29,9 @@ import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.function.SerializableConsumer;
 
+/**
+ * @since 1.0
+ */
 @Tests(fqn = "com.vaadin.flow.component.combobox.ComboBox")
 public class ComboBoxTester<T extends ComboBox<Y>, Y>
         extends ComponentTester<T> {
@@ -83,7 +86,7 @@ public class ComboBoxTester<T extends ComboBox<Y>, Y>
      * select from the filtered results.
      * <p>
      * Example usage with filtering:
-     * 
+     *
      * <pre>
      * // Apply filter first
      * comboBoxTester.setFilter("search text");

--- a/shared/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTester.java
@@ -31,6 +31,9 @@ import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.function.SerializableConsumer;
 
+/**
+ * @since 1.0
+ */
 @Tests(fqn = "com.vaadin.flow.component.combobox.MultiSelectComboBox")
 public class MultiSelectComboBoxTester<T extends MultiSelectComboBox<Y>, Y>
         extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialogTester.java
@@ -24,6 +24,8 @@ import com.vaadin.flow.dom.Element;
 
 /**
  * Tester for ConfirmDialog.
+ *
+ * @since 1.0
  */
 @Tests(ConfirmDialog.class)
 public class ConfirmDialogTester extends ComponentTester<ConfirmDialog> {

--- a/shared/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuTester.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.internal.JacksonUtils;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(ContextMenu.class)
 public class ContextMenuTester<T extends ContextMenu>
@@ -336,6 +337,7 @@ public class ContextMenuTester<T extends ContextMenu>
      *             if the provided text does not identify a menu item.
      * @throws IllegalStateException
      *             if the item at given path is not usable.
+     * @since 1.1
      */
     public String getItemTooltipText(String topLevelText,
             String... nestedItemsText) {
@@ -383,6 +385,7 @@ public class ContextMenuTester<T extends ContextMenu>
      *             if the provided position does not identify a menu item.
      * @throws IllegalStateException
      *             if the item at given position is not usable.
+     * @since 1.1
      */
     public String getItemTooltipText(int topLevelPosition,
             int... nestedItemsPositions) {

--- a/shared/src/main/java/com/vaadin/flow/component/datepicker/DatePickerTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/datepicker/DatePickerTester.java
@@ -27,6 +27,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(DatePicker.class)
 public class DatePickerTester<T extends DatePicker> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTester.java
@@ -28,6 +28,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(DateTimePicker.class)
 public class DateTimePickerTester<T extends DateTimePicker>

--- a/shared/src/main/java/com/vaadin/flow/component/details/DetailsTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/details/DetailsTester.java
@@ -23,6 +23,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(Details.class)
 public class DetailsTester<T extends Details> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/dialog/DialogTester.java
@@ -18,6 +18,9 @@ package com.vaadin.flow.component.dialog;
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Dialog.class)
 public class DialogTester extends ComponentTester<Dialog> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/grid/GridTester.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.internal.JacksonUtils;
  *            component type
  * @param <Y>
  *            item type
+ * @since 1.0
  */
 @Tests(fqn = { "com.vaadin.flow.component.grid.Grid" })
 public class GridTester<T extends Grid<Y>, Y> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/html/AnchorTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/AnchorTester.java
@@ -37,6 +37,9 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.streams.DownloadEvent;
 import com.vaadin.flow.server.streams.DownloadHandler;
 
+/**
+ * @since 1.0
+ */
 @Tests(Anchor.class)
 public class AnchorTester extends HtmlContainerTester<Anchor> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/DescriptionListTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/DescriptionListTester.java
@@ -20,6 +20,9 @@ import java.util.stream.Collectors;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(DescriptionList.class)
 public class DescriptionListTester extends HtmlClickContainer<DescriptionList> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/DivTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/DivTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Div.class)
 public class DivTester extends HtmlClickContainer<Div> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/EmphasisTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/EmphasisTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Emphasis.class)
 public class EmphasisTester extends HtmlClickContainer<Emphasis> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/H1Tester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/H1Tester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(H1.class)
 public class H1Tester extends HtmlClickContainer<H1> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/H2Tester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/H2Tester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(H2.class)
 public class H2Tester extends HtmlClickContainer<H2> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/H3Tester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/H3Tester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(H3.class)
 public class H3Tester extends HtmlClickContainer<H3> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/H4Tester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/H4Tester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(H4.class)
 public class H4Tester extends HtmlClickContainer<H4> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/H5Tester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/H5Tester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(H5.class)
 public class H5Tester extends HtmlClickContainer<H5> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/H6Tester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/H6Tester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(H6.class)
 public class H6Tester extends HtmlClickContainer<H6> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/HrTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/HrTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Hr.class)
 public class HrTester extends HtmlComponentTester<Hr> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/HtmlClickContainer.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/HtmlClickContainer.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.HtmlContainer;
 
+/**
+ * @since 1.0
+ */
 public abstract class HtmlClickContainer<T extends HtmlContainer>
         extends HtmlContainerTester<T> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/HtmlComponentTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/HtmlComponentTester.java
@@ -18,6 +18,9 @@ package com.vaadin.flow.component.html;
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.flow.component.HtmlComponent;
 
+/**
+ * @since 1.0
+ */
 public class HtmlComponentTester<T extends HtmlComponent>
         extends ComponentTester<T> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/HtmlContainerTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/HtmlContainerTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.HtmlContainer;
 
+/**
+ * @since 1.0
+ */
 public class HtmlContainerTester<T extends HtmlContainer>
         extends HtmlComponentTester<T> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/ImageTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/ImageTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Image.class)
 public class ImageTester extends HtmlClickContainer<Image> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/InputTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/InputTester.java
@@ -18,6 +18,9 @@ package com.vaadin.flow.component.html;
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Input.class)
 public class InputTester extends ComponentTester<Input> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/ListItemTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/ListItemTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(ListItem.class)
 public class ListItemTester extends HtmlClickContainer<ListItem> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/NativeButtonTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/NativeButtonTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(NativeButton.class)
 public class NativeButtonTester extends HtmlClickContainer<NativeButton> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/NativeDetailsTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/NativeDetailsTester.java
@@ -19,6 +19,9 @@ import com.vaadin.browserless.Tests;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 
+/**
+ * @since 1.0
+ */
 @Tests(NativeDetails.class)
 public class NativeDetailsTester extends HtmlComponentTester<NativeDetails> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/NativeLabelTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/NativeLabelTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(NativeLabel.class)
 public class NativeLabelTester extends HtmlContainerTester<NativeLabel> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/OrderedListTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/OrderedListTester.java
@@ -20,6 +20,9 @@ import java.util.stream.Collectors;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(OrderedList.class)
 public class OrderedListTester extends HtmlClickContainer<OrderedList> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/ParagraphTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/ParagraphTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Paragraph.class)
 public class ParagraphTester extends HtmlClickContainer<Paragraph> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/PreTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/PreTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Pre.class)
 public class PreTester extends HtmlClickContainer<Pre> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/RangeInputTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/RangeInputTester.java
@@ -20,6 +20,9 @@ import java.math.BigDecimal;
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(RangeInput.class)
 public class RangeInputTester extends ComponentTester<RangeInput> {
 

--- a/shared/src/main/java/com/vaadin/flow/component/html/SpanTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/SpanTester.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(Span.class)
 public class SpanTester extends HtmlClickContainer<Span> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/html/UnorderedListTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/html/UnorderedListTester.java
@@ -20,6 +20,9 @@ import java.util.stream.Collectors;
 
 import com.vaadin.browserless.Tests;
 
+/**
+ * @since 1.0
+ */
 @Tests(UnorderedList.class)
 public class UnorderedListTester extends HtmlClickContainer<UnorderedList> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/listbox/ListBoxTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/listbox/ListBoxTester.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.ItemLabelGenerator;
  *            component type
  * @param <V>
  *            value type
+ * @since 1.0
  */
 @Tests(fqn = { "com.vaadin.flow.component.listbox.ListBox" })
 public class ListBoxTester<T extends ListBox<V>, V> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBoxTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/listbox/MultiSelectListBoxTester.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.ItemLabelGenerator;
  *            component type
  * @param <V>
  *            value type
+ * @since 1.0
  */
 @Tests(fqn = { "com.vaadin.flow.component.listbox.MultiSelectListBox" })
 public class MultiSelectListBoxTester<T extends MultiSelectListBox<V>, V>

--- a/shared/src/main/java/com/vaadin/flow/component/login/AbstractLoginTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/login/AbstractLoginTester.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.ComponentUtil;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 public class AbstractLoginTester<T extends AbstractLogin>
         extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/login/LoginFormTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/login/LoginFormTester.java
@@ -22,6 +22,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(LoginForm.class)
 public class LoginFormTester<T extends LoginForm>

--- a/shared/src/main/java/com/vaadin/flow/component/login/LoginOverlayTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/login/LoginOverlayTester.java
@@ -24,6 +24,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(LoginOverlay.class)
 public class LoginOverlayTester<T extends LoginOverlay>

--- a/shared/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/masterdetaillayout/MasterDetailLayoutTester.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.Component;
  *
  * @param <T>
  *            component type
+ * @since 1.1
  */
 @Tests(MasterDetailLayout.class)
 public class MasterDetailLayoutTester<T extends MasterDetailLayout>

--- a/shared/src/main/java/com/vaadin/flow/component/menubar/MenuBarTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/menubar/MenuBarTester.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.contextmenu.MenuItem;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(MenuBar.class)
 public class MenuBarTester<T extends MenuBar> extends ComponentTester<T> {
@@ -279,6 +280,7 @@ public class MenuBarTester<T extends MenuBar> extends ComponentTester<T> {
      *             if the provided text does not identify a menu item.
      * @throws IllegalStateException
      *             if the item at given path is not usable.
+     * @since 1.1
      */
     public String getItemTooltipText(String topLevelText,
             String... nestedItemsText) {
@@ -326,6 +328,7 @@ public class MenuBarTester<T extends MenuBar> extends ComponentTester<T> {
      *             if the provided position does not identify a menu item.
      * @throws IllegalStateException
      *             if the item at given position is not usable.
+     * @since 1.1
      */
     public String getItemTooltipText(int topLevelPosition,
             int... nestedItemsPositions) {

--- a/shared/src/main/java/com/vaadin/flow/component/messages/MessageInputTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/messages/MessageInputTester.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.ComponentUtil;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(MessageInput.class)
 public class MessageInputTester<T extends MessageInput>

--- a/shared/src/main/java/com/vaadin/flow/component/messages/MessageListTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/messages/MessageListTester.java
@@ -27,6 +27,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(MessageList.class)
 public class MessageListTester<T extends MessageList>
@@ -132,6 +133,7 @@ public class MessageListTester<T extends MessageList>
      *         has no attachments
      * @throws IndexOutOfBoundsException
      *             – if the index is out of range (index < 0 || index >= size())
+     * @since 1.1
      */
     public List<MessageListItem.Attachment> getAttachments(int index) {
         ensureComponentIsUsable();
@@ -150,6 +152,7 @@ public class MessageListTester<T extends MessageList>
      *         has no attachment with the given name
      * @throws IndexOutOfBoundsException
      *             – if the index is out of range (index < 0 || index >= size())
+     * @since 1.1
      */
     public MessageListItem.Attachment getAttachmentByName(int index,
             String name) {

--- a/shared/src/main/java/com/vaadin/flow/component/notification/NotificationTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/notification/NotificationTester.java
@@ -25,6 +25,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(Notification.class)
 public class NotificationTester<T extends Notification>

--- a/shared/src/main/java/com/vaadin/flow/component/popover/PopoverTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/popover/PopoverTester.java
@@ -25,6 +25,8 @@ import com.vaadin.flow.component.ComponentUtil;
 
 /**
  * Tester for Popover components.
+ *
+ * @since 1.0
  */
 @Tests(Popover.class)
 public class PopoverTester extends ComponentTester<Popover> {

--- a/shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTester.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.data.binder.HasItemComponents;
  *            component type
  * @param <V>
  *            value type
+ * @since 1.0
  */
 @Tests(fqn = "com.vaadin.flow.component.radiobutton.RadioButtonGroup")
 public class RadioButtonGroupTester<T extends RadioButtonGroup<V>, V>

--- a/shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonTester.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.ComponentUtil;
  *            component type
  * @param <V>
  *            value type
+ * @since 1.0
  */
 @Tests(fqn = "com.vaadin.flow.component.radiobutton.RadioButton")
 public class RadioButtonTester<T extends RadioButton<V>, V>

--- a/shared/src/main/java/com/vaadin/flow/component/routerlink/RouterLinkTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/routerlink/RouterLinkTester.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.router.RouterLink;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(RouterLink.class)
 public class RouterLinkTester<T extends RouterLink> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/select/SelectTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/select/SelectTester.java
@@ -23,6 +23,9 @@ import com.vaadin.browserless.Tests;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.data.provider.DataViewUtils;
 
+/**
+ * @since 1.0
+ */
 @Tests(fqn = { "com.vaadin.flow.component.select.Select" })
 public class SelectTester<T extends Select<Y>, Y> extends ComponentTester<T> {
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/sidenav/SideNavTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/sidenav/SideNavTester.java
@@ -21,6 +21,9 @@ import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
 import com.vaadin.flow.component.UI;
 
+/**
+ * @since 1.0
+ */
 @Tests(SideNav.class)
 public class SideNavTester<T extends SideNav> extends ComponentTester<T> {
 

--- a/shared/src/main/java/com/vaadin/flow/component/tabs/TabSheetTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/tabs/TabSheetTester.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.Component;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(TabSheet.class)
 public class TabSheetTester<T extends TabSheet> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/tabs/TabsTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/tabs/TabsTester.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.Component;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(Tabs.class)
 public class TabsTester<T extends Tabs> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/textfield/NumberFieldTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/textfield/NumberFieldTester.java
@@ -28,6 +28,7 @@ import com.vaadin.browserless.Tests;
  *            component type
  * @param <V>
  *            value type
+ * @since 1.0
  */
 @Tests(fqn = { "com.vaadin.flow.component.textfield.IntegerField",
         "com.vaadin.flow.component.textfield.NumberField" })

--- a/shared/src/main/java/com/vaadin/flow/component/textfield/TextAreaTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/textfield/TextAreaTester.java
@@ -25,6 +25,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(TextArea.class)
 public class TextAreaTester<T extends TextArea> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/textfield/TextFieldTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/textfield/TextFieldTester.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.shared.HasClearButton;
  *            component type
  * @param <V>
  *            value type
+ * @since 1.0
  */
 @Tests({ TextField.class, PasswordField.class, EmailField.class,
         BigDecimalField.class })

--- a/shared/src/main/java/com/vaadin/flow/component/timepicker/TimePickerTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/timepicker/TimePickerTester.java
@@ -28,6 +28,7 @@ import com.vaadin.browserless.Tests;
  *
  * @param <T>
  *            component type
+ * @since 1.0
  */
 @Tests(TimePicker.class)
 public class TimePickerTester<T extends TimePicker> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/upload/UploadTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/upload/UploadTester.java
@@ -56,6 +56,7 @@ import com.vaadin.flow.server.streams.UploadResult;
  *
  * @param <T>
  *            the component type.
+ * @since 1.0
  */
 @Tests(Upload.class)
 public class UploadTester<T extends Upload> extends ComponentTester<T> {

--- a/shared/src/main/java/com/vaadin/flow/component/virtuallist/VirtualListTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/virtuallist/VirtualListTester.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.internal.JacksonUtils;
  *            component type
  * @param <Y>
  *            value type
+ * @since 1.0
  */
 @Tests(VirtualList.class)
 public class VirtualListTester<T extends VirtualList<Y>, Y>

--- a/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
+++ b/spring/src/main/java/com/vaadin/browserless/BrowserlessTestSpringLookupInitializer.java
@@ -41,6 +41,8 @@ import com.vaadin.flow.spring.SpringLookupInitializer;
  * be initialized correctly.
  *
  * For internal use only.
+ *
+ * @since 1.0
  */
 public class BrowserlessTestSpringLookupInitializer
         extends SpringLookupInitializer implements TestExecutionListener {

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
@@ -61,6 +61,8 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  * }
  * }
  * </pre>
+ *
+ * @since 1.0
  */
 @ExtendWith({ SpringExtension.class })
 @TestExecutionListeners(listeners = BrowserlessTestSpringLookupInitializer.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)

--- a/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
+++ b/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServlet.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.spring.SpringServlet;
  * {@link com.vaadin.flow.spring.SpringVaadinServletService}.
  *
  * @author mavi
+ * @since 1.0
  */
 public class MockSpringServlet extends SpringServlet {
 

--- a/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServletService.java
+++ b/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringServletService.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.spring.SpringVaadinServletService;
  * The class is intentionally opened, to be extensible in user's library.
  *
  * @author mavi
+ * @since 1.0
  */
 public class MockSpringServletService extends SpringVaadinServletService {
     @NotNull

--- a/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringVaadinSession.java
+++ b/spring/src/main/java/com/vaadin/browserless/mocks/MockSpringVaadinSession.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.server.VaadinSession;
  * </ul>
  *
  * @author mavi
+ * @since 1.0
  */
 public class MockSpringVaadinSession extends VaadinSession {
     @NotNull

--- a/spring/src/main/java/com/vaadin/browserless/mocks/MockWebApplicationContext.java
+++ b/spring/src/main/java/com/vaadin/browserless/mocks/MockWebApplicationContext.java
@@ -42,6 +42,8 @@ import org.springframework.web.context.WebApplicationContext;
  * WebApplicationContext.
  *
  * For internal use only.
+ *
+ * @since 1.0
  */
 public class MockWebApplicationContext implements WebApplicationContext {
 

--- a/spring/src/main/java/com/vaadin/browserless/mocks/SpringSecurityRequestCustomizer.java
+++ b/spring/src/main/java/com/vaadin/browserless/mocks/SpringSecurityRequestCustomizer.java
@@ -21,6 +21,8 @@ import com.vaadin.browserless.internal.MockRequestCustomizer;
  * Configures mock request with authentication details from Spring Security.
  *
  * For internal use only.
+ *
+ * @since 1.0
  */
 public class SpringSecurityRequestCustomizer implements MockRequestCustomizer {
 


### PR DESCRIPTION
Add missing `@since` tags and minimal Javadoc carriers derived from the published -sources.jar presence history on Maven Central (releases 1.0.0, 1.1.0, 1.1.1). Values: 1.0 for API present since the first release, 1.1 for API introduced in 1.1. No existing tags were wrong, so this is additions only.
