### PR TITLE
feat: simulate clipboard paste and file paste in browserless tests

### DIFF
--- a/shared/src/main/java/com/vaadin/browserless/internal/UploadSimulation.java
+++ b/shared/src/main/java/com/vaadin/browserless/internal/UploadSimulation.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.browserless.mocks.MockRequest;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinServletRequest;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.communication.TransferUtil;
+import com.vaadin.flow.server.streams.UploadEvent;
+import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.flow.server.streams.UploadResult;
+
+/**
+ * Drives an {@link UploadHandler} headlessly, reproducing what the browser does
+ * on a file upload. Shared by the upload component tester and the clipboard
+ * file-paste simulation, both of which POST files to a stream-resource URL in a
+ * real browser.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 1.1
+ */
+public final class UploadSimulation {
+
+    private UploadSimulation() {
+    }
+
+    /**
+     * Resolves the {@link UploadHandler} registered as the stream resource at
+     * the given URL (typically the value of a component's upload-target
+     * attribute).
+     *
+     * @param url
+     *            the stream-resource URL, not {@code null}
+     * @return the registered upload handler, never {@code null}
+     * @throws IllegalStateException
+     *             if no upload handler is registered at the URL
+     */
+    public static UploadHandler resolveUploadHandler(String url) {
+        StreamResourceRegistry.ElementStreamResource resource = VaadinSession
+                .getCurrent().getResourceRegistry()
+                .getResource(StreamResourceRegistry.ElementStreamResource.class,
+                        URI.create(url))
+                .orElseThrow(() -> new IllegalStateException(
+                        "Upload handler is not registered"));
+        if (resource
+                .getElementRequestHandler() instanceof UploadHandler handler) {
+            return handler;
+        }
+        throw new IllegalStateException("Invalid or null upload handler "
+                + resource.getElementRequestHandler());
+    }
+
+    /**
+     * Invokes the handler once for a single file, as if the browser had POSTed
+     * it. A {@code null} {@code content} simulates a failed/aborted upload (the
+     * handler's stream throws on read).
+     *
+     * @param handler
+     *            the upload handler to invoke, not {@code null}
+     * @param element
+     *            the element the upload targets, not {@code null}
+     * @param request
+     *            the request to expose to the handler (carries any
+     *            upload-specific headers), not {@code null}
+     * @param fileName
+     *            the uploaded file name, not {@code null}
+     * @param contentType
+     *            the uploaded content type, may be {@code null}
+     * @param content
+     *            the file bytes, or {@code null} to simulate a failure
+     * @throws RuntimeException
+     *             propagated from the handler; a failed upload is reported to
+     *             the handler via {@link UploadHandler#responseHandled} before
+     *             the exception is rethrown
+     */
+    public static void invokeUpload(UploadHandler handler, Element element,
+            VaadinRequest request, String fileName,
+            @Nullable String contentType, byte @Nullable [] content) {
+        long contentLength;
+        InputStream inputStream;
+        if (content == null) {
+            contentLength = 0L;
+            inputStream = new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    throw new IOException("Simulated upload failure");
+                }
+            };
+        } else {
+            contentLength = content.length;
+            inputStream = new ByteArrayInputStream(content);
+        }
+
+        UploadEvent event = new UploadEvent(request,
+                VaadinResponse.getCurrent(), VaadinSession.getCurrent(),
+                fileName, contentLength, contentType, element, null) {
+            @Override
+            public InputStream getInputStream() {
+                return inputStream;
+            }
+        };
+        try {
+            Method method = TransferUtil.class.getDeclaredMethod(
+                    "handleUploadRequest", UploadHandler.class,
+                    UploadEvent.class);
+            method.setAccessible(true);
+            method.invoke(null, handler, event);
+            handler.responseHandled(
+                    new UploadResult(true, VaadinResponse.getCurrent()));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new IllegalStateException("Cannot handle upload request", e);
+        } catch (InvocationTargetException e) {
+            RuntimeException cause;
+            if (e.getCause() instanceof RuntimeException re) {
+                cause = re;
+            } else if (e.getCause() instanceof IOException ioe) {
+                cause = new UncheckedIOException(ioe);
+            } else {
+                cause = new UncheckedIOException(new IOException(e));
+            }
+            handler.responseHandled(new UploadResult(false,
+                    VaadinResponse.getCurrent(), cause));
+            throw cause;
+        }
+    }
+
+    /**
+     * Runs {@code action} with the given request headers temporarily added to
+     * the current request, then removes them. Lets callers expose
+     * upload-specific headers (e.g. the clipboard paste id and file count) to
+     * the {@link UploadHandler}, which reads them via
+     * {@code event.getRequest().getHeader(...)}.
+     *
+     * @param headers
+     *            header name/value pairs to add for the duration, not
+     *            {@code null}
+     * @param action
+     *            the action to run with the headers in place, not {@code null}
+     */
+    public static void withRequestHeaders(Map<String, String> headers,
+            Runnable action) {
+        MockRequest request = (MockRequest) ((VaadinServletRequest) VaadinRequest
+                .getCurrent()).getRequest();
+        Map<String, List<String>> requestHeaders = request.getHeaders();
+        headers.forEach(
+                (name, value) -> requestHeaders.put(name, List.of(value)));
+        try {
+            action.run();
+        } finally {
+            headers.keySet().forEach(requestHeaders::remove);
+        }
+    }
+
+    /**
+     * Drains the UI's access queue so upload callbacks running inside
+     * {@code UI.access} blocks are executed.
+     *
+     * @return a {@link RuntimeException} caught while draining, or {@code null}
+     *         if none
+     */
+    public static @Nullable RuntimeException runUIQueue() {
+        try {
+            MockVaadin.runUIQueue();
+        } catch (RuntimeException ex) {
+            return ex;
+        } catch (Exception ex) {
+            // Upload callbacks run in UI.access blocks; purge the queue to
+            // ensure listeners are invoked. runUIQueue throws
+            // ExecutionException on failure but does not declare it (Kotlin).
+            if (ex instanceof ExecutionException) {
+                if (ex.getCause() instanceof RuntimeException re) {
+                    throw re;
+                } else {
+                    throw new RuntimeException(ex.getCause());
+                }
+            }
+            return new RuntimeException(ex);
+        }
+        return null;
+    }
+}

