### PR TITLE
chore: fire service listeners through the VaadinService event bus

### DIFF
--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/MockVaadin.kt
@@ -16,7 +16,7 @@
 package com.vaadin.browserless.internal
 
 import java.io.Serializable
-import java.lang.reflect.Field
+import java.util.EventObject
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.locks.ReentrantLock
 import jakarta.servlet.ServletContext
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.ComponentUtil
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.page.Page
 import com.vaadin.flow.di.Lookup
+import com.vaadin.flow.function.SerializableBiConsumer
 import com.vaadin.flow.internal.CurrentInstance
 import com.vaadin.flow.internal.StateTree
 import com.vaadin.flow.router.Location
@@ -31,12 +32,12 @@ import com.vaadin.flow.router.NavigationTrigger
 import com.vaadin.flow.server.DefaultErrorHandler
 import com.vaadin.flow.server.ErrorHandler
 import com.vaadin.flow.server.ServiceDestroyEvent
-import com.vaadin.flow.server.ServiceDestroyListener
 import com.vaadin.flow.server.SessionInitEvent
-import com.vaadin.flow.server.SessionInitListener
+import com.vaadin.flow.server.UIInitEvent
 import com.vaadin.flow.server.VaadinRequest
 import com.vaadin.flow.server.VaadinResponse
 import com.vaadin.flow.server.VaadinService
+import com.vaadin.flow.server.VaadinServiceEventBus
 import com.vaadin.flow.server.InitParameters
 import com.vaadin.flow.server.VaadinServlet
 import com.vaadin.flow.server.VaadinServletService
@@ -332,7 +333,7 @@ object MockVaadin {
         strongRefUI.set(ui)
 
         session.addUI(ui)
-        session.service.fireUIInitListeners(ui)
+        session.service.eventBus.fireEvent(UIInitEvent(ui, session.service), rethrowListenerFailure)
 
         // navigate to the initial page
         if (lastNavigation.get() != null) {
@@ -516,34 +517,20 @@ object MockVaadin {
     }
 }
 
-private val _VaadinService_sessionInitListeners: Field by lazy(LazyThreadSafetyMode.PUBLICATION) {
-    val field: Field = VaadinService::class.java.getDeclaredField("sessionInitListeners")
-    field.isAccessible = true
-    field
-}
+/**
+ * Hands a listener failure back to the caller instead of logging it, which is what
+ * [VaadinServiceEventBus.fireEvent] does by default. A listener that throws during a
+ * test should fail that test rather than only leave a line in the log.
+ */
+private val rethrowListenerFailure =
+        SerializableBiConsumer<EventObject, Exception> { _, error -> throw error }
 
 internal fun VaadinService.fireSessionInitListeners(event: SessionInitEvent) {
-    @Suppress("UNCHECKED_CAST")
-    val sessionInitListeners: Collection<SessionInitListener> =
-            _VaadinService_sessionInitListeners.get(this) as Collection<SessionInitListener>
-    for (sessionInitListener in sessionInitListeners) {
-        sessionInitListener.sessionInit(event)
-    }
-}
-
-private val _VaadinService_sessionDestroyListeners: Field by lazy(LazyThreadSafetyMode.PUBLICATION) {
-    val field: Field = VaadinService::class.java.getDeclaredField("serviceDestroyListeners")
-    field.isAccessible = true
-    field
+    eventBus.fireEvent(event, rethrowListenerFailure)
 }
 
 internal fun VaadinService.fireServiceDestroyListeners(event: ServiceDestroyEvent) {
-    @Suppress("UNCHECKED_CAST")
-    val listeners: Collection<ServiceDestroyListener> =
-            _VaadinService_sessionDestroyListeners.get(this) as Collection<ServiceDestroyListener>
-    for (listener in listeners) {
-        listener.serviceDestroy(event)
-    }
+    eventBus.fireEvent(event, rethrowListenerFailure)
 }
 
 internal class MockPage(ui: UI, private val uiFactory: UIFactory, private val session: VaadinSession) : Page(ui) {


### PR DESCRIPTION
MockVaadin reached into VaadinService's private sessionInitListeners and serviceDestroyListeners collections by reflection. vaadin/flow#25268 moved those collections into the new VaadinServiceEventBus, so the lookups started throwing NoSuchFieldException at runtime.

Fire the events through service.getEventBus() instead. The bus only logs a listener that throws, so an error handler that rethrows is passed to keep the previous behaviour of surfacing a broken listener to the test. UI init is fired the same way, as VaadinService.fireUIInitListeners is now deprecated for removal.
