### PR TITLE
chore: bump to 1.2-SNAPSHOT and Vaadin to 25.3-SNAPSHOT

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <artifactId>browserless-test-bom</artifactId>
     <packaging>pom</packaging>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
     <name>Vaadin Browserless Test (Bill of Materials)</name>
     <description>Vaadin Browserless Test (Bill of Materials)</description>
     <url>https://vaadin.com</url>

--- a/junit6-cdi-tests/pom.xml
+++ b/junit6-cdi-tests/pom.xml
@@ -18,7 +18,7 @@
     </description>
 
     <properties>
-        <!-- vaadin-cdi addon aligned with Flow 25.2 (Weld 6 / CDI 4.1) -->
+        <!-- vaadin-cdi addon aligned with Flow 25.3 (Weld 6 / CDI 4.1) -->
         <vaadin.cdi.version>16.1-SNAPSHOT</vaadin.cdi.version>
         <weld.junit5.version>5.0.3.Final</weld.junit5.version>
         <!-- Internal test module: never deploy or attach artifacts. -->

--- a/junit6-cdi-tests/pom.xml
+++ b/junit6-cdi-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>browserless-test</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>browserless-test-junit6-cdi-tests</artifactId>
     <packaging>jar</packaging>

--- a/junit6/pom.xml
+++ b/junit6/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>browserless-test</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>browserless-test-junit6</artifactId>
     <packaging>jar</packaging>

--- a/locator-processor/pom.xml
+++ b/locator-processor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>browserless-test</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>browserless-test-locator-processor</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <spring.boot.version>4.1.0-RC1</spring.boot.version>
-        <vaadin.version>25.2-SNAPSHOT</vaadin.version>
-        <flow.version>25.2-SNAPSHOT</flow.version>
+        <vaadin.version>25.3-SNAPSHOT</vaadin.version>
+        <flow.version>25.3-SNAPSHOT</flow.version>
         <slf4j.version>2.0.17</slf4j.version>
         <failsafe.version>3.5.5</failsafe.version>
         <surefire.version>3.5.5</surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <artifactId>browserless-test</artifactId>
     <packaging>pom</packaging>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
     <name>Vaadin Browserless Test</name>
     <url>https://vaadin.com</url>
     <inceptionYear>2022</inceptionYear>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>browserless-test</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>browserless-test-quarkus</artifactId>
     <packaging>jar</packaging>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>browserless-test</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>browserless-test-shared</artifactId>
     <packaging>jar</packaging>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>browserless-test</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>browserless-test-spring</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
## Description

Let's update Vaadin version so we can add tester for the new `Switch` component added in 25.3

## Type of change

- Version bump