### PR TITLE
fix: include read-only state in isUsable() check

### DIFF
--- a/junit6/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTesterTest.java
@@ -39,6 +39,22 @@ public class ComboBoxTesterTest extends BrowserlessTest {
     }
 
     @Test
+    void readOnlyComboBox_isNotUsable() {
+        view.combo.setReadOnly(true);
+
+        Assertions.assertFalse(test(view.combo).isUsable(),
+                "Read only ComboBox shouldn't be usable");
+    }
+
+    @Test
+    void readOnlyComboBox_setFilter_throws() {
+        view.combo.setReadOnly(true);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> test(view.combo).setFilter("fo"));
+    }
+
+    @Test
     void getSuggestionItems_noFilter_allItemsReturned() {
         final List<ComboBoxView.Name> suggestions = test(view.combo)
                 .getSuggestionItems();

--- a/junit6/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/combobox/MultiSelectComboBoxTesterTest.java
@@ -40,6 +40,22 @@ public class MultiSelectComboBoxTesterTest extends BrowserlessTest {
     }
 
     @Test
+    void readOnlyComboBox_isNotUsable() {
+        view.combo.setReadOnly(true);
+
+        Assertions.assertFalse(test(view.combo).isUsable(),
+                "Read only MultiSelectComboBox shouldn't be usable");
+    }
+
+    @Test
+    void readOnlyComboBox_setFilter_throws() {
+        view.combo.setReadOnly(true);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> test(view.combo).setFilter("fo"));
+    }
+
+    @Test
     void getSuggestionItems_noFilter_allItemsReturned() {
         final List<MultiSelectComboBoxView.Name> suggestions = test(view.combo)
                 .getSuggestionItems();

--- a/junit6/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/datepicker/DatePickerTesterTest.java
@@ -59,6 +59,22 @@ class DatePickerTesterTest extends BrowserlessTest {
     }
 
     @Test
+    void readOnlyPicker_isNotUsable() {
+        view.picker.setReadOnly(true);
+
+        Assertions.assertFalse(test(view.picker).isUsable(),
+                "Read only DatePicker shouldn't be usable");
+    }
+
+    @Test
+    void readOnlyPicker_setValue_throws() {
+        view.picker.setReadOnly(true);
+
+        assertThrows(IllegalStateException.class,
+                () -> test(view.picker).setValue(LocalDate.of(1995, 1, 5)));
+    }
+
+    @Test
     void setValue_eventIsFired_valueIsSet() {
 
         AtomicReference<LocalDate> value = new AtomicReference<>(null);

--- a/junit6/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/datetimepicker/DateTimePickerTesterTest.java
@@ -65,6 +65,23 @@ class DateTimePickerTesterTest extends BrowserlessTest {
     }
 
     @Test
+    void readOnlyPicker_isNotUsable() {
+        view.picker.setReadOnly(true);
+
+        Assertions.assertFalse(test(view.picker).isUsable(),
+                "Read only DateTimePicker shouldn't be usable");
+    }
+
+    @Test
+    void readOnlyPicker_setValue_throws() {
+        view.picker.setReadOnly(true);
+
+        assertThrows(IllegalStateException.class,
+                () -> test(view.picker).setValue(LocalDateTime
+                        .of(LocalDate.of(1995, 1, 5), LocalTime.NOON)));
+    }
+
+    @Test
     void setValue_eventIsFired_valueIsSet() {
 
         AtomicReference<LocalDateTime> value = new AtomicReference<>(null);

--- a/junit6/src/test/java/com/vaadin/flow/component/listbox/ListBoxTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/listbox/ListBoxTesterTest.java
@@ -37,6 +37,14 @@ class ListBoxTesterTest extends BrowserlessTest {
     }
 
     @Test
+    void readOnlyListBox_isNotUsable() {
+        view.listBox.setReadOnly(true);
+
+        Assertions.assertFalse(test(view.listBox).isUsable(),
+                "Read only ListBox shouldn't be usable");
+    }
+
+    @Test
     void getSuggestionItems_returnsAllItems() {
         assertIterableEquals(view.selection,
                 test(view.listBox).getSuggestionItems());

--- a/junit6/src/test/java/com/vaadin/flow/component/listbox/MultiSelectListBoxTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/listbox/MultiSelectListBoxTesterTest.java
@@ -37,6 +37,14 @@ class MultiSelectListBoxTesterTest extends BrowserlessTest {
     }
 
     @Test
+    void readOnlyListBox_isNotUsable() {
+        view.multiSelectListBox.setReadOnly(true);
+
+        Assertions.assertFalse(test(view.multiSelectListBox).isUsable(),
+                "Read only MultiSelectListBox shouldn't be usable");
+    }
+
+    @Test
     void getSuggestionItems_returnsAllItems() {
         assertIterableEquals(view.selection,
                 test(view.multiSelectListBox).getSuggestionItems());

--- a/junit6/src/test/java/com/vaadin/flow/component/select/SelectTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/select/SelectTesterTest.java
@@ -37,6 +37,14 @@ class SelectTesterTest extends BrowserlessTest {
     }
 
     @Test
+    void readOnlySelect_isNotUsable() {
+        view.select.setReadOnly(true);
+
+        Assertions.assertFalse(test(view.select).isUsable(),
+                "Read only Select shouldn't be usable");
+    }
+
+    @Test
     void getSuggestionItems_returnsAllItems() {
         final SelectTester<Select<String>, String> select_ = test(view.select);
         assertIterableEquals(view.items, select_.getSuggestionItems());

--- a/junit6/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/timepicker/TimePickerTesterTest.java
@@ -61,6 +61,22 @@ class TimePickerTesterTest extends BrowserlessTest {
     }
 
     @Test
+    void readOnlyPicker_isNotUsable() {
+        view.picker.setReadOnly(true);
+
+        Assertions.assertFalse(pick_.isUsable(),
+                "Read only TimePicker shouldn't be usable");
+    }
+
+    @Test
+    void readOnlyPicker_setValue_throws() {
+        view.picker.setReadOnly(true);
+
+        assertThrows(IllegalStateException.class,
+                () -> pick_.setValue(LocalTime.NOON));
+    }
+
+    @Test
     void setValue_eventIsFired_valueIsSet() {
 
         AtomicReference<LocalTime> value = new AtomicReference<>(null);

--- a/shared/src/main/java/com/vaadin/browserless/ComponentTester.java
+++ b/shared/src/main/java/com/vaadin/browserless/ComponentTester.java
@@ -31,6 +31,7 @@ import tools.jackson.databind.node.ObjectNode;
 import com.vaadin.browserless.internal.PrettyPrintTreeKt;
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.AbstractFieldSupport;
 import com.vaadin.flow.dom.DomEvent;
@@ -88,7 +89,21 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      * @see #ensureComponentIsUsable()
      */
     public boolean isUsable() {
-        return isUsable(getComponent());
+        return isUsable(getComponent()) && !isComponentReadOnly();
+    }
+
+    /**
+     * Checks whether the wrapped component is a value component that is
+     * currently in read-only state.
+     * <p>
+     * A read-only {@link HasValue} component cannot be interacted with to
+     * change its value, so it is considered not usable.
+     *
+     * @return {@code true} if the component is read-only
+     */
+    protected boolean isComponentReadOnly() {
+        return getComponent() instanceof HasValue<?, ?> hasValue
+                && hasValue.isReadOnly();
     }
 
     /**
@@ -195,6 +210,9 @@ public class ComponentTester<T extends Component> implements Clickable<T> {
      */
     protected void notUsableReasons(Consumer<String> collector) {
         notUsableReasons(component, collector);
+        if (isComponentReadOnly()) {
+            collector.accept("read only");
+        }
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroupTester.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,19 +50,6 @@ public class CheckboxGroupTester<T extends CheckboxGroup<V>, V>
      */
     public CheckboxGroupTester(T component) {
         super(component);
-    }
-
-    @Override
-    public boolean isUsable() {
-        return super.isUsable() && !getComponent().isReadOnly();
-    }
-
-    @Override
-    protected void notUsableReasons(Consumer<String> collector) {
-        super.notUsableReasons(collector);
-        if (getComponent().isReadOnly()) {
-            collector.accept("read only");
-        }
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/checkbox/CheckboxTester.java
@@ -43,16 +43,12 @@ public class CheckboxTester<T extends Checkbox> extends ComponentTester<T> {
 
     @Override
     public boolean isUsable() {
-        return super.isUsable() && !getComponent().isReadOnly()
-                && !getComponent().isDisabledBoolean();
+        return super.isUsable() && !getComponent().isDisabledBoolean();
     }
 
     @Override
     protected void notUsableReasons(Consumer<String> collector) {
         super.notUsableReasons(collector);
-        if (getComponent().isReadOnly()) {
-            collector.accept("read only");
-        }
         if (getComponent().isDisabledBoolean()) {
             collector.accept("disabled");
         }

--- a/shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/radiobutton/RadioButtonGroupTester.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.radiobutton;
 
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -48,19 +47,6 @@ public class RadioButtonGroupTester<T extends RadioButtonGroup<V>, V>
      */
     public RadioButtonGroupTester(T component) {
         super(component);
-    }
-
-    @Override
-    public boolean isUsable() {
-        return super.isUsable() && !getComponent().isReadOnly();
-    }
-
-    @Override
-    protected void notUsableReasons(Consumer<String> collector) {
-        super.notUsableReasons(collector);
-        if (getComponent().isReadOnly()) {
-            collector.accept("read only");
-        }
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/slider/NumberRangeSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/NumberRangeSliderTester.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.slider;
 
-import java.util.function.Consumer;
-
 import com.vaadin.browserless.ComponentTester;
 
 /**
@@ -215,19 +213,6 @@ abstract class NumberRangeSliderTester<T extends NumberRangeSlider<?, TValue, TN
      * @return the range value
      */
     protected abstract TValue createRange(TNumber start, TNumber end);
-
-    @Override
-    public boolean isUsable() {
-        return super.isUsable() && !getComponent().isReadOnly();
-    }
-
-    @Override
-    protected void notUsableReasons(Consumer<String> collector) {
-        super.notUsableReasons(collector);
-        if (getComponent().isReadOnly()) {
-            collector.accept("read only");
-        }
-    }
 
     private void validateRange(TNumber start, TNumber end) {
         double min = getComponent().getMin().doubleValue();

--- a/shared/src/main/java/com/vaadin/flow/component/slider/NumberSliderTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/slider/NumberSliderTester.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.slider;
 
-import java.util.function.Consumer;
-
 import com.vaadin.browserless.ComponentTester;
 
 /**
@@ -133,17 +131,4 @@ abstract class NumberSliderTester<T extends NumberSlider<?, TValue>, TValue exte
      * @return the converted value
      */
     protected abstract TValue fromDouble(double value);
-
-    @Override
-    public boolean isUsable() {
-        return super.isUsable() && !getComponent().isReadOnly();
-    }
-
-    @Override
-    protected void notUsableReasons(Consumer<String> collector) {
-        super.notUsableReasons(collector);
-        if (getComponent().isReadOnly()) {
-            collector.accept("read only");
-        }
-    }
 }

--- a/shared/src/main/java/com/vaadin/flow/component/textfield/NumberFieldTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/textfield/NumberFieldTester.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component.textfield;
 
 import java.util.Objects;
-import java.util.function.Consumer;
 
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
@@ -77,18 +76,4 @@ public class NumberFieldTester<T extends AbstractNumberField<T, V>, V extends Nu
     }
 
     // TODO: support stepUp/stepDown if controls are visible.
-
-    @Override
-    public boolean isUsable() {
-        // TextFields can be read only so the usable check needs extending
-        return super.isUsable() && !getComponent().isReadOnly();
-    }
-
-    @Override
-    protected void notUsableReasons(Consumer<String> collector) {
-        super.notUsableReasons(collector);
-        if (getComponent().isReadOnly()) {
-            collector.accept("read only");
-        }
-    }
 }

--- a/shared/src/main/java/com/vaadin/flow/component/textfield/TextAreaTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/textfield/TextAreaTester.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield;
 
-import java.util.function.Consumer;
-
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
 
@@ -66,19 +64,5 @@ public class TextAreaTester<T extends TextArea> extends ComponentTester<T> {
             // implementation
         }
         return null;
-    }
-
-    @Override
-    public boolean isUsable() {
-        // TextFields can be read only so the usable check needs extending
-        return super.isUsable() && !getComponent().isReadOnly();
-    }
-
-    @Override
-    protected void notUsableReasons(Consumer<String> collector) {
-        super.notUsableReasons(collector);
-        if (getComponent().isReadOnly()) {
-            collector.accept("read only");
-        }
     }
 }

--- a/shared/src/main/java/com/vaadin/flow/component/textfield/TextFieldTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/textfield/TextFieldTester.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield;
 
-import java.util.function.Consumer;
-
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
 import com.vaadin.flow.component.shared.HasClearButton;
@@ -100,19 +98,5 @@ public class TextFieldTester<T extends TextFieldBase<T, V>, V>
             // implementation
         }
         return null;
-    }
-
-    @Override
-    public boolean isUsable() {
-        // TextFields can be read only so the usable check needs extending
-        return super.isUsable() && !getComponent().isReadOnly();
-    }
-
-    @Override
-    protected void notUsableReasons(Consumer<String> collector) {
-        super.notUsableReasons(collector);
-        if (getComponent().isReadOnly()) {
-            collector.accept("read only");
-        }
     }
 }


### PR DESCRIPTION
Centralize the read-only check in `ComponentTester#isUsable()` so any `HasValue` component is reported as not usable when read-only. This fixes `DatePickerTester`, `TimePickerTester`, `DateTimePickerTester`, `ComboBoxTester`, `MultiSelectComboBoxTester`, `SelectTester`, `ListBoxTester` and `MultiSelectListBoxTester`, which previously ignored read-only state.

The now-redundant per-tester overrides are removed.

Fixes #138
