### PR TITLE
feat: add reload() DSL simulating a browser refresh (F5)

### DIFF
--- a/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
+++ b/junit6/src/main/java/com/vaadin/browserless/AbstractBrowserlessExtension.java
@@ -252,6 +252,34 @@ abstract class AbstractBrowserlessExtension
     }
 
     /**
+     * Simulates the user reloading the page (pressing F5): the current UI is
+     * detached and a fresh one is created in the same Vaadin session, then the
+     * current location is rendered again. Session-scoped state survives. Views
+     * annotated with
+     * {@link com.vaadin.flow.router.PreserveOnRefresh @PreserveOnRefresh} keep
+     * their component instance and state; other views are recreated.
+     *
+     * @return the view shown after the reload
+     */
+    public HasElement reload() {
+        return BrowserlessDSL.reload(getUI());
+    }
+
+    /**
+     * Simulates a page reload (see {@link #reload()}) and verifies the
+     * resulting view is of the expected type.
+     *
+     * @param expectedTarget
+     *            the expected view class after reload
+     * @param <T>
+     *            the view type
+     * @return the view shown after the reload
+     */
+    public <T extends Component> T reload(Class<T> expectedTarget) {
+        return BrowserlessDSL.reload(getUI(), expectedTarget);
+    }
+
+    /**
      * Simulates a server round-trip, flushing pending component changes.
      */
     public void roundTrip() {

--- a/junit6/src/test/java/com/example/reload/PlainCounterView.java
+++ b/junit6/src/test/java/com/example/reload/PlainCounterView.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.example.reload;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A plain (non-preserved) counter view. On a browser refresh a fresh instance
+ * is expected and its state must reset.
+ */
+@Route("plain-counter")
+public class PlainCounterView extends VerticalLayout {
+
+    private int count;
+    private final Span label = new Span("0");
+
+    public PlainCounterView() {
+        Button increment = new Button("Increment", e -> {
+            count++;
+            label.setText(String.valueOf(count));
+        });
+        increment.setId("increment");
+        label.setId("count");
+        add(label, increment);
+    }
+
+    public int getCount() {
+        return count;
+    }
+}

--- a/junit6/src/test/java/com/example/reload/PreservedCounterView.java
+++ b/junit6/src/test/java/com/example/reload/PreservedCounterView.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.example.reload;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+/**
+ * A {@link PreserveOnRefresh} view whose instance state (the counter) must
+ * survive a browser refresh: the same component instance is expected to be
+ * reused across the reload.
+ */
+@Route("preserved-counter")
+@PreserveOnRefresh
+public class PreservedCounterView extends VerticalLayout {
+
+    private int count;
+    private final Span label = new Span("0");
+
+    public PreservedCounterView() {
+        Button increment = new Button("Increment", e -> {
+            count++;
+            label.setText(String.valueOf(count));
+        });
+        increment.setId("increment");
+        label.setId("count");
+        add(label, increment);
+    }
+
+    public int getCount() {
+        return count;
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/BrowserlessBaseClassTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/BrowserlessBaseClassTest.java
@@ -84,6 +84,8 @@ class BrowserlessBaseClassTest {
             allViews.add(com.example.multiuser.ExternalNavigationView.class);
             allViews.add(com.example.multiuser.SimpleView.class);
             allViews.add(com.example.locator.LocatorDemoView.class);
+            allViews.add(com.example.reload.PreservedCounterView.class);
+            allViews.add(com.example.reload.PlainCounterView.class);
             Assertions.assertEquals(allViews.size(), routes.size());
             Assertions.assertTrue(routes.containsAll(allViews));
         }

--- a/junit6/src/test/java/com/vaadin/browserless/ReloadMultiWindowTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ReloadMultiWindowTest.java
@@ -15,12 +15,12 @@
  */
 package com.vaadin.browserless;
 
+import com.example.reload.PreservedCounterView;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.example.reload.PreservedCounterView;
 import com.vaadin.flow.component.button.Button;
 
 /**

--- a/junit6/src/test/java/com/vaadin/browserless/ReloadMultiWindowTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ReloadMultiWindowTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.reload.PreservedCounterView;
+import com.vaadin.flow.component.button.Button;
+
+/**
+ * Verifies reload semantics in the programmatic multi-window context: each
+ * window has its own preserved-component chain (keyed by a distinct window
+ * name), so reloading one window reuses that window's instance without
+ * disturbing a sibling window.
+ */
+class ReloadMultiWindowTest {
+
+    private BrowserlessApplicationContext app;
+
+    @BeforeEach
+    void setUp() {
+        app = BrowserlessApplicationContext.create(PreservedCounterView.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        app.close();
+    }
+
+    @Test
+    void reloadingOneWindow_preservesItsInstance_andLeavesSiblingUntouched() {
+        var user = app.newUser();
+        var window1 = user.newWindow();
+        var window2 = user.newWindow();
+
+        var view1 = window1.navigate(PreservedCounterView.class);
+        var view2 = window2.navigate(PreservedCounterView.class);
+
+        // Same @PreserveOnRefresh route, but distinct per-window instances.
+        Assertions.assertNotSame(view1, view2,
+                "Each window must get its own preserved instance");
+
+        window1.test(window1.find(Button.class).withId("increment").single())
+                .click();
+        Assertions.assertEquals(1, view1.getCount());
+
+        var view1AfterReload = window1.reload(PreservedCounterView.class);
+
+        Assertions.assertSame(view1, view1AfterReload,
+                "Reloading window1 must reuse its preserved instance");
+        Assertions.assertEquals(1, view1AfterReload.getCount(),
+                "window1 state must survive its reload");
+        Assertions.assertSame(view2, window2.getCurrentView(),
+                "window2 must be untouched by window1's reload");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/ReloadPreserveOnRefreshTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ReloadPreserveOnRefreshTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.browserless;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.example.reload.PlainCounterView;
+import com.example.reload.PreservedCounterView;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * Confirms the {@link #reload()} DSL honors
+ * {@link com.vaadin.flow.router.PreserveOnRefresh}: a preserved view keeps its
+ * instance and state across a refresh, while a plain view is recreated. Also
+ * verifies that session-scoped state survives the reload.
+ */
+@ViewPackages(classes = { PreservedCounterView.class, PlainCounterView.class })
+class ReloadPreserveOnRefreshTest extends BrowserlessTest {
+
+    @Test
+    void preserveOnRefresh_reusesInstanceAndState() {
+        PreservedCounterView view = navigate(PreservedCounterView.class);
+        test(find(Button.class).withId("increment").single()).click();
+        test(find(Button.class).withId("increment").single()).click();
+        Assertions.assertEquals(2, view.getCount());
+
+        PreservedCounterView afterReload = reload(PreservedCounterView.class);
+
+        Assertions.assertSame(view, afterReload,
+                "@PreserveOnRefresh view must keep the same instance across reload");
+        Assertions.assertEquals(2, afterReload.getCount(),
+                "@PreserveOnRefresh view must retain its state across reload");
+    }
+
+    @Test
+    void plainView_isRecreatedOnRefresh() {
+        PlainCounterView view = navigate(PlainCounterView.class);
+        test(find(Button.class).withId("increment").single()).click();
+        Assertions.assertEquals(1, view.getCount());
+
+        PlainCounterView afterReload = reload(PlainCounterView.class);
+
+        Assertions.assertNotSame(view, afterReload,
+                "A plain view must be recreated on reload");
+        Assertions.assertEquals(0, afterReload.getCount(),
+                "A plain view's state must reset on reload");
+    }
+
+    @Test
+    void reload_keepsSameSessionAndScopedState() {
+        navigate(PlainCounterView.class);
+        VaadinSession sessionBefore = VaadinSession.getCurrent();
+        sessionBefore.setAttribute("marker", "kept");
+        UI uiBefore = UI.getCurrent();
+
+        reload();
+
+        Assertions.assertSame(sessionBefore, VaadinSession.getCurrent(),
+                "Reload must keep the same Vaadin session");
+        Assertions.assertEquals("kept",
+                VaadinSession.getCurrent().getAttribute("marker"),
+                "Session-scoped state must survive a reload");
+        Assertions.assertNotSame(uiBefore, UI.getCurrent(),
+                "Reload must create a fresh UI");
+    }
+}

--- a/junit6/src/test/java/com/vaadin/browserless/ReloadPreserveOnRefreshTest.java
+++ b/junit6/src/test/java/com/vaadin/browserless/ReloadPreserveOnRefreshTest.java
@@ -15,11 +15,11 @@
  */
 package com.vaadin.browserless;
 
+import com.example.reload.PlainCounterView;
+import com.example.reload.PreservedCounterView;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.example.reload.PlainCounterView;
-import com.example.reload.PreservedCounterView;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.server.VaadinSession;

--- a/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
+++ b/shared/src/main/java/com/vaadin/browserless/BaseBrowserlessTest.java
@@ -210,6 +210,34 @@ public abstract class BaseBrowserlessTest {
     }
 
     /**
+     * Simulates the user reloading the page (pressing F5): the current UI is
+     * detached and a fresh one is created in the same Vaadin session, then the
+     * current location is rendered again. Session-scoped state (session
+     * attributes, security context) survives. Views annotated with
+     * {@link com.vaadin.flow.router.PreserveOnRefresh @PreserveOnRefresh} keep
+     * their component instance and state; other views are recreated.
+     *
+     * @return the view shown after the reload
+     */
+    public HasElement reload() {
+        return BrowserlessDSL.reload(verifyAndGetUI());
+    }
+
+    /**
+     * Simulates a page reload (see {@link #reload()}) and verifies the
+     * resulting view is of the expected type.
+     *
+     * @param expectedTarget
+     *            the expected view class after reload
+     * @param <T>
+     *            the view type
+     * @return the view shown after the reload
+     */
+    public <T extends Component> T reload(Class<T> expectedTarget) {
+        return BrowserlessDSL.reload(verifyAndGetUI(), expectedTarget);
+    }
+
+    /**
      * Simulates a keyboard shortcut performed on the browser.
      *
      * @param key

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessDSL.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessDSL.java
@@ -63,6 +63,16 @@ final class BrowserlessDSL {
         return validateNavigationTarget(ui, expectedTarget);
     }
 
+    static HasElement reload(UI ui) {
+        ui.getPage().reload();
+        return getCurrentView(UI.getCurrent());
+    }
+
+    static <T extends Component> T reload(UI ui, Class<T> expectedTarget) {
+        ui.getPage().reload();
+        return validateNavigationTarget(UI.getCurrent(), expectedTarget);
+    }
+
     static <T extends Component> T validateNavigationTarget(UI ui,
             Class<T> target) {
         HasElement currentView = getCurrentView(ui);

--- a/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
+++ b/shared/src/main/java/com/vaadin/browserless/BrowserlessUIContext.java
@@ -390,6 +390,43 @@ public class BrowserlessUIContext
     }
 
     /**
+     * Simulates the user reloading this window (pressing F5): the window's UI
+     * is detached and a fresh one is created in the same Vaadin session, then
+     * the current location is rendered again. Session-scoped state (session
+     * attributes, security context) survives, and sibling windows are
+     * unaffected. Views annotated with
+     * {@link com.vaadin.flow.router.PreserveOnRefresh @PreserveOnRefresh} keep
+     * their component instance and state; other views are recreated.
+     *
+     * @return the view shown after the reload
+     */
+    public HasElement reload() {
+        activate();
+        HasElement view = BrowserlessDSL.reload(ui);
+        // reload() swapped in a fresh UI; re-capture it so later operations on
+        // this window act on the live UI rather than the detached one.
+        this.ui = UI.getCurrent();
+        return view;
+    }
+
+    /**
+     * Simulates a page reload (see {@link #reload()}) and verifies the
+     * resulting view is of the expected type.
+     *
+     * @param expectedTarget
+     *            the expected view class after reload
+     * @param <T>
+     *            the view type
+     * @return the view shown after the reload
+     */
+    public <T extends Component> T reload(Class<T> expectedTarget) {
+        activate();
+        T view = BrowserlessDSL.reload(ui, expectedTarget);
+        this.ui = UI.getCurrent();
+        return view;
+    }
+
+    /**
      * Simulates a server round-trip, flushing pending component changes.
      */
     public void roundTrip() {

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -18,10 +18,12 @@ package com.vaadin.browserless.internal
 import java.io.Serializable
 import java.lang.reflect.Field
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantLock
 import jakarta.servlet.ServletContext
 import com.vaadin.flow.component.ComponentUtil
 import com.vaadin.flow.component.UI
+import com.vaadin.flow.component.page.ExtendedClientDetails
 import com.vaadin.flow.component.page.Page
 import com.vaadin.flow.di.Lookup
 import com.vaadin.flow.internal.CurrentInstance
@@ -76,6 +78,13 @@ object MockVaadin {
     private val strongRefReq = ThreadLocal<VaadinRequest>()
     private val strongRefRes = ThreadLocal<VaadinResponse>()
     private val lastNavigation = ThreadLocal<Location>()
+
+    // The window name to assign to the next UI created by [createUI]. A reload
+    // records the closing UI's window name here so the recreated UI reuses it
+    // (see [closeCurrentUI]); a brand-new window leaves it unset and gets a
+    // fresh unique name. Mirrors the [lastNavigation] hand-off.
+    private val lastWindowName = ThreadLocal<String>()
+    private val windowNameCounter = AtomicLong()
 
     /**
      * Mocks Vaadin for the current test method:
@@ -168,6 +177,9 @@ object MockVaadin {
     fun closeCurrentUI(fireUIDetach: Boolean) {
         val ui: UI = UI.getCurrent() ?: return
         lastNavigation.set(ui.internals.activeViewLocation)
+        // Preserve the window name so a following createUI (reload / session
+        // recreation) reuses it, keeping @PreserveOnRefresh's cache key stable.
+        lastWindowName.set(ui.internals.extendedClientDetails.windowName)
         if (ui.isClosing && ui.internals.session != null) {
             ui._close()
         }
@@ -194,6 +206,7 @@ object MockVaadin {
             VaadinService.setCurrent(null)
         }
         lastNavigation.remove()
+        lastWindowName.remove()
     }
 
     private fun clearVaadinInstances(fireUIDetach: Boolean) {
@@ -333,6 +346,21 @@ object MockVaadin {
 
         session.addUI(ui)
         session.service.fireUIInitListeners(ui)
+
+        // Assign a stable, non-null window name via ExtendedClientDetails so
+        // @PreserveOnRefresh works. Flow keys its preserved-component cache on
+        // window.name, and the name must (a) be non-null and (b) stay constant
+        // across reloads of the same window. A reload carries the previous UI's
+        // name in lastWindowName; a brand-new window gets a fresh unique name.
+        // screenWidth is set to a real value so retrieveExtendedClientDetails
+        // resolves synchronously rather than waiting for a client round-trip.
+        val windowName = lastWindowName.get()
+            ?: "window-${windowNameCounter.incrementAndGet()}"
+        lastWindowName.remove()
+        ui.internals.setExtendedClientDetails(
+            ExtendedClientDetails(ui, "1920", "1080", null, null, null, null,
+                null, null, null, null, null, null, null, null, windowName,
+                null, null, null))
 
         // navigate to the initial page
         if (lastNavigation.get() != null) {
@@ -508,11 +536,14 @@ object MockVaadin {
      * (`BrowserlessUIContext.close`) call [closeCurrentUI] without a matching
      * [createUI], so this method must be invoked afterwards to prevent the
      * recorded location from leaking into the next unrelated [createUI] on the
-     * same thread (e.g. `user.newWindow()`).
+     * same thread (e.g. `user.newWindow()`). Also clears the recorded window
+     * name for the same reason: a fresh window must get a new unique name, not
+     * inherit the closed window's name.
      */
     @JvmStatic
     fun clearLastNavigation() {
         lastNavigation.remove()
+        lastWindowName.remove()
     }
 }
 


### PR DESCRIPTION
Adds reload() and reload(Class) to BaseBrowserlessTest, AbstractBrowserlessExtension and BrowserlessUIContext, delegating to a new BrowserlessDSL.reload(UI). A reload detaches the current UI and creates a fresh one in the same Vaadin session, then re-renders the current location; session-scoped state (attributes, security context) survives.

Crucially this makes @PreserveOnRefresh work. Flow keys its preserved- component cache on window.name, but the mock never set ExtendedClientDetails, so the window name was always null and the cache was never populated. MockVaadin.createUI now assigns every UI complete ExtendedClientDetails with a stable, non-null window name (carried across a reload via a new lastWindowName ThreadLocal, fresh unique name per new window) and a real screenWidth so retrieveExtendedClientDetails resolves synchronously. Preserved views now keep their instance and state across a reload; plain views are recreated.

Tests cover preserve-reuse, plain-reset, session survival and multi-window isolation.
