### PR TITLE
feat: allow custom Vaadin configurations per test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ end-to-end testing) by covering the fast-feedback layer of the testing pyramid.
   browser windows per user against a shared application within a single test;
   Vaadin thread-locals and per-user security context are switched
   automatically as you interact with each window
+- **Per-test Vaadin configuration** — apply application properties, feature
+  flags, and `Lookup` services to a single test class or method with
+  `@BrowserlessTestConfig`, without touching system properties or leaking into
+  other tests
 - **External navigation capture** — assert URLs triggered by
   `Page.setLocation()` and `Page.open()` (including `_blank`, named, and
   `_self` / `_parent` / `_top` targets) without leaving the test
@@ -368,6 +372,105 @@ window.find(PersonFormLocator::new).fillIn("Ada", "ada@example.com").submit();
 Locators are the typed convenience layer; `find(Class)` and `ComponentQuery`
 remain available for ad-hoc, lower-level queries and for filters not surfaced
 on locators. Use whichever fits — they search the same component tree.
+
+## Per-test Vaadin configuration
+
+Some tests need a Vaadin environment configured differently from the rest of
+the suite — a view behind a feature flag, or a setting such as
+`devmode.sessionSerialization.enabled`. Annotate the test class or the test
+method with `@BrowserlessTestConfig`:
+
+```java
+@ViewPackages(classes = CartView.class)
+@BrowserlessTestConfig(
+        applicationProperties = "devmode.sessionSerialization.enabled=true",
+        featureFlags = "myExperimentalFeature")
+class CartViewTest extends BrowserlessTest {
+
+    @Test
+    void experimentalFeatureIsAvailable() {
+        // the feature flag is enabled for this test only
+    }
+
+    @Test
+    @BrowserlessTestConfig(featureFlags = "myExperimentalFeature=false")
+    void fallbackWhenFeatureIsDisabled() {
+        // method level configuration wins over the class level one
+    }
+}
+```
+
+- `applicationProperties` entries are `name=value` pairs, applied to the Vaadin
+  deployment configuration of the mock environment. The value is everything
+  after the first `=`.
+- `featureFlags` entries are either a feature identifier, to enable it, or an
+  `id=true|false` pair. They override whatever
+  `vaadin-featureflags.properties` or the `vaadin.experimental.*` system
+  properties declare.
+- `lookupServices` are implementation classes registered with the Vaadin
+  `Lookup` — an `InstantiatorFactory`, a `ResourceProvider`, and so on:
+
+  ```java
+  @BrowserlessTestConfig(lookupServices = MyInstantiatorFactory.class)
+  class MyViewTest extends BrowserlessTest {
+  }
+  ```
+
+All of them are scoped to the Vaadin environment created for the test, so there
+is nothing to reset afterwards and nothing leaks into other tests.
+
+Class level and method level annotations are merged, with the method winning;
+for a `@Nested` test, the enclosing class configuration is merged in as well.
+Lookup services are the exception: they **accumulate** instead of being
+replaced, so a test method can add a service but cannot remove one declared by
+its class. Services required by the Spring and Quarkus integrations are always
+registered and are never affected by the test configuration.
+A method level annotation cannot be honored when the Vaadin environment is
+shared by all the tests in a class (`BrowserlessClassExtension`), and is
+rejected with an error.
+
+The same configuration can be defined programmatically, without annotations,
+on the extensions:
+
+```java
+@RegisterExtension
+BrowserlessExtension extension = new BrowserlessExtension()
+        .withApplicationProperty("devmode.sessionSerialization.enabled", "true")
+        .withFeatureFlags(FeatureFlags.COLLABORATION_ENGINE_BACKEND);
+```
+
+on the application context builder, for multi-user tests:
+
+```java
+try (var app = BrowserlessApplicationContext.create(builder -> builder
+        .withViewPackages(CartView.class)
+        .withApplicationProperty("devmode.sessionSerialization.enabled", "true")
+        .withFeatureFlags("myExperimentalFeature"))) {
+    // ...
+}
+```
+
+or by overriding `testConfiguration()` on a base class based test:
+
+```java
+@Override
+protected BrowserlessConfiguration testConfiguration() {
+    return BrowserlessConfiguration.builder()
+            .withConfiguration(super.testConfiguration())
+            .withFeatureFlags("myExperimentalFeature").build();
+}
+```
+
+When both are used, the programmatic configuration wins over the class level
+annotation, and loses against the method level one.
+
+> [!NOTE]
+> With Spring, a Vaadin property defined in the Spring environment (e.g.
+> `vaadin.devmode.sessionSerialization.enabled` in `application.properties`) is
+> applied by `SpringServlet` on top of the test configuration, and therefore
+> wins over `@BrowserlessTestConfig`. Use `@TestPropertySource` to override
+> such a property for a test. Properties that are not Vaadin init parameters
+> are not affected.
 
 ## Multi-user and multi-window testing
 

--- a/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
@@ -29,6 +29,7 @@ import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.internal.Routes;
 import com.vaadin.browserless.locator.Locators;
 import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.experimental.Feature;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.Key;
@@ -45,8 +46,9 @@ abstract class AbstractBrowserlessExtension
 
     // Programmatic config (builder-style)
     private final Set<String> viewPackages = new HashSet<>();
-    private final Set<Class<?>> services = new HashSet<>();
     private final Set<String> componentTesterPackages = new HashSet<>();
+    private final BrowserlessConfiguration.Builder configuration = BrowserlessConfiguration
+            .builder();
 
     // Runtime state
     private TestSignalEnvironment signalsTestEnvironment;
@@ -64,7 +66,7 @@ abstract class AbstractBrowserlessExtension
     }
 
     protected void addServices(Class<?>... serviceClasses) {
-        services.addAll(Arrays.asList(serviceClasses));
+        configuration.withLookupServices(serviceClasses);
     }
 
     protected void addComponentTesterPackages(String... packages) {
@@ -76,14 +78,48 @@ abstract class AbstractBrowserlessExtension
                 .forEach(componentTesterPackages::add);
     }
 
+    protected void addApplicationProperty(String name, String value) {
+        configuration.withApplicationProperty(name, value);
+    }
+
+    protected void addApplicationProperties(Map<String, String> properties) {
+        configuration.withApplicationProperties(properties);
+    }
+
+    protected void addFeatureFlags(String... featureIds) {
+        configuration.withFeatureFlags(featureIds);
+    }
+
+    protected void addFeatureFlags(Feature... features) {
+        configuration.withFeatureFlags(features);
+    }
+
+    protected void addFeatureFlag(String featureId, boolean enabled) {
+        configuration.withFeatureFlag(featureId, enabled);
+    }
+
+    protected void addFeatureFlag(Feature feature, boolean enabled) {
+        configuration.withFeatureFlag(feature, enabled);
+    }
+
+    protected void addConfiguration(BrowserlessConfiguration configuration) {
+        this.configuration.withConfiguration(configuration);
+    }
+
     // --- Lifecycle callbacks ---
 
     protected void doInit(Object testInstance, ExtensionContext ctx) {
+        BrowserlessConfiguration effectiveConfiguration = BrowserlessTestConfigExtension
+                .resolveConfiguration(ctx, configuration.build());
         if (testInstance instanceof BaseBrowserlessTest base) {
+            base.setResolvedConfiguration(effectiveConfiguration);
             base.initVaadinEnvironment();
-            cleanupAction = base::cleanVaadinEnvironment;
+            cleanupAction = () -> {
+                base.cleanVaadinEnvironment();
+                base.setResolvedConfiguration(null);
+            };
         } else {
-            standaloneInit(ctx.getRequiredTestClass());
+            standaloneInit(ctx.getRequiredTestClass(), effectiveConfiguration);
             cleanupAction = this::standaloneCleanup;
         }
     }
@@ -103,7 +139,8 @@ abstract class AbstractBrowserlessExtension
         MockVaadin.tearDown();
     }
 