--- a/shared/src/main/java/com/vaadin/flow/component/clipboard/ClipboardSimulator.java
+++ b/shared/src/main/java/com/vaadin/flow/component/clipboard/ClipboardSimulator.java
@@ -16,11 +16,23 @@
 package com.vaadin.flow.component.clipboard;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.node.ObjectNode;
 
+import com.vaadin.browserless.ComponentQuery;
+import com.vaadin.browserless.internal.UploadSimulation;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.flow.shared.JsonConstants;
 
 /**
  * Browserless test driver for the {@link Clipboard} API: a per-window stand-in
@@ -53,6 +65,7 @@ public final class ClipboardSimulator implements Serializable {
     private @Nullable String html;
     private boolean readDenied;
     private boolean writeDenied;
+    private long nextPasteId = 1;
 
     private ClipboardSimulator() {
     }
@@ -185,6 +198,174 @@ public final class ClipboardSimulator implements Serializable {
     public void grantAccess() {
         readDenied = false;
         writeDenied = false;
+    }
+
+    /**
+     * Simulates a paste gesture onto the given component, delivering this
+     * clipboard's current contents to any {@link Clipboard#onPaste} listener
+     * registered on it (or a descendant, since {@code paste} bubbles).
+     *
+     * @param target
+     *            the component to paste onto, not {@code null}
+     */
+    public void pasteInto(Component target) {
+        firePaste(target, text, html);
+    }
+
+    /**
+     * Simulates a paste gesture onto the given component with explicit
+     * contents, without changing this clipboard's stored contents. Useful for a
+     * one-off paste distinct from the clipboard's current state.
+     *
+     * @param target
+     *            the component to paste onto, not {@code null}
+     * @param text
+     *            the {@code text/plain} contents to paste, or {@code null}
+     * @param html
+     *            the {@code text/html} contents to paste, or {@code null}
+     */
+    public void pasteInto(Component target, @Nullable String text,
+            @Nullable String html) {
+        firePaste(target, text, html);
+    }
+
+    /**
+     * Dispatches a {@code paste} DOM event to the component, using the exact
+     * event-data keys {@link Clipboard#onPaste} reads and mapping the paste
+     * target to the component so {@code PasteEvent#getTargetElement()}
+     * resolves. The client-side skip-editable filter of {@code onPaste} is not
+     * evaluated — the listener always receives the event.
+     */
+    private static void firePaste(Component target, @Nullable String text,
+            @Nullable String html) {
+        Element element = target.getElement();
+        ObjectNode eventData = JacksonUtils.createObjectNode();
+        putNullable(eventData, Clipboard.PASTE_TEXT_EXPR, text);
+        putNullable(eventData, Clipboard.PASTE_HTML_EXPR, html);
+        eventData.put(JsonConstants.MAP_STATE_NODE_EVENT_DATA,
+                element.getNode().getId());
+        DomEvent event = new DomEvent(element, "paste", eventData);
+        element.getNode().getFeature(ElementListenerMap.class).fireEvent(event);
+    }
+
+    private static void putNullable(ObjectNode data, String key,
+            @Nullable String value) {
+        if (value == null) {
+            data.putNull(key);
+        } else {
+            data.put(key, value);
+        }
+    }
+
+    /**
+     * Simulates a paste gesture onto the single component matched by the given
+     * query, delivering this clipboard's current contents to its
+     * {@link Clipboard#onPaste} listener. Convenience for the common
+     * find-then-paste flow.
+     *
+     * @param target
+     *            a query resolving to exactly one component to paste onto, not
+     *            {@code null}
+     * @throws java.util.NoSuchElementException
+     *             if the query does not match exactly one component
+     */
+    public void pasteInto(ComponentQuery<? extends Component> target) {
+        pasteInto(target.single());
+    }
+
+    /**
+     * Simulates a paste gesture onto the single component matched by the given
+     * query with explicit contents, without changing this clipboard's stored
+     * contents.
+     *
+     * @param target
+     *            a query resolving to exactly one component to paste onto, not
+     *            {@code null}
+     * @param text
+     *            the {@code text/plain} contents to paste, or {@code null}
+     * @param html
+     *            the {@code text/html} contents to paste, or {@code null}
+     * @throws java.util.NoSuchElementException
+     *             if the query does not match exactly one component
+     */
+    public void pasteInto(ComponentQuery<? extends Component> target,
+            @Nullable String text, @Nullable String html) {
+        pasteInto(target.single(), text, html);
+    }
+
+    /**
+     * Simulates a file paste onto the given component, delivering each file to
+     * its {@link Clipboard#onFilePaste} handler as one upload (carrying the
+     * paste-id and file-count headers), then firing the paste-finished event so
+     * queued UI changes flush.
+     *
+     * @param target
+     *            the component to paste onto, not {@code null}
+     * @param files
+     *            the pasted files, at least one
+     * @throws IllegalArgumentException
+     *             if no files are given
+     * @throws IllegalStateException
+     *             if no {@code onFilePaste} handler is registered on the
+     *             component
+     */
+    public void pasteFilesInto(Component target, PastedFile... files) {
+        firePastedFiles(target, files);
+    }
+
+    /**
+     * Simulates a file paste onto the single component matched by the given
+     * query. Convenience for the common find-then-paste flow.
+     *
+     * @param target
+     *            a query resolving to exactly one component to paste onto, not
+     *            {@code null}
+     * @param files
+     *            the pasted files, at least one
+     * @throws java.util.NoSuchElementException
+     *             if the query does not match exactly one component
+     */
+    public void pasteFilesInto(ComponentQuery<? extends Component> target,
+            PastedFile... files) {
+        firePastedFiles(target.single(), files);
+    }
+
+    private void firePastedFiles(Component target, PastedFile... files) {
+        if (files.length == 0) {
+            throw new IllegalArgumentException("At least one file is required");
+        }
+        Element element = target.getElement();
+        String url = element.getAttributeNames()
+                .filter(name -> name
+                        .startsWith(Clipboard.PASTE_UPLOAD_ATTRIBUTE_PREFIX))
+                .map(element::getAttribute).findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "No Clipboard.onFilePaste registration found on "
+                                + target));
+        UploadHandler handler = UploadSimulation.resolveUploadHandler(url);
+        Map<String, String> headers = Map.of(Clipboard.PASTE_ID_HEADER,
+                Long.toString(nextPasteId++), Clipboard.PASTE_FILE_COUNT_HEADER,
+                Integer.toString(files.length));
+        // Each file is a separate upload carrying the paste headers, exactly as
+        // the client posts them; the handler (or its PasteFileHandler wrapper)
+        // reads the headers to correlate the paste.
+        UploadSimulation.withRequestHeaders(headers, () -> {
+            for (PastedFile file : files) {
+                UploadSimulation.invokeUpload(handler, element,
+                        VaadinRequest.getCurrent(), file.fileName(),
+                        file.contentType(), file.content());
+            }
+        });
+        RuntimeException caught = UploadSimulation.runUIQueue();
+        // The client dispatches this once all uploads settle; the server
+        // listener forces the round trip that flushes UI.access changes.
+        element.getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(new DomEvent(element,
+                        Clipboard.FILE_PASTE_FINISHED_EVENT,
+                        JacksonUtils.createObjectNode()));
+        if (caught != null) {
+            throw caught;
+        }
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/flow/component/clipboard/PastedFile.java
+++ b/shared/src/main/java/com/vaadin/flow/component/clipboard/PastedFile.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A single file to deliver through
+ * {@link ClipboardSimulator#pasteFilesInto(com.vaadin.flow.component.Component, PastedFile...)}
+ * when simulating a file paste in a browserless test.
+ *
+ * @since 1.1
+ */
+public final class PastedFile {
+
+    private final String fileName;
+    private final @Nullable String contentType;
+    private final byte[] content;
+
+    private PastedFile(String fileName, @Nullable String contentType,
+            byte[] content) {
+        this.fileName = Objects.requireNonNull(fileName,
+                "fileName must not be null");
+        this.contentType = contentType;
+        this.content = Objects.requireNonNull(content,
+                "content must not be null");
+    }
+
+    /**
+     * Creates a pasted file with the given name, content type and bytes.
+     *
+     * @param fileName
+     *            the file name, not {@code null}
+     * @param contentType
+     *            the MIME type, or {@code null}
+     * @param content
+     *            the file bytes, not {@code null}
+     * @return a new {@link PastedFile}
+     */
+    public static PastedFile of(String fileName, @Nullable String contentType,
+            byte[] content) {
+        return new PastedFile(fileName, contentType, content);
+    }
+
+    /**
+     * Creates a pasted file from a file on disk; the content type is guessed
+     * from the file name.
+     *
+     * @param file
+     *            the file to read, not {@code null}
+     * @return a new {@link PastedFile}
+     * @throws UncheckedIOException
+     *             if the file cannot be read
+     */
+    public static PastedFile of(File file) {
+        Objects.requireNonNull(file, "file must not be null");
+        return of(file, URLConnection.guessContentTypeFromName(file.getName()));
+    }
+
+    /**
+     * Creates a pasted file from a file on disk with an explicit content type.
+     *
+     * @param file
+     *            the file to read, not {@code null}
+     * @param contentType
+     *            the MIME type, or {@code null}
+     * @return a new {@link PastedFile}
+     * @throws UncheckedIOException
+     *             if the file cannot be read
+     */
+    public static PastedFile of(File file, @Nullable String contentType) {
+        Objects.requireNonNull(file, "file must not be null");
+        try {
+            return new PastedFile(file.getName(), contentType,
+                    Files.readAllBytes(file.toPath()));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    String fileName() {
+        return fileName;
+    }
+
+    @Nullable
+    String contentType() {
+        return contentType;
+    }
+
+    byte[] content() {
+        return content;
+    }
+}

--- a/shared/src/main/java/com/vaadin/flow/component/upload/UploadTester.java
+++ b/shared/src/main/java/com/vaadin/flow/component/upload/UploadTester.java
@@ -15,14 +15,11 @@
  */
 package com.vaadin.flow.component.upload;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URI;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.util.Collection;
@@ -30,26 +27,19 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import com.vaadin.browserless.ComponentTester;
 import com.vaadin.browserless.Tests;
-import com.vaadin.browserless.internal.MockVaadin;
-import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.browserless.internal.UploadSimulation;
 import com.vaadin.flow.server.StreamVariable;
 import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.communication.TransferUtil;
 import com.vaadin.flow.server.communication.streaming.StreamingEndEventImpl;
 import com.vaadin.flow.server.communication.streaming.StreamingErrorEventImpl;
 import com.vaadin.flow.server.communication.streaming.StreamingStartEventImpl;
-import com.vaadin.flow.server.streams.UploadEvent;
 import com.vaadin.flow.server.streams.UploadHandler;
-import com.vaadin.flow.server.streams.UploadResult;
 
 /**
  * Tester for Upload components.
@@ -239,111 +229,30 @@ public class UploadTester<T extends Upload> extends ComponentTester<T> {
         } else {
             // A round trip is necessary to ensure upload handler registration
             roundTrip();
-            var target = getComponent().getElement().getAttribute("target");
-            StreamResourceRegistry.ElementStreamResource resource = VaadinSession
-                    .getCurrent().getResourceRegistry()
-                    .getResource(
-                            StreamResourceRegistry.ElementStreamResource.class,
-                            URI.create(target))
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Upload handler is not registered"));
-            if (resource
-                    .getElementRequestHandler() instanceof UploadHandler uploadHandler) {
-                RuntimeException caughtException;
-                try {
-                    items.forEach(item -> doUpload(item, uploadHandler));
-                } finally {
-                    caughtException = runUIQueue();
-                    fireAllFinish();
-                }
-                if (caughtException != null) {
-                    throw caughtException;
-                }
-            } else {
-                throw new IllegalStateException(
-                        "Invalid or null upload handler "
-                                + resource.getElementRequestHandler());
+            String target = getComponent().getElement().getAttribute("target");
+            UploadHandler uploadHandler = UploadSimulation
+                    .resolveUploadHandler(target);
+            RuntimeException caughtException;
+            try {
+                items.forEach(item -> UploadSimulation.invokeUpload(
+                        uploadHandler, getComponent().getElement(),
+                        VaadinRequest.getCurrent(), item.fileName,
+                        item.contentType,
+                        item.contentsProducer == null ? null
+                                : getUploadedItemContent(
+                                        item.contentsProducer)));
+            } finally {
+                caughtException = UploadSimulation.runUIQueue();
+                fireAllFinish();
+            }
+            if (caughtException != null) {
+                throw caughtException;
             }
         }
     }
 
     private boolean useLegacyAPI() {
         return getComponent().getReceiver() != null;
-    }
-
-    private RuntimeException runUIQueue() {
-        try {
-            MockVaadin.runUIQueue();
-        } catch (RuntimeException ex) {
-            return ex;
-        } catch (Exception ex) {
-            // upload callbacks are executed in UI.access blocks.
-            // we need to purge the queue to ensure listeners are
-            // invoked
-            // runUIQueue throws ExecutionException in case of failure
-            // but the method does not declare any thrown exception
-            // (kotlin magic)
-            if (ex instanceof ExecutionException) {
-                if (ex.getCause() instanceof RuntimeException re) {
-                    throw re;
-                } else {
-                    throw new RuntimeException(ex.getCause());
-                }
-            }
-            return new RuntimeException(ex);
-        }
-        return null;
-    }
-
-    private void doUpload(UploadItem item, UploadHandler uploadHandler) {
-        long contentLength;
-        InputStream inputStream;
-        if (item.contentsProducer == null) {
-            contentLength = 0L;
-            inputStream = new InputStream() {
-                @Override
-                public int read() throws IOException {
-                    throw new IOException("Simulated upload failure");
-                }
-            };
-        } else {
-            byte[] content = getUploadedItemContent(item.contentsProducer);
-            contentLength = content.length;
-            inputStream = new ByteArrayInputStream(content);
-        }
-
-        UploadEvent event = new UploadEvent(VaadinRequest.getCurrent(),
-                VaadinResponse.getCurrent(), VaadinSession.getCurrent(),
-                item.fileName, contentLength, item.contentType,
-                getComponent().getElement(), null) {
-            @Override
-            public InputStream getInputStream() {
-                return inputStream;
-            }
-        };
-        try {
-            Method method = TransferUtil.class.getDeclaredMethod(
-                    "handleUploadRequest", UploadHandler.class,
-                    UploadEvent.class);
-            method.setAccessible(true);
-            method.invoke(null, uploadHandler, event);
-            uploadHandler.responseHandled(
-                    new UploadResult(true, VaadinResponse.getCurrent()));
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-            throw new IllegalStateException("Cannot handle upload request", e);
-        } catch (InvocationTargetException e) {
-            RuntimeException cause;
-            if (e.getCause() instanceof RuntimeException re) {
-                cause = re;
-            } else if (e.getCause() instanceof IOException ioe) {
-                cause = new UncheckedIOException(ioe);
-            } else {
-                cause = new UncheckedIOException(new IOException(e));
-            }
-            uploadHandler.responseHandled(new UploadResult(false,
-                    VaadinResponse.getCurrent(), cause));
-            throw cause;
-        }
     }
 
     private void doLegacyUpload(Collection<UploadItem> items) {

--- a/shared/src/test/java/com/vaadin/browserless/ClipboardSimulationTest.java
+++ b/shared/src/test/java/com/vaadin/browserless/ClipboardSimulationTest.java
@@ -15,10 +15,16 @@
  */
 package com.vaadin.browserless;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.clipboard.Clipboard;
 import com.vaadin.flow.component.clipboard.ClipboardSimulator;
+import com.vaadin.flow.component.clipboard.PasteFileHandler;
+import com.vaadin.flow.component.clipboard.PastedFile;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.trigger.internal.PromiseAction.Error;
@@ -37,11 +43,19 @@ class ClipboardSimulationTest {
     static class ClipboardView extends Div {
         final NativeButton copy = new NativeButton("copy");
         final NativeButton paste = new NativeButton("paste");
+        final Div pasteTarget = new Div();
+        final Div fileTarget = new Div();
         String copied;
         int copyCount;
         Error copyError;
         String pasted;
         Error pasteError;
+        String onPasteText;
+        String onPasteHtml;
+        int pasteStartTotal;
+        final List<String> pastedFileNames = new ArrayList<>();
+        final List<String> pastedFileContents = new ArrayList<>();
+        int pasteCompleteCount;
 
         ClipboardView() {
             Clipboard.onClick(copy).writeText("hello", c -> {
@@ -50,7 +64,19 @@ class ClipboardSimulationTest {
             }, e -> copyError = e);
             Clipboard.onClick(paste).readText(t -> pasted = t,
                     e -> pasteError = e);
-            add(copy, paste);
+            pasteTarget.setId("paste-target");
+            Clipboard.onPaste(pasteTarget, e -> {
+                onPasteText = e.getText();
+                onPasteHtml = e.getHtml();
+            });
+            Clipboard.onFilePaste(fileTarget, PasteFileHandler.batch()
+                    .onStart(start -> pasteStartTotal = start.totalFiles())
+                    .onFile(file -> {
+                        pastedFileNames.add(file.fileName());
+                        pastedFileContents.add(new String(file.bytes(),
+                                StandardCharsets.UTF_8));
+                    }).onComplete(complete -> pasteCompleteCount++).build());
+            add(copy, paste, pasteTarget, fileTarget);
         }
     }
 
@@ -135,6 +161,65 @@ class ClipboardSimulationTest {
             // The other environment is untouched.
             assertEquals(0, a[0].copyCount);
             assertTrue(ClipboardSimulator.forUI(w1.getUI()).isEmpty());
+        }
+    }
+
+    @Test
+    void pasteInto_deliversClipboardContentsToOnPasteListener() {
+        try (BrowserlessUIContext window = open()) {
+            ClipboardView view = window.find(ClipboardView.class).single();
+            ClipboardSimulator clipboard = clipboard(window);
+            clipboard.setContents("plain text", "<b>rich</b>");
+
+            clipboard.pasteInto(view.pasteTarget);
+
+            assertEquals("plain text", view.onPasteText);
+            assertEquals("<b>rich</b>", view.onPasteHtml);
+        }
+    }
+
+    @Test
+    void pasteInto_withComponentQuery_resolvesTarget() {
+        try (BrowserlessUIContext window = open()) {
+            clipboard(window).setText("via-query");
+
+            clipboard(window)
+                    .pasteInto(window.find(Div.class).withId("paste-target"));
+
+            ClipboardView view = window.find(ClipboardView.class).single();
+            assertEquals("via-query", view.onPasteText);
+        }
+    }
+
+    @Test
+    void pasteInto_withExplicitContents_deliversThem() {
+        try (BrowserlessUIContext window = open()) {
+            ClipboardView view = window.find(ClipboardView.class).single();
+
+            clipboard(window).pasteInto(view.pasteTarget, "explicit", null);
+
+            assertEquals("explicit", view.onPasteText);
+            assertNull(view.onPasteHtml);
+        }
+    }
+
+    @Test
+    void pasteFilesInto_deliversFilesToOnFilePasteBatchHandler() {
+        try (BrowserlessUIContext window = open()) {
+            ClipboardView view = window.find(ClipboardView.class).single();
+
+            clipboard(window).pasteFilesInto(view.fileTarget,
+                    PastedFile.of("a.txt", "text/plain",
+                            "AAA".getBytes(StandardCharsets.UTF_8)),
+                    PastedFile.of("b.txt", "text/plain",
+                            "BBB".getBytes(StandardCharsets.UTF_8)));
+
+            assertEquals(List.of("a.txt", "b.txt"), view.pastedFileNames);
+            assertEquals(List.of("AAA", "BBB"), view.pastedFileContents);
+            // totalFiles comes from the X-Paste-File-Count header,
+            // onComplete fires once the whole paste has been observed.
+            assertEquals(2, view.pasteStartTotal);
+            assertEquals(1, view.pasteCompleteCount);
         }
     }
 


### PR DESCRIPTION
Extend `ClipboardSimulator` to drive clipboard read paths.
`pasteInto` fires an `onPaste` DOM event with simulated text/html, and
`pasteFilesInto` simulates `onFilePaste` by invoking the resolved
`UploadHandler` for each `PastedFile`.

Extract the upload plumbing shared with `UploadTester` into an internal
`UploadSimulation` helper (no behavioral change to `UploadTester`).

