### PR TITLE
refactor: drop the kotlin-reflect dependency

### DIFF
--- a/junit6/pom.xml
+++ b/junit6/pom.xml
@@ -207,11 +207,6 @@
             <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
 
 
         <dependency>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -182,11 +182,6 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
             <version>4.8.184</version>

--- a/shared/src/main/kotlin/com/vaadin/browserless/internal/PrettyPrintTree.kt
+++ b/shared/src/main/kotlin/com/vaadin/browserless/internal/PrettyPrintTree.kt
@@ -16,10 +16,10 @@
 package com.vaadin.browserless.internal
 
 
+import java.lang.reflect.AccessibleObject
+import java.lang.reflect.Field
+import java.lang.reflect.Method
 import java.util.*
-import kotlin.reflect.KCallable
-import kotlin.reflect.jvm.isAccessible
-import kotlin.reflect.jvm.kotlinFunction
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.HasValidation
 import com.vaadin.flow.component.HasValue
@@ -143,20 +143,7 @@ fun Component.toPrettyString(): String {
         }
     }
     // Any component with href should output it not only Anchor
-    val hrefCallable = try {
-        val functionOrProperty = this.javaClass.kotlin.members.find { it.name == "href" }
-        functionOrProperty?.isAccessible = true
-        functionOrProperty
-    } catch (t: TypeNotPresentException) {
-        // Some components have methods referencing Spring classes that may not
-        // be present for all project. Kotlin member introspection seems to
-        // immediately scan for all metadata (parameters, generics, ...) making
-        // this method fail. As a fallback we inspect with Java reflection API
-        // that seems to be more lazy
-        val method = this.javaClass.methods.find { it.name == "href" }
-        method?.kotlinFunction
-    }
-    hrefCallable?.call(this)?.let {
+    hrefValue()?.let {
         list.add("href='$it'")
     }
     if (this is Button && icon is Icon) {
@@ -200,6 +187,36 @@ fun Component.toPrettyString(): String {
         name = javaClass.name
     }
     return name + list
+}
+
+/**
+ * Reads the `href` value of this component, so that [toPrettyString] can dump it for
+ * any component declaring it, not just [Anchor]. Both a no-arg `href()` method and a
+ * `href` field are looked up, anywhere in the class hierarchy.
+ *
+ * The Java reflection API is used on purpose since it resolves member metadata lazily:
+ * some components have methods referencing classes (e.g. Spring ones) which may not be
+ * present in all projects, and eagerly scanning all metadata (parameters, generics, ...)
+ * would fail for those.
+ *
+ * @return the `href` value, or null if this component has none.
+ */
+private fun Component.hrefValue(): Any? {
+    var clazz: Class<*>? = javaClass
+    while (clazz != null) {
+        val member: AccessibleObject? =
+            clazz.declaredMethods.firstOrNull { it.name == "href" && it.parameterCount == 0 }
+                ?: clazz.declaredFields.firstOrNull { it.name == "href" }
+        if (member != null) {
+            member.isAccessible = true
+            return when (member) {
+                is Method -> member.invoke(this)
+                else -> (member as Field).get(this)
+            }
+        }
+        clazz = clazz.superclass
+    }
+    return null
 }
 
 /**


### PR DESCRIPTION
The only code requiring kotlin-reflect at runtime was the href lookup in toPrettyString(), which used javaClass.kotlin.members / kotlinFunction to read Anchor's private href field. Replace it with a plain Java reflection walk up the class hierarchy looking for a no-arg href() method or an href field.

This also removes the TypeNotPresentException fallback: it existed because Kotlin member introspection eagerly scans all member metadata and blows up on components referencing classes (e.g. Spring ones) that are not on the classpath. The Java reflection API resolves that metadata lazily, so the failure can no longer happen.

The remaining kotlin.reflect imports (KClass, KProperty1) only use stdlib-supported operations (.java, .name) and need no reflect artifact, so kotlin-reflect can be removed from shared and junit6.