-    private void standaloneInit(Class<?> testClass) {
+    private void standaloneInit(Class<?> testClass,
+            BrowserlessConfiguration configuration) {
         // Scan for additional component testers
         Set<String> testerPkgs = new HashSet<>(componentTesterPackages);
         ComponentTesterPackages testerAnnotation = testClass
@@ -130,7 +167,7 @@ abstract class AbstractBrowserlessExtension
         packages.removeIf(Objects::isNull);
 
         Routes routes = RouteDiscovery.discover(packages);
-        MockVaadin.setup(routes, MockedUI::new, services);
+        MockVaadin.setup(routes, MockedUI::new, Set.of(), configuration);
         signalsTestEnvironment = TestSignalEnvironment.register();
     }
 

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessClassExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessClassExtension.java
@@ -15,9 +15,13 @@
  */
 package com.vaadin.browserless;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.vaadin.experimental.Feature;
 
 /**
  * JUnit 5 extension for browserless Vaadin testing with per-class lifecycle.
@@ -130,6 +134,123 @@ public class BrowserlessClassExtension extends AbstractBrowserlessExtension
     public BrowserlessClassExtension withComponentTesterPackages(
             Class<?>... classes) {
         addComponentTesterPackages(classes);
+        return this;
+    }
+
+    /**
+     * Sets a Vaadin application property (init parameter) for the tests using
+     * this extension.
+     *
+     * @param name
+     *            the property name
+     * @param value
+     *            the property value
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessClassExtension withApplicationProperty(String name,
+            String value) {
+        addApplicationProperty(name, value);
+        return this;
+    }
+
+    /**
+     * Sets Vaadin application properties (init parameters) for the tests using
+     * this extension.
+     *
+     * @param properties
+     *            the properties to set
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessClassExtension withApplicationProperties(
+            Map<String, String> properties) {
+        addApplicationProperties(properties);
+        return this;
+    }
+
+    /**
+     * Enables the given Vaadin feature flags for the tests using this
+     * extension.
+     *
+     * @param featureIds
+     *            the identifiers of the features to enable
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessClassExtension withFeatureFlags(String... featureIds) {
+        addFeatureFlags(featureIds);
+        return this;
+    }
+
+    /**
+     * Enables the given Vaadin feature flags for the tests using this
+     * extension.
+     *
+     * @param features
+     *            the features to enable
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessClassExtension withFeatureFlags(Feature... features) {
+        addFeatureFlags(features);
+        return this;
+    }
+
+    /**
+     * Enables or disables the given Vaadin feature flag for the tests using
+     * this extension.
+     *
+     * @param featureId
+     *            the identifier of the feature
+     * @param enabled
+     *            {@code true} to enable the feature, {@code false} to disable
+     *            it
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessClassExtension withFeatureFlag(String featureId,
+            boolean enabled) {
+        addFeatureFlag(featureId, enabled);
+        return this;
+    }
+
+    /**
+     * Enables or disables the given Vaadin feature flag for the tests using
+     * this extension.
+     *
+     * @param feature
+     *            the feature
+     * @param enabled
+     *            {@code true} to enable the feature, {@code false} to disable
+     *            it
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessClassExtension withFeatureFlag(Feature feature,
+            boolean enabled) {
+        addFeatureFlag(feature, enabled);
+        return this;
+    }
+
+    /**
+     * Applies the given custom Vaadin configuration to the tests using this
+     * extension.
+     * <p>
+     * The configuration wins over the one declared by a
+     * {@link BrowserlessTestConfig} annotation on the test class. Since the
+     * Vaadin environment is shared by all the tests in the class, a
+     * {@link BrowserlessTestConfig} annotation on a test method is not
+     * supported.
+     *
+     * @param configuration
+     *            the configuration to apply
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessClassExtension withConfiguration(
+            BrowserlessConfiguration configuration) {
+        addConfiguration(configuration);
         return this;
     }
 

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessExtension.java
@@ -15,9 +15,13 @@
  */
 package com.vaadin.browserless;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.vaadin.experimental.Feature;
 
 /**
  * JUnit 5 extension for browserless Vaadin testing with per-method lifecycle.
@@ -123,6 +127,121 @@ public class BrowserlessExtension extends AbstractBrowserlessExtension
     public BrowserlessExtension withComponentTesterPackages(
             Class<?>... classes) {
         addComponentTesterPackages(classes);
+        return this;
+    }
+
+    /**
+     * Sets a Vaadin application property (init parameter) for the tests using
+     * this extension.
+     *
+     * @param name
+     *            the property name
+     * @param value
+     *            the property value
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessExtension withApplicationProperty(String name,
+            String value) {
+        addApplicationProperty(name, value);
+        return this;
+    }
+
+    /**
+     * Sets Vaadin application properties (init parameters) for the tests using
+     * this extension.
+     *
+     * @param properties
+     *            the properties to set
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessExtension withApplicationProperties(
+            Map<String, String> properties) {
+        addApplicationProperties(properties);
+        return this;
+    }
+
+    /**
+     * Enables the given Vaadin feature flags for the tests using this
+     * extension.
+     *
+     * @param featureIds
+     *            the identifiers of the features to enable
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessExtension withFeatureFlags(String... featureIds) {
+        addFeatureFlags(featureIds);
+        return this;
+    }
+
+    /**
+     * Enables the given Vaadin feature flags for the tests using this
+     * extension.
+     *
+     * @param features
+     *            the features to enable
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessExtension withFeatureFlags(Feature... features) {
+        addFeatureFlags(features);
+        return this;
+    }
+
+    /**
+     * Enables or disables the given Vaadin feature flag for the tests using
+     * this extension.
+     *
+     * @param featureId
+     *            the identifier of the feature
+     * @param enabled
+     *            {@code true} to enable the feature, {@code false} to disable
+     *            it
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessExtension withFeatureFlag(String featureId,
+            boolean enabled) {
+        addFeatureFlag(featureId, enabled);
+        return this;
+    }
+
+    /**
+     * Enables or disables the given Vaadin feature flag for the tests using
+     * this extension.
+     *
+     * @param feature
+     *            the feature
+     * @param enabled
+     *            {@code true} to enable the feature, {@code false} to disable
+     *            it
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessExtension withFeatureFlag(Feature feature,
+            boolean enabled) {
+        addFeatureFlag(feature, enabled);
+        return this;
+    }
+
+    /**
+     * Applies the given custom Vaadin configuration to the tests using this
+     * extension.
+     * <p>
+     * The configuration wins over the one declared by a
+     * {@link BrowserlessTestConfig} annotation on the test class, but loses
+     * against the one declared on the test method.
+     *
+     * @param configuration
+     *            the configuration to apply
+     * @return this extension instance
+     * @since 1.2
+     */
+    public BrowserlessExtension withConfiguration(
+            BrowserlessConfiguration configuration) {
+        addConfiguration(configuration);
         return this;
     }
 

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessTest.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessTest.java
@@ -17,6 +17,7 @@ package com.vaadin.browserless;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Base JUnit 6 class for browserless tests.
@@ -112,8 +113,10 @@ import org.junit.jupiter.api.BeforeEach;
  * @see BrowserlessExtension
  *
  * @see BrowserlessClassExtension
+ * @see BrowserlessTestConfig
  * @since 1.0
  */
+@ExtendWith(BrowserlessTestConfigExtension.class)
 public abstract class BrowserlessTest extends BaseBrowserlessTest
         implements TesterWrappers {
 

--- a/junit6/src/main/java/com/vaadin/browserless/BrowserlessTestConfigExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/BrowserlessTestConfigExtension.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+
+/**
+ * JUnit extension resolving the {@link BrowserlessTestConfig} annotations
+ * declared by a test, and making the resulting configuration available to the
+ * {@link BaseBrowserlessTest} instance before it initializes the Vaadin
+ * environment.
+ * <p>
+ * Registered by the browserless base test classes; there is no need to add it
+ * to a test explicitly.
+ *
+ * @since 1.2
+ */
+public class BrowserlessTestConfigExtension
+        implements BeforeEachCallback, AfterEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        browserlessTest(context).ifPresent(test -> test
+                .setResolvedConfiguration(resolveConfiguration(context)));
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        browserlessTest(context)
+                .ifPresent(test -> test.setResolvedConfiguration(null));
+    }
+
+    private static Optional<BaseBrowserlessTest> browserlessTest(
+            ExtensionContext context) {
+        return context.getTestInstance()
+                .filter(BaseBrowserlessTest.class::isInstance)
+                .map(BaseBrowserlessTest.class::cast);
+    }
+
+    /**
+     * Resolves the effective configuration for the given extension context,
+     * merging the {@link BrowserlessTestConfig} annotations declared by the
+     * test class and by the current test method, if any.
+     * <p>
+     * Meta annotations, superclasses and, for nested tests, enclosing classes
+     * are taken into account. Values declared on the test method win over the
+     * ones declared on the test class, which in turn win over the ones declared
+     * on an enclosing test class.
+     *
+     * @param context
+     *            the current extension context, not {@literal null}
+     * @return the effective configuration, never {@literal null}
+     */
+    static BrowserlessConfiguration resolveConfiguration(
+            ExtensionContext context) {
+        return resolveConfiguration(context, BrowserlessConfiguration.empty());
+    }
+
+    /**
+     * Same as {@link #resolveConfiguration(ExtensionContext)}, but with a
+     * configuration defined programmatically that wins over the one declared on
+     * the test class, and loses against the one declared on the test method.
+     *
+     * @param context
+     *            the current extension context, not {@literal null}
+     * @param programmaticConfiguration
+     *            the configuration defined programmatically, not
+     *            {@literal null}
+     * @return the effective configuration, never {@literal null}
+     */
+    static BrowserlessConfiguration resolveConfiguration(
+            ExtensionContext context,
+            BrowserlessConfiguration programmaticConfiguration) {
+        // Enclosing classes of a nested test are merged from the outermost to
+        // the innermost one, so that a nested test can refine the configuration
+        // declared by its enclosing test class.
+        BrowserlessConfiguration configuration = BrowserlessConfiguration
+                .empty();
+        for (Class<?> enclosingClass : context.getEnclosingTestClasses()) {
+            configuration = configuration.merge(forClass(enclosingClass));
+        }
+        configuration = configuration
+                .merge(context.getTestClass()
+                        .map(BrowserlessTestConfigExtension::forClass)
+                        .orElseGet(BrowserlessConfiguration::empty))
+                .merge(programmaticConfiguration);
+
+        Optional<Method> testMethod = context.getTestMethod();
+        if (testMethod.isEmpty()) {
+            // The Vaadin environment is created once for the whole test class,
+            // so a method level configuration could not be applied.
+            context.getTestClass().ifPresent(
+                    BrowserlessTestConfigExtension::failOnMethodLevelConfiguration);
+            return configuration;
+        }
+        return configuration.merge(AnnotationSupport
+                .findAnnotation(testMethod.get(), BrowserlessTestConfig.class)
+                .map(BrowserlessConfiguration::from)
+                .orElseGet(BrowserlessConfiguration::empty));
+    }
+
+    private static BrowserlessConfiguration forClass(Class<?> testClass) {
+        return AnnotationSupport
+                .findAnnotation(testClass, BrowserlessTestConfig.class)
+                .map(BrowserlessConfiguration::from)
+                .orElseGet(BrowserlessConfiguration::empty);
+    }
+
+    /**
+     * Fails if the given test class declares a {@link BrowserlessTestConfig}
+     * annotation on a method, which cannot be honored when the Vaadin
+     * environment is created once for the whole class.
+     *
+     * @param testClass
+     *            the test class to check, not {@literal null}
+     */
+    static void failOnMethodLevelConfiguration(Class<?> testClass) {
+        String annotatedMethods = AnnotationSupport
+                .findAnnotatedMethods(testClass, BrowserlessTestConfig.class,
+                        HierarchyTraversalMode.TOP_DOWN)
+                .stream().map(Method::getName).sorted()
+                .collect(Collectors.joining(", "));
+        if (!annotatedMethods.isEmpty()) {
+            throw new BrowserlessTestSetupException("@"
+                    + BrowserlessTestConfig.class.getSimpleName()
+                    + " is not supported on test methods when the Vaadin environment is "
+                    + "shared by all the tests in the class, but it is present on "
+                    + annotatedMethods
+                    + ". Move the configuration to the test class, or use a Vaadin "
+                    + "environment created for each test method.");
+        }
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigBaseClassTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigBaseClassTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.experimental.Feature;
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Verifies that {@link BrowserlessTestConfig} declared on a
+ * {@link BrowserlessTest} subclass and on its test methods is applied to the
+ * mock Vaadin environment.
+ */
+@ViewPackages(classes = WelcomeView.class)
+@BrowserlessTestConfig(applicationProperties = { "class.property=fromClass",
+        "shared.property=fromClass" }, featureFlags = "collaborationEngineBackend")
+class BrowserlessTestConfigBaseClassTest extends BrowserlessTest {
+
+    private static final Feature FEATURE = FeatureFlags.COLLABORATION_ENGINE_BACKEND;
+
+    @Test
+    void classLevelConfiguration_isApplied() {
+        Assertions.assertEquals("fromClass", property("class.property"));
+        Assertions.assertEquals("fromClass", property("shared.property"));
+        Assertions.assertTrue(featureFlags().isEnabled(FEATURE),
+                "Feature flag enabled on the test class should be enabled");
+    }
+
+    @Test
+    @BrowserlessTestConfig(applicationProperties = "shared.property=fromMethod", featureFlags = "collaborationEngineBackend=false")
+    void methodLevelConfiguration_winsOverClassLevel() {
+        Assertions.assertEquals("fromMethod", property("shared.property"),
+                "Method level property should win over the class level one");
+        Assertions.assertEquals("fromClass", property("class.property"),
+                "Class level properties should still be applied");
+        Assertions.assertFalse(featureFlags().isEnabled(FEATURE),
+                "Method level configuration should be able to disable a feature");
+    }
+
+    @Test
+    void otherTestMethods_areNotAffected() {
+        Assertions.assertEquals("fromClass", property("shared.property"),
+                "Configuration of another test method must not leak");
+        Assertions.assertTrue(featureFlags().isEnabled(FEATURE));
+    }
+
+    @Test
+    void browserlessMode_isStillEnforced() {
+        Assertions.assertTrue(
+                VaadinService.getCurrent().getDeploymentConfiguration()
+                        .getBooleanProperty("browserless", false));
+    }
+
+    private static String property(String name) {
+        return VaadinService.getCurrent().getDeploymentConfiguration()
+                .getStringProperty(name, null);
+    }
+
+    private static FeatureFlags featureFlags() {
+        return FeatureFlags.get(VaadinService.getCurrent().getContext());
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigClassExtensionTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigClassExtensionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Verifies that a class level {@link BrowserlessTestConfig} is applied to the
+ * Vaadin environment shared by all the tests of a
+ * {@link BrowserlessClassExtension}, and that a method level configuration is
+ * rejected, since it could not be honored.
+ */
+@ViewPackages(classes = WelcomeView.class)
+@BrowserlessTestConfig(applicationProperties = "class.property=fromClass", featureFlags = "collaborationEngineBackend")
+class BrowserlessTestConfigClassExtensionTest {
+
+    @RegisterExtension
+    static BrowserlessClassExtension extension = new BrowserlessClassExtension()
+            .withApplicationProperty("extension.property", "fromExtension");
+
+    @Test
+    void classLevelConfiguration_isApplied() {
+        Assertions.assertEquals("fromClass",
+                VaadinService.getCurrent().getDeploymentConfiguration()
+                        .getStringProperty("class.property", null));
+        Assertions.assertEquals("fromExtension",
+                VaadinService.getCurrent().getDeploymentConfiguration()
+                        .getStringProperty("extension.property", null));
+        Assertions.assertTrue(
+                FeatureFlags.get(VaadinService.getCurrent().getContext())
+                        .isEnabled(FeatureFlags.COLLABORATION_ENGINE_BACKEND));
+    }
+
+    @Test
+    void methodLevelConfiguration_isRejected() {
+        BrowserlessTestSetupException exception = Assertions.assertThrows(
+                BrowserlessTestSetupException.class,
+                () -> BrowserlessTestConfigExtension
+                        .failOnMethodLevelConfiguration(
+                                MethodLevelConfigFixture.class));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains("configuredTestMethod"),
+                "The error should name the offending test methods, but was: "
+                        + exception.getMessage());
+    }
+
+    @Test
+    void withoutMethodLevelConfiguration_isAccepted() {
+        Assertions.assertDoesNotThrow(() -> BrowserlessTestConfigExtension
+                .failOnMethodLevelConfiguration(
+                        BrowserlessTestConfigClassExtensionTest.class));
+    }
+
+    static class MethodLevelConfigFixture {
+        @BrowserlessTestConfig(featureFlags = "collaborationEngineBackend")
+        void configuredTestMethod() {
+        }
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigExtensionTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigExtensionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.experimental.Feature;
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Verifies how {@link BrowserlessExtension} combines the configuration declared
+ * with {@link BrowserlessTestConfig} and the one defined programmatically on
+ * the extension instance.
+ */
+@ViewPackages(classes = WelcomeView.class)
+@BrowserlessTestConfig(applicationProperties = { "class.property=fromClass",
+        "shared.property=fromClass",
+        "overridden.property=fromClass" }, featureFlags = "collaborationEngineBackend")
+class BrowserlessTestConfigExtensionTest {
+
+    private static final Feature FEATURE = FeatureFlags.COLLABORATION_ENGINE_BACKEND;
+
+    @RegisterExtension
+    BrowserlessExtension extension = new BrowserlessExtension()
+            .withApplicationProperty("extension.property", "fromExtension")
+            .withApplicationProperty("overridden.property", "fromExtension")
+            .withApplicationProperty("shared.property", "fromExtension");
+
+    @Test
+    void programmaticConfiguration_winsOverClassLevelAnnotation() {
+        Assertions.assertEquals("fromExtension",
+                property("overridden.property"));
+        Assertions.assertEquals("fromExtension",
+                property("extension.property"));
+        Assertions.assertEquals("fromClass", property("class.property"),
+                "Class level properties should still be applied");
+        Assertions.assertTrue(featureFlags().isEnabled(FEATURE),
+                "Feature flags declared on the test class should be applied");
+    }
+
+    @Test
+    @BrowserlessTestConfig(applicationProperties = "shared.property=fromMethod")
+    void methodLevelAnnotation_winsOverProgrammaticConfiguration() {
+        Assertions.assertEquals("fromMethod", property("shared.property"));
+        Assertions.assertEquals("fromExtension",
+                property("overridden.property"));
+    }
+
+    private static String property(String name) {
+        return VaadinService.getCurrent().getDeploymentConfiguration()
+                .getStringProperty(name, null);
+    }
+
+    private static FeatureFlags featureFlags() {
+        return FeatureFlags.get(VaadinService.getCurrent().getContext());
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigLookupServicesTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigLookupServicesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Verifies that lookup services can be declared with
+ * {@link BrowserlessTestConfig}, and that they accumulate with the ones
+ * provided by the deprecated {@link BaseBrowserlessTest#lookupServices()} hook.
+ */
+@ViewPackages(classes = WelcomeView.class)
+class BrowserlessTestConfigLookupServicesTest {
+
+    @Nested
+    @BrowserlessTestConfig(lookupServices = TestCustomInstantiatorFactory.class)
+    class DeclaredOnClass extends BrowserlessTest {
+
+        @Test
+        void annotatedService_isAvailableInLookup() {
+            Assertions.assertInstanceOf(TestCustomInstantiatorFactory.class,
+                    lookup().lookup(InstantiatorFactory.class));
+        }
+
+        @Test
+        @BrowserlessTestConfig(lookupServices = TestNoOpInstantiatorFactory.class)
+        void methodServices_accumulateWithClassOnes() {
+            assertRegistered(TestCustomInstantiatorFactory.class,
+                    TestNoOpInstantiatorFactory.class);
+        }
+    }
+
+    @Nested
+    @BrowserlessTestConfig(lookupServices = TestNoOpInstantiatorFactory.class)
+    class DeclaredOnBothClassAndDeprecatedHook extends BrowserlessTest {
+
+        @SuppressWarnings("deprecation")
+        @Override
+        protected Set<Class<?>> lookupServices() {
+            return Set.of(TestCustomInstantiatorFactory.class);
+        }
+
+        @Test
+        void deprecatedHookAndAnnotation_areBothHonored() {
+            assertRegistered(TestCustomInstantiatorFactory.class,
+                    TestNoOpInstantiatorFactory.class);
+        }
+    }
+
+    private static void assertRegistered(Class<?>... expectedServices) {
+        Collection<InstantiatorFactory> factories = lookup()
+                .lookupAll(InstantiatorFactory.class);
+        Set<Class<?>> registered = factories.stream().map(Object::getClass)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        for (Class<?> expected : expectedServices) {
+            Assertions.assertTrue(registered.contains(expected),
+                    "Expecting " + expected.getSimpleName()
+                            + " to be registered in Lookup, but found "
+                            + registered);
+        }
+    }
+
+    private static Lookup lookup() {
+        Lookup lookup = VaadinService.getCurrent().getContext()
+                .getAttribute(Lookup.class);
+        Assertions.assertNotNull(lookup, "Expecting Lookup to be initialized");
+        return lookup;
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigNestedTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessTestConfigNestedTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.example.base.WelcomeView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Verifies that a nested test inherits the {@link BrowserlessTestConfig} of its
+ * enclosing test class, and can refine it.
+ */
+@BrowserlessTestConfig(applicationProperties = { "outer.property=fromOuter",
+        "shared.property=fromOuter" })
+class BrowserlessTestConfigNestedTest {
+
+    @Nested
+    @ViewPackages(classes = WelcomeView.class)
+    @BrowserlessTestConfig(applicationProperties = {
+            "nested.property=fromNested", "shared.property=fromNested" })
+    class NestedTest extends BrowserlessTest {
+
+        @Test
+        void enclosingConfiguration_isMergedWithTheNestedOne() {
+            Assertions.assertEquals("fromOuter", property("outer.property"),
+                    "Configuration of the enclosing test class should be applied");
+            Assertions.assertEquals("fromNested", property("nested.property"));
+            Assertions.assertEquals("fromNested", property("shared.property"),
+                    "Nested configuration should win over the enclosing one");
+        }
+    }
+
+    private static String property(String name) {
+        return VaadinService.getCurrent().getDeploymentConfiguration()
+                .getStringProperty(name, null);
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/TestNoOpInstantiatorFactory.java
+++ b/junit6/src/test/java/com/vaadin/browserless/TestNoOpInstantiatorFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * An {@link InstantiatorFactory} that does not provide any
+ * {@link Instantiator}, used to verify that lookup services accumulate. Vaadin
+ * ignores factories returning {@literal null}, so registering this one together
+ * with {@link TestCustomInstantiatorFactory} does not make the service
+ * initialization fail with multiple eligible instantiators.
+ */
+public class TestNoOpInstantiatorFactory implements InstantiatorFactory {
+
+    @Override
+    public Instantiator createInstantitor(VaadinService vaadinService) {
+        return null;
+    }
+}

--- a/junit6/src/test/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsTesterTest.java
@@ -18,31 +18,21 @@ package com.vaadin.flow.component.breadcrumbs;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.browserless.BrowserlessTest;
+import com.vaadin.browserless.BrowserlessTestConfig;
 import com.vaadin.browserless.ViewPackages;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.RouteConfiguration;
 
 @ViewPackages
+@BrowserlessTestConfig(featureFlags = "breadcrumbsComponent")
 class BreadcrumbsTesterTest extends BrowserlessTest {
 
     BreadcrumbsView view;
-
-    @BeforeAll
-    static void enableBreadcrumbsFeatureFlag() {
-        System.setProperty("vaadin.experimental.breadcrumbsComponent", "true");
-    }
-
-    @AfterAll
-    static void clearBreadcrumbsFeatureFlag() {
-        System.clearProperty("vaadin.experimental.breadcrumbsComponent");
-    }
 
     @BeforeEach
     void init() {

--- a/junit6/src/test/java/com/vaadin/flow/component/checkbox/SwitchTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/checkbox/SwitchTesterTest.java
@@ -17,30 +17,20 @@ package com.vaadin.flow.component.checkbox;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.browserless.BrowserlessTest;
+import com.vaadin.browserless.BrowserlessTestConfig;
 import com.vaadin.browserless.ViewPackages;
 import com.vaadin.flow.router.RouteConfiguration;
 
 @ViewPackages
+@BrowserlessTestConfig(featureFlags = "switchComponent")
 class SwitchTesterTest extends BrowserlessTest {
 
     SwitchView view;
-
-    @BeforeAll
-    static void enableSwitchFeatureFlag() {
-        System.setProperty("vaadin.experimental.switchComponent", "true");
-    }
-
-    @AfterAll
-    static void clearSwitchFeatureFlag() {
-        System.clearProperty("vaadin.experimental.switchComponent");
-    }
 
     @BeforeEach
     void registerView() {

--- a/junit6/src/test/java/com/vaadin/flow/component/messages/MessageListTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/messages/MessageListTesterTest.java
@@ -21,9 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,17 +36,6 @@ import com.vaadin.flow.router.RouteConfiguration;
 class MessageListTesterTest extends BrowserlessTest {
 
     MessagesView view;
-
-    @BeforeAll
-    static void enableAttachmentsFeatureFlag() {
-        System.setProperty("vaadin.experimental.messageListAttachments",
-                "true");
-    }
-
-    @AfterAll
-    static void clearAttachmentsFeatureFlag() {
-        System.clearProperty("vaadin.experimental.messageListAttachments");
-    }
 
     @BeforeEach
     void init() {

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/DecimalRangeSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/DecimalRangeSliderTesterTest.java
@@ -17,9 +17,7 @@ package com.vaadin.flow.component.slider;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,16 +29,6 @@ import com.vaadin.flow.router.RouteConfiguration;
 class DecimalRangeSliderTesterTest extends BrowserlessTest {
 
     DecimalRangeSliderView view;
-
-    @BeforeAll
-    static void enableSliderFeatureFlag() {
-        System.setProperty("vaadin.experimental.sliderComponent", "true");
-    }
-
-    @AfterAll
-    static void clearSliderFeatureFlag() {
-        System.clearProperty("vaadin.experimental.sliderComponent");
-    }
 
     @BeforeEach
     void init() {

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/DecimalSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/DecimalSliderTesterTest.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.component.slider;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,16 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DecimalSliderTesterTest extends BrowserlessTest {
 
     DecimalSliderView view;
-
-    @BeforeAll
-    static void enableSliderFeatureFlag() {
-        System.setProperty("vaadin.experimental.sliderComponent", "true");
-    }
-
-    @AfterAll
-    static void clearSliderFeatureFlag() {
-        System.clearProperty("vaadin.experimental.sliderComponent");
-    }
 
     @BeforeEach
     void init() {

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerRangeSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerRangeSliderTesterTest.java
@@ -17,9 +17,7 @@ package com.vaadin.flow.component.slider;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,16 +29,6 @@ import com.vaadin.flow.router.RouteConfiguration;
 class IntegerRangeSliderTesterTest extends BrowserlessTest {
 
     IntegerRangeSliderView view;
-
-    @BeforeAll
-    static void enableSliderFeatureFlag() {
-        System.setProperty("vaadin.experimental.sliderComponent", "true");
-    }
-
-    @AfterAll
-    static void clearSliderFeatureFlag() {
-        System.clearProperty("vaadin.experimental.sliderComponent");
-    }
 
     @BeforeEach
     void init() {

--- a/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerSliderTesterTest.java
+++ b/junit6/src/test/java/com/vaadin/flow/component/slider/IntegerSliderTesterTest.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.component.slider;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,16 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class IntegerSliderTesterTest extends BrowserlessTest {
 
     IntegerSliderView view;
-
-    @BeforeAll
-    static void enableSliderFeatureFlag() {
-        System.setProperty("vaadin.experimental.sliderComponent", "true");
-    }
-
-    @AfterAll
-    static void clearSliderFeatureFlag() {
-        System.clearProperty("vaadin.experimental.sliderComponent");
-    }
 
     @BeforeEach
     void init() {

--- a/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
+++ b/quarkus/src/main/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTest.java
@@ -21,8 +21,10 @@ import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.vaadin.browserless.BaseBrowserlessTest;
+import com.vaadin.browserless.BrowserlessTestConfigExtension;
 import com.vaadin.browserless.TesterWrappers;
 import com.vaadin.browserless.internal.MockVaadin;
 import com.vaadin.browserless.mocks.MockedUI;
@@ -80,6 +82,7 @@ import com.vaadin.browserless.quarkus.mocks.MockQuarkusServlet;
  *
  * @since 1.0
  */
+@ExtendWith(BrowserlessTestConfigExtension.class)
 public abstract class QuarkusBrowserlessTest extends BaseBrowserlessTest
         implements TesterWrappers {
 
@@ -94,7 +97,8 @@ public abstract class QuarkusBrowserlessTest extends BaseBrowserlessTest
         scanTesters();
         MockQuarkusServlet servlet = new MockQuarkusServlet(discoverRoutes(),
                 CDI.current().getBeanManager(), MockedUI::new);
-        MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+        MockVaadin.setup(MockedUI::new, servlet, allLookupServices(),
+                testConfiguration());
         initSignalsSupport();
     }
 
@@ -105,7 +109,7 @@ public abstract class QuarkusBrowserlessTest extends BaseBrowserlessTest
     }
 
     @Override
-    protected Set<Class<?>> lookupServices() {
+    protected Set<Class<?>> frameworkLookupServices() {
         return Set.of(QuarkusTestLookupInitializer.class);
     }
 }

--- a/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTestConfigTest.java
+++ b/quarkus/src/test/java/com/vaadin/browserless/quarkus/QuarkusBrowserlessTestConfigTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.quarkus;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.BrowserlessTestConfig;
+import com.vaadin.browserless.ViewPackages;
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Verifies that {@link BrowserlessTestConfig} is applied to the mock Vaadin
+ * Quarkus environment.
+ */
+@QuarkusTest
+@ViewPackages(packages = "com.example")
+@BrowserlessTestConfig(applicationProperties = "class.property=fromClass", featureFlags = "collaborationEngineBackend")
+class QuarkusBrowserlessTestConfigTest extends QuarkusBrowserlessTest {
+
+    @Test
+    void classLevelConfiguration_isApplied() {
+        Assertions.assertEquals("fromClass", property("class.property"));
+        Assertions.assertTrue(
+                FeatureFlags.get(VaadinService.getCurrent().getContext())
+                        .isEnabled(FeatureFlags.COLLABORATION_ENGINE_BACKEND));
+    }
+
+    @Test
+    @BrowserlessTestConfig(applicationProperties = "method.property=fromMethod", featureFlags = "collaborationEngineBackend=false")
+    void methodLevelConfiguration_isApplied() {
+        Assertions.assertEquals("fromMethod", property("method.property"));
+        Assertions.assertEquals("fromClass", property("class.property"));
+        Assertions.assertFalse(
+                FeatureFlags.get(VaadinService.getCurrent().getContext())
+                        .isEnabled(FeatureFlags.COLLABORATION_ENGINE_BACKEND));
+    }
+
+    private static String property(String name) {
+        return VaadinService.getCurrent().getDeploymentConfiguration()
+                .getStringProperty(name, null);
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
+++ b/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
@@ -17,6 +17,7 @@ package com.vaadin.browserless;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -53,6 +54,7 @@ import com.vaadin.flow.server.VaadinSession;
 public abstract class BaseBrowserlessTest {
 
     private TestSignalEnvironment signalsTestEnvironment;
+    private BrowserlessConfiguration resolvedConfiguration;
 
     protected synchronized Routes discoverRoutes() {
         return discoverRoutes(scanPackages());
@@ -75,8 +77,28 @@ public abstract class BaseBrowserlessTest {
      */
     protected void initVaadinEnvironment() {
         scanTesters();
-        MockVaadin.setup(discoverRoutes(), MockedUI::new, lookupServices());
+        MockVaadin.setup(discoverRoutes(), MockedUI::new, allLookupServices(),
+                testConfiguration());
         initSignalsSupport();
+    }
+
+    /**
+     * Gets the lookup services to register, combining the ones required by the
+     * framework integration, the ones provided by the deprecated
+     * {@link #lookupServices()} hook, and the ones declared by the test
+     * configuration.
+     *
+     * For internal use only.
+     *
+     * @return the set of services implementation classes, never
+     *         {@literal null}.
+     */
+    @SuppressWarnings("deprecation")
+    protected final Set<Class<?>> allLookupServices() {
+        Set<Class<?>> services = new LinkedHashSet<>(frameworkLookupServices());
+        services.addAll(lookupServices());
+        services.addAll(testConfiguration().getLookupServices());
+        return services;
     }
 
     protected void initSignalsSupport() {
@@ -136,9 +158,72 @@ public abstract class BaseBrowserlessTest {
      * {@link com.vaadin.flow.di.ResourceProvider}, etc.
      *
      * @return set of services implementation classes, never {@literal null}.
+     * @deprecated since 1.2, declare the services with
+     *             {@link BrowserlessTestConfig#lookupServices()} or by
+     *             overriding {@link #testConfiguration()} instead. Overrides of
+     *             this method are still honored.
      */
+    @Deprecated(since = "1.2")
     protected Set<Class<?>> lookupServices() {
         return Collections.emptySet();
+    }
+
+    /**
+     * Gets the services implementations required by the framework integration
+     * to initialize the Vaadin {@link com.vaadin.flow.di.Lookup}, for example
+     * the Spring or Quarkus lookup initializers.
+     *
+     * These services are always registered, regardless of the test
+     * configuration, so that a test customizing {@link #testConfiguration()}
+     * cannot accidentally break the framework integration.
+     *
+     * Meant to be overridden by framework specific base classes only; tests
+     * should declare their own services with
+     * {@link BrowserlessTestConfig#lookupServices()}.
+     *
+     * @return set of services implementation classes, never {@literal null}.
+     * @since 1.2
+     */
+    protected Set<Class<?>> frameworkLookupServices() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Gets the custom Vaadin configuration, such as application properties and
+     * feature flags, to apply to the mock Vaadin environment.
+     *
+     * Default implementation returns the configuration declared by the
+     * {@link BrowserlessTestConfig} annotations present on the test class and
+     * on the current test method, if any. Override this method to provide the
+     * configuration programmatically, potentially on top of the declared one.
+     *
+     * <pre>
+     * &#64;Override
+     * protected BrowserlessConfiguration testConfiguration() {
+     *     return BrowserlessConfiguration.builder()
+     *             .withConfiguration(super.testConfiguration())
+     *             .withFeatureFlags("myExperimentalFeature").build();
+     * }
+     * </pre>
+     *
+     * @return the configuration to apply, never {@literal null}.
+     * @see BrowserlessTestConfig
+     * @since 1.2
+     */
+    protected BrowserlessConfiguration testConfiguration() {
+        if (resolvedConfiguration != null) {
+            return resolvedConfiguration;
+        }
+        return BrowserlessConfiguration.from(getClass());
+    }
+
+    /**
+     * Sets the configuration resolved by the JUnit extension that handles
+     * {@link BrowserlessTestConfig} annotations, so that annotations on the
+     * current test method are taken into account as well.
+     */
+    void setResolvedConfiguration(BrowserlessConfiguration configuration) {
+        this.resolvedConfiguration = configuration;
     }
 
     /**

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessApplicationContext.java
@@ -16,9 +16,9 @@
 package com.vaadin.browserless;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,6 +33,7 @@ import com.vaadin.browserless.internal.Routes;
 import com.vaadin.browserless.internal.UIFactory;
 import com.vaadin.browserless.mocks.MockVaadinServlet;
 import com.vaadin.browserless.mocks.MockedUI;
+import com.vaadin.experimental.Feature;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -341,7 +342,8 @@ public class BrowserlessApplicationContext implements AutoCloseable {
         private Routes routes;
         private BiFunction<Routes, UIFactory, VaadinServlet> servletFactory;
         private UIFactory uiFactory = () -> new MockedUI();
-        private Set<Class<?>> lookupServices = Collections.emptySet();
+        private final BrowserlessConfiguration.Builder configuration = BrowserlessConfiguration
+                .builder();
         private final Set<String> viewPackages = new LinkedHashSet<>();
         private final Set<String> componentTesterPackages = new LinkedHashSet<>();
         private final List<Runnable> closeHooks = new ArrayList<>();
@@ -532,20 +534,136 @@ public class BrowserlessApplicationContext implements AutoCloseable {
          *             {@code null}
          */
         public Builder withLookupServices(Class<?>... services) {
-            Objects.requireNonNull(services);
-            if (services.length == 0) {
-                return this;
-            }
-            Set<Class<?>> updated = new LinkedHashSet<>(this.lookupServices);
-            for (Class<?> service : services) {
-                updated.add(Objects.requireNonNull(service));
-            }
-            this.lookupServices = updated;
+            configuration.withLookupServices(services);
             return this;
         }
 
         Set<Class<?>> getLookupServices() {
-            return lookupServices;
+            return configuration.build().getLookupServices();
+        }
+
+        /**
+         * Sets a Vaadin application property (init parameter) for this
+         * application. A previously set value for the same name is replaced.
+         *
+         * @param name
+         *            the property name; must not be {@code null}
+         * @param value
+         *            the property value; must not be {@code null}
+         * @return this builder
+         * @throws IllegalArgumentException
+         *             if the name is blank or reserved by the browserless
+         *             environment
+         */
+        public Builder withApplicationProperty(String name, String value) {
+            configuration.withApplicationProperty(name, value);
+            return this;
+        }
+
+        /**
+         * Sets Vaadin application properties (init parameters) for this
+         * application. Previously set values for the same names are replaced.
+         *
+         * @param properties
+         *            the properties to set; must not be {@code null}
+         * @return this builder
+         * @throws IllegalArgumentException
+         *             if a name is blank or reserved by the browserless
+         *             environment
+         */
+        public Builder withApplicationProperties(
+                Map<String, String> properties) {
+            configuration.withApplicationProperties(properties);
+            return this;
+        }
+
+        /**
+         * Enables the given Vaadin feature flags for this application,
+         * overriding the values potentially defined in the
+         * {@literal vaadin-featureflags.properties} file or in system
+         * properties.
+         *
+         * @param featureIds
+         *            the identifiers of the features to enable; must not be
+         *            {@code null}
+         * @return this builder
+         */
+        public Builder withFeatureFlags(String... featureIds) {
+            configuration.withFeatureFlags(featureIds);
+            return this;
+        }
+
+        /**
+         * Enables the given Vaadin feature flags for this application,
+         * overriding the values potentially defined in the
+         * {@literal vaadin-featureflags.properties} file or in system
+         * properties.
+         *
+         * @param features
+         *            the features to enable; must not be {@code null}
+         * @return this builder
+         */
+        public Builder withFeatureFlags(Feature... features) {
+            configuration.withFeatureFlags(features);
+            return this;
+        }
+
+        /**
+         * Enables or disables the given Vaadin feature flag for this
+         * application, overriding the value potentially defined in the
+         * {@literal vaadin-featureflags.properties} file or in system
+         * properties.
+         *
+         * @param featureId
+         *            the identifier of the feature; must not be {@code null}
+         * @param enabled
+         *            {@code true} to enable the feature, {@code false} to
+         *            disable it
+         * @return this builder
+         */
+        public Builder withFeatureFlag(String featureId, boolean enabled) {
+            configuration.withFeatureFlag(featureId, enabled);
+            return this;
+        }
+
+        /**
+         * Enables or disables the given Vaadin feature flag for this
+         * application, overriding the value potentially defined in the
+         * {@literal vaadin-featureflags.properties} file or in system
+         * properties.
+         *
+         * @param feature
+         *            the feature; must not be {@code null}
+         * @param enabled
+         *            {@code true} to enable the feature, {@code false} to
+         *            disable it
+         * @return this builder
+         */
+        public Builder withFeatureFlag(Feature feature, boolean enabled) {
+            configuration.withFeatureFlag(feature, enabled);
+            return this;
+        }
+
+        /**
+         * Applies the given custom Vaadin configuration to this builder,
+         * replacing previously set entries with the same names.
+         * <p>
+         * Useful to reuse a configuration declared with
+         * {@link BrowserlessTestConfig} on a test class:
+         *
+         * <pre>
+         * BrowserlessApplicationContext.create(b -&gt; b.withViewPackages(MyView.class)
+         *         .withConfiguration(BrowserlessConfiguration.from(getClass())));
+         * </pre>
+         *
+         * @param testConfiguration
+         *            the configuration to apply; must not be {@code null}
+         * @return this builder
+         */
+        public Builder withConfiguration(
+                BrowserlessConfiguration testConfiguration) {
+            configuration.withConfiguration(testConfiguration);
+            return this;
         }
 
         /**
@@ -611,7 +729,8 @@ public class BrowserlessApplicationContext implements AutoCloseable {
             VaadinServlet servlet = servletFactory != null
                     ? servletFactory.apply(resolvedRoutes, uiFactory)
                     : new MockVaadinServlet(resolvedRoutes, uiFactory);
-            return MockVaadin.setupServlet(servlet, lookupServices);
+            return MockVaadin.setupServlet(servlet, Set.of(),
+                    configuration.build());
         }
 
         UIFactory uiFactory() {

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessConfiguration.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessConfiguration.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.io.Serializable;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import com.vaadin.experimental.Feature;
+import com.vaadin.flow.server.InitParameters;
+
+/**
+ * Custom Vaadin configuration to apply to a mock Vaadin environment.
+ * <p>
+ * Holds Vaadin application properties (also known as init parameters) and
+ * feature flag overrides. Both are scoped to the environment they are applied
+ * to, so a configuration used by a test neither affects other tests nor
+ * requires any clean up.
+ * <p>
+ * Instances are immutable and can be created with a {@link #builder()} or
+ * derived from a {@link BrowserlessTestConfig} annotation.
+ *
+ * <pre>
+ * BrowserlessConfiguration configuration = BrowserlessConfiguration.builder()
+ *         .withApplicationProperty(
+ *                 InitParameters.APPLICATION_PARAMETER_DEVMODE_ENABLE_SERIALIZE_SESSION,
+ *                 "true")
+ *         .withFeatureFlags("myExperimentalFeature") //
+ *         .build();
+ * </pre>
+ *
+ * @see BrowserlessTestConfig
+ * @since 1.2
+ */
+public final class BrowserlessConfiguration implements Serializable {
+
+    private static final BrowserlessConfiguration EMPTY = new BrowserlessConfiguration(
+            Map.of(), Map.of(), Set.of());
+
+    private final Map<String, String> applicationProperties;
+    private final Map<String, Boolean> featureFlags;
+    private final Set<Class<?>> lookupServices;
+
+    private BrowserlessConfiguration(Map<String, String> applicationProperties,
+            Map<String, Boolean> featureFlags, Set<Class<?>> lookupServices) {
+        this.applicationProperties = Collections
+                .unmodifiableMap(new LinkedHashMap<>(applicationProperties));
+        this.featureFlags = Collections
+                .unmodifiableMap(new LinkedHashMap<>(featureFlags));
+        this.lookupServices = Collections
+                .unmodifiableSet(new LinkedHashSet<>(lookupServices));
+    }
+
+    /**
+     * Gets a configuration that does not customize the Vaadin environment.
+     *
+     * @return an empty configuration, never {@literal null}
+     */
+    public static BrowserlessConfiguration empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Creates a new builder for a custom Vaadin configuration.
+     *
+     * @return a new builder, never {@literal null}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a configuration from the {@link BrowserlessTestConfig} annotation
+     * potentially present on the given element.
+     * <p>
+     * Meta annotations are not taken into account; use
+     * {@link #from(BrowserlessTestConfig)} with an annotation resolved by other
+     * means, such as JUnit {@code AnnotationSupport}, for a more thorough
+     * lookup.
+     *
+     * @param element
+     *            the annotated element to inspect, not {@literal null}
+     * @return the configuration declared by the element, or an empty
+     *         configuration if the annotation is not present, never
+     *         {@literal null}
+     */
+    public static BrowserlessConfiguration from(AnnotatedElement element) {
+        Objects.requireNonNull(element, "element must not be null");
+        return from(element.getAnnotation(BrowserlessTestConfig.class));
+    }
+
+    /**
+     * Creates a configuration from the given {@link BrowserlessTestConfig}
+     * annotation.
+     *
+     * @param annotation
+     *            the annotation to convert, may be {@literal null}
+     * @return the configuration declared by the annotation, or an empty
+     *         configuration if the annotation is {@literal null}, never
+     *         {@literal null}
+     * @throws IllegalArgumentException
+     *             if an annotation entry is not well formed
+     */
+    public static BrowserlessConfiguration from(
+            BrowserlessTestConfig annotation) {
+        if (annotation == null) {
+            return empty();
+        }
+        Builder builder = builder();
+        for (String entry : annotation.applicationProperties()) {
+            int separator = indexOfSeparator(entry, "applicationProperties");
+            builder.withApplicationProperty(entry.substring(0, separator),
+                    entry.substring(separator + 1));
+        }
+        for (String entry : annotation.featureFlags()) {
+            int separator = entry.indexOf('=');
+            if (separator < 0) {
+                builder.withFeatureFlag(entry, true);
+            } else {
+                builder.withFeatureFlag(entry.substring(0, separator),
+                        parseBoolean(entry.substring(separator + 1), entry));
+            }
+        }
+        builder.withLookupServices(annotation.lookupServices());
+        return builder.build();
+    }
+
+    private static int indexOfSeparator(String entry, String attribute) {
+        int separator = entry == null ? -1 : entry.indexOf('=');
+        if (separator < 0) {
+            throw new IllegalArgumentException("Invalid " + attribute
+                    + " entry '" + entry
+                    + "'. Entries must be defined as 'name=value' pairs.");
+        }
+        return separator;
+    }
+
+    private static boolean parseBoolean(String value, String entry) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        throw new IllegalArgumentException("Invalid featureFlags entry '"
+                + entry + "'. Expecting either a feature identifier "
+                + "or an 'id=true|false' pair.");
+    }
+
+    /**
+     * Gets the Vaadin application properties (init parameters) to apply to the
+     * mock Vaadin environment.
+     *
+     * @return an unmodifiable map of application properties, never
+     *         {@literal null}
+     */
+    public Map<String, String> getApplicationProperties() {
+        return applicationProperties;
+    }
+
+    /**
+     * Gets the feature flag overrides to apply to the mock Vaadin environment,
+     * as a map of feature identifiers to their enablement state.
+     *
+     * @return an unmodifiable map of feature flag overrides, never
+     *         {@literal null}
+     */
+    public Map<String, Boolean> getFeatureFlags() {
+        return featureFlags;
+    }
+
+    /**
+     * Gets the service implementation classes to be used to initialize the
+     * Vaadin {@link com.vaadin.flow.di.Lookup}.
+     *
+     * @return an unmodifiable set of service implementation classes, never
+     *         {@literal null}
+     */
+    public Set<Class<?>> getLookupServices() {
+        return lookupServices;
+    }
+
+    /**
+     * Checks if this configuration does not customize the Vaadin environment at
+     * all.
+     *
+     * @return {@literal true} if neither application properties, nor feature
+     *         flags, nor lookup services are defined, {@literal false}
+     *         otherwise
+     */
+    public boolean isEmpty() {
+        return applicationProperties.isEmpty() && featureFlags.isEmpty()
+                && lookupServices.isEmpty();
+    }
+
+    /**
+     * Creates a new configuration by merging the given configuration into this
+     * one. Application properties and feature flags defined by the given
+     * configuration win over the ones defined by this configuration, while
+     * lookup services of both configurations are accumulated.
+     *
+     * @param overrides
+     *            the configuration to merge into this one, not {@literal null}
+     * @return a new merged configuration, never {@literal null}
+     */
+    public BrowserlessConfiguration merge(BrowserlessConfiguration overrides) {
+        Objects.requireNonNull(overrides, "overrides must not be null");
+        if (overrides.isEmpty()) {
+            return this;
+        }
+        if (isEmpty()) {
+            return overrides;
+        }
+        return builder().withConfiguration(this).withConfiguration(overrides)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof BrowserlessConfiguration other)) {
+            return false;
+        }
+        return applicationProperties.equals(other.applicationProperties)
+                && featureFlags.equals(other.featureFlags)
+                && lookupServices.equals(other.lookupServices);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(applicationProperties, featureFlags,
+                lookupServices);
+    }
+
+    @Override
+    public String toString() {
+        return "BrowserlessConfiguration{applicationProperties="
+                + applicationProperties + ", featureFlags=" + featureFlags
+                + ", lookupServices=" + lookupServices + "}";
+    }
+
+    /**
+     * Builder for {@link BrowserlessConfiguration} instances.
+     */
+    public static final class Builder {
+
+        private final Map<String, String> applicationProperties = new LinkedHashMap<>();
+        private final Map<String, Boolean> featureFlags = new LinkedHashMap<>();
+        private final Set<Class<?>> lookupServices = new LinkedHashSet<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Sets a Vaadin application property (init parameter) to apply to the
+         * mock Vaadin environment. A previously set value for the same name is
+         * replaced.
+         *
+         * @param name
+         *            the property name, not {@literal null}
+         * @param value
+         *            the property value, not {@literal null}
+         * @return this builder
+         * @throws IllegalArgumentException
+         *             if the name is blank or reserved by the browserless
+         *             environment
+         */
+        public Builder withApplicationProperty(String name, String value) {
+            Objects.requireNonNull(name, "property name must not be null");
+            Objects.requireNonNull(value, "property value must not be null");
+            if (name.isBlank()) {
+                throw new IllegalArgumentException(
+                        "property name must not be blank");
+            }
+            if (InitParameters.BROWSERLESS.equals(name)) {
+                throw new IllegalArgumentException("The '"
+                        + InitParameters.BROWSERLESS
+                        + "' application property is enforced by the browserless "
+                        + "test environment and cannot be customized.");
+            }
+            applicationProperties.put(name, value);
+            return this;
+        }
+
+        /**
+         * Sets Vaadin application properties (init parameters) to apply to the
+         * mock Vaadin environment. Previously set values for the same names are
+         * replaced.
+         *
+         * @param properties
+         *            the properties to set, not {@literal null}
+         * @return this builder
+         * @throws IllegalArgumentException
+         *             if a name is blank or reserved by the browserless
+         *             environment
+         */
+        public Builder withApplicationProperties(
+                Map<String, String> properties) {
+            Objects.requireNonNull(properties, "properties must not be null");
+            properties.forEach(this::withApplicationProperty);
+            return this;
+        }
+
+        /**
+         * Enables the given Vaadin feature flags, overriding the values
+         * potentially defined in the {@literal vaadin-featureflags.properties}
+         * file or in system properties.
+         *
+         * @param featureIds
+         *            the identifiers of the features to enable, not
+         *            {@literal null}
+         * @return this builder
+         */
+        public Builder withFeatureFlags(String... featureIds) {
+            Objects.requireNonNull(featureIds, "featureIds must not be null");
+            for (String featureId : featureIds) {
+                withFeatureFlag(featureId, true);
+            }
+            return this;
+        }
+
+        /**
+         * Enables the given Vaadin feature flags, overriding the values
+         * potentially defined in the {@literal vaadin-featureflags.properties}
+         * file or in system properties.
+         *
+         * @param features
+         *            the features to enable, not {@literal null}
+         * @return this builder
+         */
+        public Builder withFeatureFlags(Feature... features) {
+            Objects.requireNonNull(features, "features must not be null");
+            for (Feature feature : features) {
+                Objects.requireNonNull(feature, "feature must not be null");
+                withFeatureFlag(feature.getId(), true);
+            }
+            return this;
+        }
+
+        /**
+         * Enables or disables the given Vaadin feature flag, overriding the
+         * value potentially defined in the
+         * {@literal vaadin-featureflags.properties} file or in system
+         * properties.
+         *
+         * @param featureId
+         *            the identifier of the feature, not {@literal null}
+         * @param enabled
+         *            {@literal true} to enable the feature, {@literal false} to
+         *            disable it
+         * @return this builder
+         * @throws IllegalArgumentException
+         *             if the feature identifier is blank
+         */
+        public Builder withFeatureFlag(String featureId, boolean enabled) {
+            Objects.requireNonNull(featureId, "featureId must not be null");
+            if (featureId.isBlank()) {
+                throw new IllegalArgumentException(
+                        "feature identifier must not be blank");
+            }
+            featureFlags.put(featureId, enabled);
+            return this;
+        }
+
+        /**
+         * Enables or disables the given Vaadin feature flag, overriding the
+         * value potentially defined in the
+         * {@literal vaadin-featureflags.properties} file or in system
+         * properties.
+         *
+         * @param feature
+         *            the feature, not {@literal null}
+         * @param enabled
+         *            {@literal true} to enable the feature, {@literal false} to
+         *            disable it
+         * @return this builder
+         */
+        public Builder withFeatureFlag(Feature feature, boolean enabled) {
+            Objects.requireNonNull(feature, "feature must not be null");
+            return withFeatureFlag(feature.getId(), enabled);
+        }
+
+        /**
+         * Adds the given service implementation classes to the ones used to
+         * initialize the Vaadin {@link com.vaadin.flow.di.Lookup}, such as
+         * {@link com.vaadin.flow.di.InstantiatorFactory} or
+         * {@link com.vaadin.flow.di.ResourceProvider} implementations.
+         * <p>
+         * Successive calls accumulate; lookup services are never replaced.
+         * Calling with no arguments is a no-op.
+         *
+         * @param services
+         *            the service implementation classes to add, not
+         *            {@literal null}
+         * @return this builder
+         */
+        public Builder withLookupServices(Class<?>... services) {
+            Objects.requireNonNull(services, "services must not be null");
+            for (Class<?> service : services) {
+                lookupServices.add(Objects.requireNonNull(service,
+                        "service must not be null"));
+            }
+            return this;
+        }
+
+        /**
+         * Applies all entries of the given configuration to this builder,
+         * replacing previously set application properties and feature flags
+         * with the same names, and accumulating lookup services.
+         *
+         * @param configuration
+         *            the configuration to apply, not {@literal null}
+         * @return this builder
+         */
+        public Builder withConfiguration(
+                BrowserlessConfiguration configuration) {
+            Objects.requireNonNull(configuration,
+                    "configuration must not be null");
+            applicationProperties
+                    .putAll(configuration.getApplicationProperties());
+            featureFlags.putAll(configuration.getFeatureFlags());
+            lookupServices.addAll(configuration.getLookupServices());
+            return this;
+        }
+
+        /**
+         * Builds the configuration.
+         *
+         * @return a new configuration, never {@literal null}
+         */
+        public BrowserlessConfiguration build() {
+            if (applicationProperties.isEmpty() && featureFlags.isEmpty()
+                    && lookupServices.isEmpty()) {
+                return empty();
+            }
+            return new BrowserlessConfiguration(applicationProperties,
+                    featureFlags, lookupServices);
+        }
+    }
+}

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessTestConfig.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessTestConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Applies a custom Vaadin configuration to a single test class or test method.
+ * <p>
+ * Both Vaadin application properties (also known as init parameters) and
+ * feature flags are scoped to the mock Vaadin environment created for the
+ * annotated test, so they neither require a {@code @BeforeEach}/
+ * {@code @AfterEach} pair to set and reset system properties, nor leak into
+ * other tests.
+ *
+ * <pre>
+ * &#64;BrowserlessTestConfig(applicationProperties = "devmode.sessionSerialization.enabled=true", featureFlags = "myExperimentalFeature")
+ * class MyViewTest extends BrowserlessTest {
+ * }
+ * </pre>
+ *
+ * The annotation can be placed both on the test class and on a test method. In
+ * that case the two configurations are merged, and values declared on the
+ * method win over the ones declared on the class.
+ * <p>
+ * Method level configuration requires an environment that is created for each
+ * test method. It is therefore not supported when the Vaadin environment is
+ * shared by all the tests in the class, for example with
+ * {@link BrowserlessTestConfig} on a class using
+ * {@code @TestInstance(Lifecycle.PER_CLASS)} or
+ * {@code BrowserlessClassExtension}; in those cases the annotation must be
+ * placed on the test class.
+ *
+ * @see BrowserlessConfiguration
+ * @since 1.2
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Documented
+@Inherited
+public @interface BrowserlessTestConfig {
+
+    /**
+     * Vaadin feature flags to enable or disable for the annotated test,
+     * overriding the values potentially defined in the
+     * {@literal vaadin-featureflags.properties} file or in system properties.
+     * <p>
+     * Each entry is either the identifier of the feature, to enable it, or an
+     * {@code id=true|false} pair, for example {@code featureFlags = {
+     * "featureToEnable", "featureToDisable=false" }}.
+     *
+     * @return the feature flags to override, never {@literal null}
+     */
+    String[] featureFlags() default {};
+
+    /**
+     * Vaadin application properties (init parameters) to apply to the mock
+     * Vaadin environment created for the annotated test.
+     * <p>
+     * Each entry is a {@code name=value} pair, for example
+     * {@code applicationProperties = "devmode.sessionSerialization.enabled=true"}.
+     * Values are split on the first {@literal =} character, so a value may
+     * itself contain {@literal =}.
+     *
+     * @return the application properties to apply, never {@literal null}
+     */
+    String[] applicationProperties() default {};
+
+    /**
+     * Service implementation classes to be used to initialize the Vaadin
+     * {@link com.vaadin.flow.di.Lookup} for the annotated test, such as
+     * {@link com.vaadin.flow.di.InstantiatorFactory} or
+     * {@link com.vaadin.flow.di.ResourceProvider} implementations.
+     * <p>
+     * Unlike application properties and feature flags, lookup services declared
+     * on the test class and on the test method are <strong>accumulated</strong>
+     * rather than replaced: a test method can add a service, but cannot remove
+     * one declared by its test class.
+     *
+     * @return the lookup service implementation classes, never {@literal null}
+     */
+    Class<?>[] lookupServices() default {};
+}

--- a/shared/src/main/java/com/vaadin/browserless/SecuredBrowserlessApplicationContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/SecuredBrowserlessApplicationContext.java
@@ -16,11 +16,13 @@
 package com.vaadin.browserless;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
 import com.vaadin.browserless.internal.Routes;
 import com.vaadin.browserless.internal.UIFactory;
+import com.vaadin.experimental.Feature;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletService;
 
@@ -210,6 +212,66 @@ public class SecuredBrowserlessApplicationContext<C>
          */
         public Builder<C> withCloseHook(Runnable hook) {
             base.withCloseHook(hook);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withApplicationProperty
+         */
+        public Builder<C> withApplicationProperty(String name, String value) {
+            base.withApplicationProperty(name, value);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withApplicationProperties
+         */
+        public Builder<C> withApplicationProperties(
+                Map<String, String> properties) {
+            base.withApplicationProperties(properties);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withFeatureFlags(String...)
+         */
+        public Builder<C> withFeatureFlags(String... featureIds) {
+            base.withFeatureFlags(featureIds);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withFeatureFlags(Feature...)
+         */
+        public Builder<C> withFeatureFlags(Feature... features) {
+            base.withFeatureFlags(features);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withFeatureFlag(String,
+         *      boolean)
+         */
+        public Builder<C> withFeatureFlag(String featureId, boolean enabled) {
+            base.withFeatureFlag(featureId, enabled);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withFeatureFlag(Feature,
+         *      boolean)
+         */
+        public Builder<C> withFeatureFlag(Feature feature, boolean enabled) {
+            base.withFeatureFlag(feature, enabled);
+            return this;
+        }
+
+        /**
+         * @see BrowserlessApplicationContext.Builder#withConfiguration
+         */
+        public Builder<C> withConfiguration(
+                BrowserlessConfiguration configuration) {
+            base.withConfiguration(configuration);
             return this;
         }
 

--- a/shared/src/main/java/com/vaadin/browserless/internal/BrowserlessFeatureFlags.java
+++ b/shared/src/main/java/com/vaadin/browserless/internal/BrowserlessFeatureFlags.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless.internal;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.vaadin.browserless.BrowserlessTestSetupException;
+import com.vaadin.experimental.Feature;
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.VaadinContext;
+
+/**
+ * {@link FeatureFlags} implementation that applies test defined feature flag
+ * overrides on top of the ones resolved by Vaadin.
+ * <p>
+ * The instance is installed into the {@link VaadinContext} of the mock
+ * environment before the Vaadin servlet is initialized, so that everything
+ * reading feature flags during startup, for example a
+ * {@link com.vaadin.flow.server.VaadinServiceInitListener}, already observes
+ * the test configuration.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 1.2
+ */
+public class BrowserlessFeatureFlags extends FeatureFlags {
+
+    /*
+     * NOTE: assigned only after the super constructor completes, so it is null
+     * while the super constructor invokes loadProperties().
+     */
+    private Map<String, Boolean> overrides;
+
+    private BrowserlessFeatureFlags(Lookup lookup,
+            Map<String, Boolean> overrides) {
+        super(lookup);
+        this.overrides = new LinkedHashMap<>(overrides);
+        applyOverrides();
+    }
+
+    /**
+     * Installs a {@link FeatureFlags} instance applying the given overrides
+     * into the given Vaadin context.
+     * <p>
+     * Must be invoked before anything requests the feature flags for the
+     * context, otherwise Vaadin creates and caches its own instance.
+     *
+     * @param context
+     *            the Vaadin context of the mock environment, not
+     *            {@literal null}
+     * @param overrides
+     *            feature identifiers mapped to their enablement state, not
+     *            {@literal null}
+     * @throws BrowserlessTestSetupException
+     *             if a feature identifier is not known by Vaadin
+     */
+    public static void install(VaadinContext context,
+            Map<String, Boolean> overrides) {
+        Objects.requireNonNull(context, "context must not be null");
+        Objects.requireNonNull(overrides, "overrides must not be null");
+        BrowserlessFeatureFlags featureFlags = new BrowserlessFeatureFlags(
+                context.getAttribute(Lookup.class), overrides);
+        context.setAttribute(FeatureFlagsWrapper.class,
+                new FeatureFlagsWrapper(featureFlags));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Re-applies the test defined overrides, so that they are not silently
+     * discarded by code reloading the feature flags, for example through
+     * {@link #setPropertiesLocation(java.io.File)}.
+     */
+    @Override
+    public void loadProperties() {
+        super.loadProperties();
+        applyOverrides();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Toggles the feature for the current test only. Unlike the default
+     * implementation, it neither requires development mode nor stores the new
+     * state into the {@literal vaadin-featureflags.properties} file of the
+     * project.
+     */
+    @Override
+    public void setEnabled(String featureId, boolean enabled) {
+        feature(featureId).setEnabled(enabled);
+    }
+
+    private void applyOverrides() {
+        if (overrides == null) {
+            // invoked by the super constructor, before overrides are known
+            return;
+        }
+        overrides.forEach(
+                (featureId, enabled) -> feature(featureId).setEnabled(enabled));
+    }
+
+    private Feature feature(String featureId) {
+        return getFeatures().stream()
+                .filter(feature -> feature.getId().equals(featureId))
+                .findFirst()
+                .orElseThrow(() -> new BrowserlessTestSetupException(
+                        "Unknown Vaadin feature flag '" + featureId
+                                + "'. Available feature flags: "
+                                + getFeatures().stream().map(Feature::getId)
+                                        .sorted()
+                                        .collect(Collectors.joining(", "))
+                                + ". Feature flags are contributed by the Vaadin "
+                                + "modules on the classpath, so a missing one may "
+                                + "also indicate a missing dependency."));
+    }
+}

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -39,10 +39,12 @@ import com.vaadin.flow.server.VaadinResponse
 import com.vaadin.flow.server.VaadinService
 import com.vaadin.flow.server.InitParameters
 import com.vaadin.flow.server.VaadinServlet
+import com.vaadin.flow.server.VaadinServletContext
 import com.vaadin.flow.server.VaadinServletService
 import com.vaadin.flow.server.VaadinSession
 import com.vaadin.flow.server.WrappedHttpSession
 import com.vaadin.flow.shared.communication.PushMode
+import com.vaadin.browserless.BrowserlessConfiguration
 import com.vaadin.browserless.mocks.MockHttpSession
 import com.vaadin.browserless.mocks.MockRequest
 import com.vaadin.browserless.mocks.MockResponse
@@ -99,15 +101,18 @@ object MockVaadin {
      * @param routes all classes annotated with [com.vaadin.flow.router.Route]; use [Routes.autoDiscoverViews] to auto-discover all such classes.
      * @param uiFactory produces [UI] instances and sets them as current, by default simply instantiates [MockedUI] class.
      * @param lookupServices service classes to be provided to the lookup initializer
+     * @param configuration custom Vaadin configuration, such as application properties, feature flags
+     * and lookup services, to apply to the mocked environment.
      */
     @JvmStatic
     @JvmOverloads
     fun setup(routes: Routes = Routes(),
               uiFactory: UIFactory = UIFactory { MockedUI() },
-              lookupServices: Set<Class<*>> = emptySet()) {
+              lookupServices: Set<Class<*>> = emptySet(),
+              configuration: BrowserlessConfiguration = BrowserlessConfiguration.empty()) {
         // init servlet
         val servlet = MockVaadinServlet(routes)
-        setup(uiFactory, servlet, lookupServices)
+        setup(uiFactory, servlet, lookupServices, configuration)
     }
 
     /**
@@ -126,12 +131,16 @@ object MockVaadin {
      * Please consult [com.vaadin.browserless.mocks.MockService]
      * on what methods you must override in your custom service.
      * @param lookupServices service classes to be provided to the lookup initializer
+     * @param configuration custom Vaadin configuration, such as application properties, feature flags
+     * and lookup services, to apply to the mocked environment.
      */
     @JvmStatic
+    @JvmOverloads
     fun setup(uiFactory: UIFactory = UIFactory { MockedUI() }, servlet: VaadinServlet,
-              lookupServices: Set<Class<*>> = emptySet()
+              lookupServices: Set<Class<*>> = emptySet(),
+              configuration: BrowserlessConfiguration = BrowserlessConfiguration.empty()
     ) {
-        val service = setupServlet(servlet, lookupServices)
+        val service = setupServlet(servlet, lookupServices, configuration)
         VaadinService.setCurrent(service)
 
         // init Vaadin Session
@@ -143,15 +152,35 @@ object MockVaadin {
      * session, UI, or set any thread-locals. Call this when you need to share
      * a single service across multiple independent sessions (multi-user testing).
      *
+     * @param configuration custom Vaadin configuration, such as application properties, feature flags
+     * and lookup services, to apply to the mocked environment. Lookup services defined by the
+     * configuration are used in addition to the ones given by [lookupServices].
      * @return the initialized [VaadinServletService]
      */
     @JvmStatic
+    @JvmOverloads
     fun setupServlet(servlet: VaadinServlet,
-                     lookupServices: Set<Class<*>> = emptySet()
+                     lookupServices: Set<Class<*>> = emptySet(),
+                     configuration: BrowserlessConfiguration = BrowserlessConfiguration.empty()
     ): VaadinServletService {
         if (!servlet.isInitialized) {
-            val ctx: ServletContext = MockVaadinHelper.createMockContext(lookupServices)
+            // Lookup services can be given both explicitly and through the configuration
+            // (e.g. by a @BrowserlessTestConfig annotation); they accumulate.
+            val ctx: ServletContext = MockVaadinHelper.createMockContext(
+                    lookupServices + configuration.lookupServices)
+            // Context init parameters are read by ApplicationConfiguration, which is
+            // created and cached on first access, so they must be set before anything
+            // else touches the context.
+            configuration.applicationProperties.forEach { (name, value) -> ctx.setInitParameter(name, value) }
+            // Installed before the servlet is initialized, so that feature flags read
+            // during startup (e.g. by a VaadinServiceInitListener) already observe the
+            // test configuration. Installed even without overrides, so that tests
+            // toggling feature flags at runtime don't write them into the project
+            // resources folder, from where other tests would then read them.
+            BrowserlessFeatureFlags.install(VaadinServletContext(ctx), configuration.featureFlags)
             val config = MockServletConfig(ctx)
+            config.servletInitParams.putAll(configuration.applicationProperties)
+            // Enforced by the browserless environment, so it wins over test configuration
             config.servletInitParams[InitParameters.BROWSERLESS] = "true"
             servlet.init(config)
         }

--- a/shared/src/test/java/com/vaadin/browserless/BrowserlessConfigurationTest.java
+++ b/shared/src/test/java/com/vaadin/browserless/BrowserlessConfigurationTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.server.InitParameters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BrowserlessConfigurationTest {
+
+    @BrowserlessTestConfig(applicationProperties = { "first=one",
+            "second=two=three" }, featureFlags = { "enabledFeature",
+                    "disabledFeature=FALSE",
+                    "explicitlyEnabled=true" }, lookupServices = {
+                            ServiceA.class, ServiceB.class })
+    private static class AnnotatedClass {
+    }
+
+    private static class ServiceA {
+    }
+
+    private static class ServiceB {
+    }
+
+    private static class ServiceC {
+    }
+
+    private static class NotAnnotatedClass {
+    }
+
+    @BrowserlessTestConfig(applicationProperties = "missingSeparator")
+    private static class InvalidPropertyClass {
+    }
+
+    @BrowserlessTestConfig(featureFlags = "feature=maybe")
+    private static class InvalidFeatureFlagClass {
+    }
+
+    @Test
+    void fromAnnotatedClass_entriesAreParsed() {
+        BrowserlessConfiguration configuration = BrowserlessConfiguration
+                .from(AnnotatedClass.class);
+
+        assertEquals(Map.of("first", "one", "second", "two=three"),
+                configuration.getApplicationProperties(),
+                "Property values should be split on the first '=' only");
+        assertEquals(
+                Map.of("enabledFeature", true, "disabledFeature", false,
+                        "explicitlyEnabled", true),
+                configuration.getFeatureFlags());
+        assertEquals(List.of(ServiceA.class, ServiceB.class),
+                List.copyOf(configuration.getLookupServices()),
+                "Lookup services should be parsed preserving declaration order");
+    }
+
+    @Test
+    void merge_lookupServicesAccumulate() {
+        BrowserlessConfiguration base = BrowserlessConfiguration.builder()
+                .withLookupServices(ServiceA.class, ServiceB.class).build();
+        BrowserlessConfiguration overrides = BrowserlessConfiguration.builder()
+                .withLookupServices(ServiceB.class, ServiceC.class).build();
+
+        assertEquals(List.of(ServiceA.class, ServiceB.class, ServiceC.class),
+                List.copyOf(base.merge(overrides).getLookupServices()),
+                "Lookup services must accumulate rather than being replaced");
+    }
+
+    @Test
+    void lookupServices_makeConfigurationNotEmpty() {
+        assertFalse(BrowserlessConfiguration.builder()
+                .withLookupServices(ServiceA.class).build().isEmpty());
+        assertTrue(BrowserlessConfiguration.builder().withLookupServices()
+                .build().isEmpty(), "No arguments should be a no-op");
+    }
+
+    @Test
+    void fromNotAnnotatedClass_isEmpty() {
+        assertTrue(BrowserlessConfiguration.from(NotAnnotatedClass.class)
+                .isEmpty());
+        assertSame(BrowserlessConfiguration.empty(),
+                BrowserlessConfiguration.from((BrowserlessTestConfig) null));
+    }
+
+    @Test
+    void fromAnnotation_invalidEntries_throw() {
+        assertThrows(IllegalArgumentException.class,
+                () -> BrowserlessConfiguration.from(InvalidPropertyClass.class),
+                "Application properties without a separator should be rejected");
+        assertThrows(IllegalArgumentException.class,
+                () -> BrowserlessConfiguration
+                        .from(InvalidFeatureFlagClass.class),
+                "Feature flags with a non boolean value should be rejected");
+    }
+
+    @Test
+    void reservedApplicationProperty_isRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> BrowserlessConfiguration.builder()
+                        .withApplicationProperty(InitParameters.BROWSERLESS,
+                                "false"));
+    }
+
+    @Test
+    void builder_featureConstantsAndIdentifiersAreEquivalent() {
+        BrowserlessConfiguration fromConstant = BrowserlessConfiguration
+                .builder()
+                .withFeatureFlags(FeatureFlags.COLLABORATION_ENGINE_BACKEND)
+                .build();
+        BrowserlessConfiguration fromIdentifier = BrowserlessConfiguration
+                .builder()
+                .withFeatureFlags(
+                        FeatureFlags.COLLABORATION_ENGINE_BACKEND.getId())
+                .build();
+
+        assertEquals(fromConstant, fromIdentifier);
+    }
+
+    @Test
+    void merge_argumentWins() {
+        BrowserlessConfiguration base = BrowserlessConfiguration.builder()
+                .withApplicationProperty("shared", "base")
+                .withApplicationProperty("onlyBase", "base")
+                .withFeatureFlag("shared", true)
+                .withFeatureFlag("onlyBase", true).build();
+        BrowserlessConfiguration overrides = BrowserlessConfiguration.builder()
+                .withApplicationProperty("shared", "override")
+                .withFeatureFlag("shared", false).build();
+
+        BrowserlessConfiguration merged = base.merge(overrides);
+
+        assertEquals(Map.of("shared", "override", "onlyBase", "base"),
+                merged.getApplicationProperties());
+        assertEquals(Map.of("shared", false, "onlyBase", true),
+                merged.getFeatureFlags());
+        assertEquals("base", base.getApplicationProperties().get("shared"),
+                "Merging should not modify the original configuration");
+    }
+
+    @Test
+    void merge_emptyConfigurations_areNoOp() {
+        BrowserlessConfiguration configuration = BrowserlessConfiguration
+                .builder().withApplicationProperty("key", "value").build();
+
+        assertSame(configuration,
+                configuration.merge(BrowserlessConfiguration.empty()));
+        assertSame(configuration,
+                BrowserlessConfiguration.empty().merge(configuration));
+    }
+
+    @Test
+    void emptyBuilder_buildsEmptyConfiguration() {
+        BrowserlessConfiguration configuration = BrowserlessConfiguration
+                .builder().build();
+        assertTrue(configuration.isEmpty());
+        assertFalse(
+                BrowserlessConfiguration.builder()
+                        .withFeatureFlag("feature", false).build().isEmpty(),
+                "Disabling a feature is still a customization");
+    }
+}

--- a/shared/src/test/java/com/vaadin/browserless/BuilderVaadinConfigurationTest.java
+++ b/shared/src/test/java/com/vaadin/browserless/BuilderVaadinConfigurationTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.browserless.mocks.MockVaadinServlet;
+import com.vaadin.experimental.Feature;
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinServletService;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the custom Vaadin configuration declared on the application
+ * context builder reaches the mocked Vaadin environment.
+ */
+class BuilderVaadinConfigurationTest {
+
+    private static final Feature FEATURE = FeatureFlags.COLLABORATION_ENGINE_BACKEND;
+
+    @Test
+    void applicationProperties_areVisibleInDeploymentConfiguration() {
+        try (var app = BrowserlessApplicationContext
+                .create(b -> b.withoutRoutes()
+                        .withApplicationProperty("custom.property", "value")
+                        .withApplicationProperties(
+                                Map.of("another.property", "another")))) {
+            DeploymentConfiguration configuration = app.getService()
+                    .getDeploymentConfiguration();
+
+            assertEquals("value",
+                    configuration.getStringProperty("custom.property", null));
+            assertEquals("another",
+                    configuration.getStringProperty("another.property", null));
+        }
+    }
+
+    @Test
+    void featureFlags_areAppliedToTheApplication() {
+        try (var app = BrowserlessApplicationContext.create(
+                b -> b.withoutRoutes().withFeatureFlags(FEATURE.getId()))) {
+            assertTrue(featureFlags(app).isEnabled(FEATURE),
+                    "Feature flag enabled on the builder should be enabled");
+        }
+    }
+
+    @Test
+    void featureFlags_areVisibleWhileTheServiceIsInitialized() {
+        AtomicBoolean enabledDuringServiceInit = new AtomicBoolean();
+        try (var app = BrowserlessApplicationContext.create(b -> b
+                .withoutRoutes().withFeatureFlags(FEATURE)
+                .withServletFactory((routes,
+                        uiFactory) -> new MockVaadinServlet(routes, uiFactory) {
+                            @Override
+                            protected VaadinServletService createServletService(
+                                    DeploymentConfiguration deploymentConfiguration) {
+                                enabledDuringServiceInit.set(FeatureFlags
+                                        .get(new VaadinServletContext(
+                                                getServletContext()))
+                                        .isEnabled(FEATURE));
+                                return super.createServletService(
+                                        deploymentConfiguration);
+                            }
+                        }))) {
+            assertTrue(enabledDuringServiceInit.get(),
+                    "Feature flag should already be enabled when the Vaadin service is created");
+        }
+    }
+
+    @Test
+    void featureFlags_doNotLeakToOtherApplications() {
+        try (var app = BrowserlessApplicationContext
+                .create(b -> b.withoutRoutes().withFeatureFlags(FEATURE))) {
+            assertTrue(featureFlags(app).isEnabled(FEATURE));
+        }
+        try (var app = BrowserlessApplicationContext
+                .create(b -> b.withoutRoutes())) {
+            assertFalse(featureFlags(app).isEnabled(FEATURE),
+                    "Feature flag should not leak into an application that does not enable it");
+        }
+    }
+
+    @Test
+    void featureFlags_canBeToggledWithoutStoringThemOnDisk() {
+        try (var app = BrowserlessApplicationContext
+                .create(b -> b.withoutRoutes())) {
+            File propertiesFile = new File(
+                    ApplicationConfiguration.get(app.getService().getContext())
+                            .getJavaResourceFolder(),
+                    FeatureFlags.PROPERTIES_FILENAME);
+            boolean existedBefore = propertiesFile.exists();
+
+            FeatureFlags featureFlags = featureFlags(app);
+            featureFlags.setEnabled(FEATURE.getId(), true);
+
+            assertTrue(featureFlags.isEnabled(FEATURE));
+            assertEquals(existedBefore, propertiesFile.exists(),
+                    "Toggling a feature flag in a test should not write "
+                            + propertiesFile + " into the project");
+        }
+    }
+
+    @Test
+    void featureFlags_toggledInATest_doNotLeakToOtherApplications() {
+        try (var app = BrowserlessApplicationContext
+                .create(b -> b.withoutRoutes())) {
+            featureFlags(app).setEnabled(FEATURE.getId(), true);
+        }
+        try (var app = BrowserlessApplicationContext
+                .create(b -> b.withoutRoutes())) {
+            assertFalse(featureFlags(app).isEnabled(FEATURE));
+        }
+    }
+
+    @Test
+    void featureFlags_survivePropertiesReload() {
+        try (var app = BrowserlessApplicationContext
+                .create(b -> b.withoutRoutes().withFeatureFlags(FEATURE))) {
+            FeatureFlags featureFlags = featureFlags(app);
+            featureFlags.loadProperties();
+
+            assertTrue(featureFlags.isEnabled(FEATURE),
+                    "Overrides should be re-applied when feature flags are reloaded");
+        }
+    }
+
+    @Test
+    void unknownFeatureFlag_failsWithAvailableFlags() {
+        BrowserlessTestSetupException exception = assertThrows(
+                BrowserlessTestSetupException.class,
+                () -> BrowserlessApplicationContext.create(b -> b
+                        .withoutRoutes().withFeatureFlags("notAFeatureFlag")));
+
+        assertTrue(exception.getMessage().contains("notAFeatureFlag"));
+        assertTrue(exception.getMessage().contains(FEATURE.getId()),
+                "The error should list the available feature flags");
+    }
+
+    private static FeatureFlags featureFlags(
+            BrowserlessApplicationContext app) {
+        return FeatureFlags.get(app.getService().getContext());
+    }
+}

--- a/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
+++ b/spring/src/main/java/com/vaadin/browserless/SpringBrowserlessTest.java
@@ -64,7 +64,7 @@ import com.vaadin.browserless.mocks.SpringSecurityRequestCustomizer;
  *
  * @since 1.0
  */
-@ExtendWith({ SpringExtension.class })
+@ExtendWith({ SpringExtension.class, BrowserlessTestConfigExtension.class })
 @TestExecutionListeners(listeners = BrowserlessTestSpringLookupInitializer.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public abstract class SpringBrowserlessTest extends BaseBrowserlessTest
         implements TesterWrappers {
@@ -78,7 +78,7 @@ public abstract class SpringBrowserlessTest extends BaseBrowserlessTest
     }
 
     @Override
-    protected Set<Class<?>> lookupServices() {
+    protected Set<Class<?>> frameworkLookupServices() {
         return Set.of(BrowserlessTestSpringLookupInitializer.class,
                 SpringSecurityRequestCustomizer.class);
     }
@@ -96,7 +96,8 @@ public abstract class SpringBrowserlessTest extends BaseBrowserlessTest
         scanTesters();
         MockSpringServlet servlet = new MockSpringServlet(discoverRoutes(),
                 applicationContext, MockedUI::new);
-        MockVaadin.setup(MockedUI::new, servlet, lookupServices());
+        MockVaadin.setup(MockedUI::new, servlet, allLookupServices(),
+                testConfiguration());
         initSignalsSupport();
     }
 

--- a/spring/src/test/java/com/vaadin/browserless/SpringBrowserlessTestConfigTest.java
+++ b/spring/src/test/java/com/vaadin/browserless/SpringBrowserlessTestConfigTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import java.security.Principal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Verifies that {@link BrowserlessTestConfig} is applied to the mock Vaadin
+ * Spring environment.
+ */
+@ContextConfiguration(classes = SpringBrowserlessTestConfigTest.TestConfig.class)
+@BrowserlessTestConfig(applicationProperties = "class.property=fromClass", featureFlags = "collaborationEngineBackend")
+class SpringBrowserlessTestConfigTest extends SpringBrowserlessTest {
+
+    @Test
+    void classLevelConfiguration_isApplied() {
+        Assertions.assertEquals("fromClass", property("class.property"));
+        Assertions.assertTrue(
+                FeatureFlags.get(VaadinService.getCurrent().getContext())
+                        .isEnabled(FeatureFlags.COLLABORATION_ENGINE_BACKEND));
+    }
+
+    @Test
+    @BrowserlessTestConfig(applicationProperties = "method.property=fromMethod", featureFlags = "collaborationEngineBackend=false")
+    void methodLevelConfiguration_isApplied() {
+        Assertions.assertEquals("fromMethod", property("method.property"));
+        Assertions.assertEquals("fromClass", property("class.property"));
+        Assertions.assertFalse(
+                FeatureFlags.get(VaadinService.getCurrent().getContext())
+                        .isEnabled(FeatureFlags.COLLABORATION_ENGINE_BACKEND));
+    }
+
+    @Test
+    @WithMockUser(username = "john", roles = "DEV")
+    @BrowserlessTestConfig(lookupServices = TestNoOpInstantiatorFactory.class)
+    void testDeclaredLookupServices_doNotReplaceFrameworkOnes() {
+        Assertions.assertNotNull(VaadinService.getCurrent().getContext()
+                .getAttribute(Lookup.class), "Expecting Lookup to be set up");
+        // SpringSecurityRequestCustomizer is required by the Spring
+        // integration: the principal is only available on the request if it is
+        // still registered alongside the one declared by the test.
+        Principal principal = VaadinRequest.getCurrent().getUserPrincipal();
+        Assertions.assertNotNull(principal,
+                "Lookup services declared by the test must not replace the Spring ones");
+        Assertions.assertEquals("john", principal.getName());
+    }
+
+    private static String property(String name) {
+        return VaadinService.getCurrent().getDeploymentConfiguration()
+                .getStringProperty(name, null);
+    }
+
+    /**
+     * An {@link InstantiatorFactory} that does not provide any instantiator, so
+     * that registering it does not conflict with the Spring one.
+     */
+    static class TestNoOpInstantiatorFactory implements InstantiatorFactory {
+        @Override
+        public Instantiator createInstantitor(VaadinService vaadinService) {
+            return null;
+        }
+    }
+
+    // Empty configuration class used only to be able to bootstrap spring
+    // ApplicationContext
+    @Configuration
+    static class TestConfig {
+    }
+}


### PR DESCRIPTION
Adds `@BrowserlessTestConfig` to declare Vaadin application properties,
feature flags and `Lookup` services for a single test class or method.
Class and method level annotations are merged, with the method winning,
except for lookup services, that are accumulated.

The same settings can be provided programmatically with
`BrowserlessConfiguration`, on `BrowserlessExtension` and
`BrowserlessClassExtension`, on the `BrowserlessApplicationContext`
builder, or by overriding `testConfiguration()`.

Settings are applied to the Vaadin environment created for the test, so
they don't need to be reset and don't leak into other tests. As a side
effect, feature flags toggled during a test are no longer stored into
the project `vaadin-featureflags.properties` file.

`BaseBrowserlessTest.lookupServices()` is deprecated in favour of the
test configuration; existing overrides are still honoured. Services
required by the Spring and Quarkus integrations moved to the new
`frameworkLookupServices()`, so that they can't be dropped by a test.

Fixes https://github.com/vaadin/browserless-test/issues/48