### PR TITLE
fix: find slotted children via ComponentUtil.getAllChildren

### DIFF
--- a/junit6/src/test/java/com/vaadin/browserless/CardSlotTraversalTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/CardSlotTraversalTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.card.Card;
+
+/**
+ * Verifies that components placed in a {@link Card}'s slots (header,
+ * header-prefix, header-suffix, footer) are locatable by {@code find(...)}, not
+ * just components in the default content slot.
+ */
+class CardSlotTraversalTest extends BrowserlessTest {
+
+    @Test
+    void cardContent_slottedAndPlain_allLocatable() {
+        Button contentButton = new Button("Content button");
+        Button headerSuffixButton = new Button("Header-suffix button");
+        Button headerPrefixButton = new Button("Header-prefix button");
+        Button headerButton = new Button("Header button");
+        Button footerButton = new Button("Footer button");
+
+        Card card = new Card();
+        card.add(contentButton);
+        card.setHeaderSuffix(headerSuffixButton);
+        card.setHeaderPrefix(headerPrefixButton);
+        card.setHeader(headerButton);
+        card.addToFooter(footerButton);
+
+        getCurrentView().getElement().appendChild(card.getElement());
+
+        // Control: a button in the card content slot (regular getChildren()).
+        Assertions.assertTrue(
+                find(Button.class).withText("Content button").exists(),
+                "button in card content slot must be locatable");
+
+        Assertions.assertTrue(
+                find(Button.class).withText("Header-suffix button").exists(),
+                "button in card header-suffix slot must be locatable");
+        Assertions.assertTrue(
+                find(Button.class).withText("Header-prefix button").exists(),
+                "button in card header-prefix slot must be locatable");
+        Assertions.assertTrue(
+                find(Button.class).withText("Header button").exists(),
+                "button in card header slot must be locatable");
+        Assertions.assertTrue(
+                find(Button.class).withText("Footer button").exists(),
+                "button in card footer slot must be locatable");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/DialogSlotTraversalTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/DialogSlotTraversalTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+
+/**
+ * Verifies that components added to a {@link Dialog}'s header and footer are
+ * locatable by {@code find(...)}, not just the main content, even though the
+ * dialog places them in slotted wrapper elements and excludes them from
+ * {@code getChildren()}. The locator descends through the non-component wrapper
+ * to reach them.
+ */
+class DialogSlotTraversalTest extends BrowserlessTest {
+
+    @Test
+    void dialogContent_headerFooterAndPlain_allLocatable() {
+        Button headerButton = new Button("Header button");
+        Button footerButton = new Button("Footer button");
+        Button contentButton = new Button("Content button");
+
+        Dialog dialog = new Dialog();
+        dialog.getHeader().add(headerButton);
+        dialog.getFooter().add(footerButton);
+        dialog.add(contentButton);
+        dialog.open();
+
+        // Control: a button in the dialog content (regular getChildren()).
+        Assertions.assertTrue(
+                find(Button.class).withText("Content button").exists(),
+                "button in dialog content must be locatable");
+
+        // The slotted header/footer buttons must be locatable too: they live in
+        // wrapper elements the dialog excludes from getChildren().
+        Assertions.assertTrue(
+                find(Button.class).withText("Header button").exists(),
+                "button in dialog header slot must be locatable");
+        Assertions.assertTrue(
+                find(Button.class).withText("Footer button").exists(),
+                "button in dialog footer slot must be locatable");
+    }
+}

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/TestingLifecycleHook.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/TestingLifecycleHook.kt
@@ -17,6 +17,7 @@ package com.vaadin.browserless.internal
 
 import java.lang.reflect.Method
 import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.ComponentUtil
 import com.vaadin.flow.component.Composite
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.contextmenu.MenuItemBase
@@ -121,9 +122,17 @@ interface TestingLifecycleHook {
             // thus duplicating any virtual children the child component might have.
             component.children.toList()
         }
-        // Also include virtual children.
-        // Issue: https://github.com/mvysny/karibu-testing/issues/85
-        else -> (component.children.toList() + component._getVirtualChildren()).distinct()
+        // Union the component's own reported children with Flow's element-tree
+        // traversal. Neither source alone is complete: getChildren() may hide
+        // element children (Dialog and Card exclude slotted content) while
+        // ComponentUtil.getAllChildren, which walks the element hierarchy
+        // (regular and virtual children, descending through non-component
+        // wrapper elements), misses children that are not part of the element
+        // tree (ContextMenu keeps its items in a server-side MenuManager list
+        // that getChildren() delegates to). getAllChildren also keeps virtual
+        // children, see https://github.com/mvysny/karibu-testing/issues/85.
+        else -> (component.children.toList()
+                + ComponentUtil.getAllChildren(component).toList()).distinct()
     }
 
 


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/9280
Related to https://github.com/vaadin/flow-components/pull/9743

Replaces https://github.com/vaadin/browserless-test/pull/89

Added usage of `ComponentUtil.getAllChildren()` helper to handle components that filter out non-default content from `getChildren()` - particularly, `Card` and `Dialog` (the latter was changed in 25.3 alpha - see PR above).


## Type of change

- Bugfix